### PR TITLE
Align Agent Skills with standard single-skill structure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,9 +31,7 @@ coverage/
 test-results/
 playwright-report/
 
-# Local skills (domain-specific, not published)
-src/skills/*/
-!src/skills/
+# Local extensions (not published)
 local/extensions/
 
 # OS generated files

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ An Office add-in research project that provides an AI-powered coding assistant u
 - **AI Chat Panel** — conversational assistant embedded in Excel's task pane
 - **83 Excel tools** — the AI can read/write ranges, create charts, manage tables, format cells, add comments, create pivot tables, set data validation, and manipulate sheets
 - **Agent system** — split system prompt architecture + custom agents with host targeting (`hosts`, `defaultForHosts`)
-- **Skills system** — bundled skill files that inject additional context into the system prompt, toggleable via the SkillPicker
+- **Skills system** — bundled skill files that inject additional context into the system prompt, toggleable via the SkillPicker (standard Agent Skills layout: one `SKILL.md` plus optional `references/` docs)
 - **Custom extension import** — import local ZIP files for custom agents and custom skills from Settings
 - **Extension management UX** — manage imported agents/skills in Settings, with bundled content shown as read-only
 - **Multi-model support** — add and validate deployed model names from your Azure AI Foundry endpoint (manual entry flow)
@@ -29,6 +29,13 @@ An Office add-in research project that provides an AI-powered coding assistant u
 - **API key authentication** — simple API key auth per endpoint, no Azure AD app registration required
 - **Multiple endpoints** — configure and switch between several Azure AI Foundry resources
 - **First-time setup wizard** — guided onboarding flow with auto-discovery and manual model entry
+
+## Agent Skills Format
+
+This project follows the standard Agent Skills model:
+
+- A skill is a folder containing `SKILL.md`.
+- Optional supporting docs live under `references/` inside that same skill.
 
 ## Prerequisites
 

--- a/scripts/generate-staging-manifest.mjs
+++ b/scripts/generate-staging-manifest.mjs
@@ -41,22 +41,22 @@ xml = xml.replace(/<Id>[\s\S]*?<\/Id>/, `<Id>${addinId}</Id>`);
 
 xml = xml.replace(
   /<DisplayName\s+DefaultValue="[^"]*"\s*\/>/,
-  `<DisplayName DefaultValue="${displayName}" />`,
+  `<DisplayName DefaultValue="${displayName}" />`
 );
 
 xml = xml.replace(
   /<bt:String\s+id="GetStarted.Title"\s+DefaultValue="[^"]*"\s*\/>/,
-  `<bt:String id="GetStarted.Title" DefaultValue="${displayName}" />`,
+  `<bt:String id="GetStarted.Title" DefaultValue="${displayName}" />`
 );
 
 xml = xml.replace(
   /<bt:String\s+id="CommandsGroup.Label"\s+DefaultValue="[^"]*"\s*\/>/,
-  `<bt:String id="CommandsGroup.Label" DefaultValue="${commandsGroupLabel}" />`,
+  `<bt:String id="CommandsGroup.Label" DefaultValue="${commandsGroupLabel}" />`
 );
 
 xml = xml.replace(
   /<bt:String\s+id="TaskpaneButton.Label"\s+DefaultValue="[^"]*"\s*\/>/,
-  `<bt:String id="TaskpaneButton.Label" DefaultValue="${chatButtonLabel}" />`,
+  `<bt:String id="TaskpaneButton.Label" DefaultValue="${chatButtonLabel}" />`
 );
 
 xml = xml.replaceAll('https://localhost:3000', baseUrl);

--- a/src/skills/excel/SKILL.md
+++ b/src/skills/excel/SKILL.md
@@ -1,0 +1,48 @@
+---
+name: excel
+description: General-purpose Excel skill for workbook analysis, transformation, reporting, and visualization tasks.
+license: MIT
+---
+
+# Excel Default Skill
+
+Use this as the default orchestration skill for Excel tasks.
+
+## Operating Loop
+
+1. **Discover** — Inspect workbook structure and existing data first.
+2. **Read** — Read exact target ranges/tables before any mutation.
+3. **Execute** — Apply focused updates with the narrowest possible write scope.
+4. **Verify** — Re-read key outputs and confirm formulas/values are correct.
+5. **Summarize** — Finish with a concise plain-language change summary.
+
+## Delegated Guidance
+
+Use the focused reference docs in `references/` when task depth requires it:
+
+- Data quality workflow: `references/data-quality.md`
+- Reporting workflow: `references/reporting.md`
+- Visualization workflow: `references/visualization.md`
+- Modeling workflow: `references/modeling.md`
+
+## Always-On Defaults
+
+- Prefer targeted updates over delete/rebuild operations.
+- Always apply formats after writes when data type is known.
+- Always finish with a clear summary of changes made.
+
+## High-Level Tool Guidance
+
+| Task                        | Primary Tool                                               |
+| --------------------------- | ---------------------------------------------------------- |
+| Discover workbook structure | `get_workbook_info`, `list_sheets`, `list_tables`          |
+| Inspect data before changes | `get_used_range`, `get_range_values`, `get_range_formulas` |
+| Write values/formulas       | `set_range_values`, `set_range_formulas`                   |
+| Apply formatting            | `set_number_format`, `format_range`, `auto_fit_columns`    |
+| Manage structured data      | `create_table`, `get_table_data`, `filter_table`           |
+| Build visuals               | `create_chart`, `set_chart_type`, `set_chart_title`        |
+| Build models/calculations   | `set_range_formulas`, `recalculate_workbook`, `analyze_data` |
+
+## Multi-Step Requests
+
+Execute all requested steps in sequence where possible. If one step fails, report the failure clearly and continue independent remaining steps.

--- a/src/skills/excel/references/data-quality.md
+++ b/src/skills/excel/references/data-quality.md
@@ -1,0 +1,25 @@
+# Data Quality Workflow
+
+Use when cleaning, normalizing, validating, or repairing workbook data.
+
+## Workflow
+
+1. Profile source ranges/tables and identify blanks, type mismatches, and duplicates.
+2. Normalize values, date formats, and casing with targeted updates.
+3. Validate with explicit rules where user input is expected.
+4. Verify by re-reading key ranges.
+
+## Rules
+
+- Never overwrite unknown formulas without reading them first.
+- Prefer targeted cell/range updates over full rewrites.
+- Preserve headers and table structure unless explicitly asked to redesign.
+- If values are ambiguous, apply the least destructive transformation.
+
+## Tool Patterns
+
+- Profile values: `get_used_range` -> `get_range_values`
+- Inspect formulas: `get_range_formulas`
+- Normalize values: `set_range_values`
+- Add constraints: `set_list_validation`, `set_number_validation`
+- Verify results: `get_range_values`

--- a/src/skills/excel/references/modeling.md
+++ b/src/skills/excel/references/modeling.md
@@ -1,0 +1,32 @@
+# Modeling Workflow
+
+Use when requests involve formulas, assumptions, dependencies, scenario logic, or model refactoring.
+
+## Principles
+
+- Keep assumptions in explicit input cells/tables, separate from calculated outputs.
+- Use predictable row/column structure so formulas can be filled or copied safely.
+- Prefer readable formulas over compact but opaque expressions.
+- Reuse shared assumptions to avoid drift across sheets.
+
+## Workflow
+
+1. Identify input ranges and expected output ranges before writing formulas.
+2. Write formulas in the minimal target range first.
+3. Re-read formulas to confirm references and relative/absolute behavior.
+4. Trigger recalculation when model changes are complete.
+5. Re-read key outputs and sanity-check totals/signs/order of magnitude.
+
+## Quality Checks
+
+- Validate that totals reconcile (subtotals roll up to grand totals).
+- Spot-check boundary cases (zero, blank, negative, large values).
+- Confirm copied formulas preserve intended references.
+- Flag circular references or volatile formula overuse when detected.
+
+## Tool Patterns
+
+- Read model state: `get_range_values`, `get_range_formulas`
+- Apply formulas: `set_range_formulas`
+- Recalculate: `recalculate_workbook`
+- Structure check: `analyze_data`

--- a/src/skills/excel/references/reporting.md
+++ b/src/skills/excel/references/reporting.md
@@ -1,0 +1,26 @@
+# Reporting Workflow
+
+Use when building summaries, KPI blocks, rollups, and report-ready worksheet outputs.
+
+## Workflow
+
+1. Discover and read source data.
+2. Build summary structures (table, pivot, or formula-driven section).
+3. Apply presentation formatting and labels.
+4. Validate totals and key metrics.
+5. Present concise findings.
+
+## Rules
+
+- Keep source data and reporting output separated when possible.
+- Use tables for structured reporting ranges.
+- Ensure number formats match metric semantics (currency, percent, date, integer).
+- Include high-signal metrics by default; avoid clutter.
+
+## Tool Patterns
+
+- Source discovery: `list_tables`, `get_used_range`
+- Build report table: `set_range_values` -> `create_table`
+- KPI formulas: `set_range_formulas` + `set_number_format`
+- Pivots: `create_pivot_table` + `add_pivot_field`
+- Final polish: `format_range`, `auto_fit_columns`

--- a/src/skills/excel/references/visualization.md
+++ b/src/skills/excel/references/visualization.md
@@ -1,0 +1,25 @@
+# Visualization Workflow
+
+Use when creating or refining charts and visual summaries in Excel.
+
+## Workflow
+
+1. Confirm chart intent (trend, comparison, composition, distribution).
+2. Ensure source data is clean and correctly typed.
+3. Create chart with an appropriate default type.
+4. Improve readability (title, labels, axis meaning, layout).
+5. Verify chart reflects the intended range and interpretation.
+
+## Rules
+
+- Prefer simple chart types unless complexity is explicitly requested.
+- Add explicit titles that describe the metric and scope.
+- Avoid overcrowded visuals; keep categories and series legible.
+- Verify the chart source range after data updates.
+
+## Tool Patterns
+
+- Prepare data: `get_range_values` + `set_number_format`
+- Create chart: `create_chart`
+- Tune semantics: `set_chart_type`, `set_chart_title`
+- Final placement/readability: keep chart near source data or on a report sheet

--- a/src/types/skill.ts
+++ b/src/types/skill.ts
@@ -4,7 +4,6 @@ export interface SkillMetadata {
   description: string;
   version: string;
   tags: string[];
-  references?: string[];
   license?: string;
   repository?: string;
   documentation?: string;

--- a/tests/unit/buildSkillContext.test.ts
+++ b/tests/unit/buildSkillContext.test.ts
@@ -51,11 +51,11 @@ describe('buildSkillContext', () => {
     expect(explicit).toBe(all);
   });
 
-  it('resolves @references directives to internal skill and agent content', () => {
+  it('keeps @references directives as plain content without expansion', () => {
     const importedSkill: AgentSkill = {
       metadata: {
         name: 'Ref Tester',
-        description: 'Skill that references internal context.',
+        description: 'Skill with plain @references text.',
         version: '1.0.0',
         tags: [],
       },
@@ -65,9 +65,9 @@ describe('buildSkillContext', () => {
     setImportedSkills([importedSkill]);
 
     const context = buildSkillContext(['Ref Tester']);
-    expect(context).toContain('Reference: skill:excel');
-    expect(context).toContain('Reference: agent:Excel');
-    expect(context).toContain('You are an AI assistant running inside a Microsoft Excel add-in.');
+    expect(context).toContain('@references skill:excel, agent:Excel');
+    expect(context).not.toContain('Reference: skill:excel');
+    expect(context).not.toContain('Reference: agent:Excel');
   });
 });
 
@@ -141,7 +141,7 @@ Content`;
     expect(metadata.tags).toEqual(['azure', 'excel']);
   });
 
-  it('parses references array', () => {
+  it('ignores non-standard references field', () => {
     const raw = `---
 name: with-refs
 references:
@@ -150,6 +150,6 @@ references:
 ---
 Content`;
     const { metadata } = parseFrontmatter(raw);
-    expect(metadata.references).toEqual(['skill:excel', 'agent:Excel']);
+    expect(metadata).not.toHaveProperty('references');
   });
 });


### PR DESCRIPTION
## Summary
- align skills runtime behavior with standard Agent Skills format
- use one bundled `excel` skill with supporting `references/` docs
- remove custom cross-skill reference expansion in skill context building
- update skill tests for standard behavior
- include staging manifest script normalization as a separate commit

## Validation
- runTests: tests/unit/buildSkillContext.test.ts (16 passed, 0 failed)

## Notes
- single-skill layout now uses `src/skills/excel/SKILL.md` with `src/skills/excel/references/*`
