### PR TITLE
Improve user-facing chat errors for rate limits and common HTTP failures

### DIFF
--- a/src/hooks/useOfficeChat.ts
+++ b/src/hooks/useOfficeChat.ts
@@ -8,6 +8,7 @@ import { buildSkillContext } from '@/services/skills';
 import { resolveActiveAgent } from '@/services/agents';
 import { useSettingsStore } from '@/stores';
 import { buildSystemPrompt } from '@/services/ai/systemPrompt';
+import { normalizeChatErrorMessage } from '@/services/ai/chatErrorMessage';
 import type { OfficeHostApp } from '@/services/office/host';
 
 export type { UseChatHelpers };
@@ -46,6 +47,7 @@ export function useOfficeChat(
   return useChat({
     transport: transport ?? undefined,
     onError: error => {
+      error.message = normalizeChatErrorMessage(error.message);
       console.error('[useOfficeChat] Chat error:', error);
       console.error('[useOfficeChat] Error details:', {
         message: error.message,

--- a/src/services/ai/chatErrorMessage.ts
+++ b/src/services/ai/chatErrorMessage.ts
@@ -1,0 +1,37 @@
+function extractRetryAfterSeconds(message: string): number | null {
+  const match = /retry\s+after\s+(\d+)\s*seconds?/i.exec(message);
+  if (!match) return null;
+
+  const parsed = Number.parseInt(match[1] ?? '', 10);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+export function normalizeChatErrorMessage(message: string): string {
+  const trimmed = message.trim();
+  const retryAfterSeconds = extractRetryAfterSeconds(trimmed);
+
+  if (/\b429\b|too many requests|rate limit|token rate limit/i.test(trimmed)) {
+    const retry = retryAfterSeconds ? ` Retry in about ${retryAfterSeconds}s.` : '';
+    return (
+      'Rate limit reached for the current model/deployment. ' +
+      'Try a smaller request, switch models, or wait briefly.' +
+      retry
+    );
+  }
+
+  if (/\b404\b|not found|deployment.*not found|resource.*not found/i.test(trimmed)) {
+    return (
+      'Endpoint or deployment not found. Check your endpoint URL and model deployment name in Settings.'
+    );
+  }
+
+  if (/\b401\b|unauthorized|invalid api key|authentication/i.test(trimmed)) {
+    return 'Authentication failed. Verify your API key in Settings.';
+  }
+
+  if (/\b403\b|forbidden|permission|access denied/i.test(trimmed)) {
+    return 'Access denied for this endpoint/model. Verify permissions and deployment access.';
+  }
+
+  return trimmed;
+}

--- a/tests/unit/chatErrorMessage.test.ts
+++ b/tests/unit/chatErrorMessage.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+import { normalizeChatErrorMessage } from '@/services/ai/chatErrorMessage';
+
+describe('normalizeChatErrorMessage', () => {
+  it('normalizes rate-limit errors and includes retry hint when present', () => {
+    const raw =
+      'Failed after 5 attempts. Last error: 429 Too Many Requests. Please retry after 17 seconds.';
+
+    const normalized = normalizeChatErrorMessage(raw);
+    expect(normalized).toContain('Rate limit reached');
+    expect(normalized).toContain('Retry in about 17s');
+  });
+
+  it('normalizes not-found/deployment errors', () => {
+    const normalized = normalizeChatErrorMessage('HTTP 404 deployment not found');
+    expect(normalized).toContain('Endpoint or deployment not found');
+  });
+
+  it('normalizes auth and permission errors', () => {
+    expect(normalizeChatErrorMessage('401 Unauthorized')).toContain('Authentication failed');
+    expect(normalizeChatErrorMessage('403 Forbidden')).toContain('Access denied');
+  });
+
+  it('passes through unknown errors', () => {
+    const raw = 'Unexpected transport disconnect';
+    expect(normalizeChatErrorMessage(raw)).toBe(raw);
+  });
+});


### PR DESCRIPTION
## Summary
- add chat error normalization helper for common API failures
- convert raw 429/404/401/403 messages into concise actionable text
- include retry-after hint for rate-limit messages when available
- add focused unit tests for normalization behavior

## Validation
- npm run lint
- unit: tests/unit/chatErrorMessage.test.ts