### PR TITLE
Fix chat store default messages typing

### DIFF
--- a/src/stores/chatStore.ts
+++ b/src/stores/chatStore.ts
@@ -9,9 +9,9 @@ interface ChatStoreState {
   reset: () => void;
 }
 
-const DEFAULT_CHAT_STATE = {
+const DEFAULT_CHAT_STATE: Pick<ChatStoreState, 'messages'> = {
   messages: [],
-} as const;
+};
 
 function toSerializableMessages(messages: unknown[]): unknown[] {
   try {


### PR DESCRIPTION
## Summary
- fix DEFAULT_CHAT_STATE typing in chatStore to use mutable unknown[]
- remove as const readonly inference causing CI TypeScript build failure

## Validation
- npm run build