### PR TITLE
Fix Pages build: pivot value-sort scope overload

### DIFF
--- a/src/tools/configs/pivotTable.config.ts
+++ b/src/tools/configs/pivotTable.config.ts
@@ -645,7 +645,7 @@ export const pivotTableConfigs: readonly ToolConfig[] = [
 
       if (pivotItemScopeName) {
         const scopeItem = field.items.getItem(pivotItemScopeName);
-        field.sortByValues(sortBy, valuesHierarchy, scopeItem);
+        field.sortByValues(sortBy, valuesHierarchy, [scopeItem]);
       } else {
         field.sortByValues(sortBy, valuesHierarchy);
       }


### PR DESCRIPTION
## Why
Staging add-in from GitHub Pages was failing because the Pages build workflow failed on a TypeScript overload mismatch in sort_pivot_field_values.

## Change
- pass pivot item scope as an array to PivotField.sortByValues(...) to match Office.js typings

## Validation
- npm run build (passes locally)