### PR TITLE
Add more pivot introspection APIs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,7 @@ local/extensions/
 # OS generated files
 .DS_Store
 Thumbs.db
+*.xlsx
 
 # Editor files
 .vscode/settings.json

--- a/scripts/check-tool-coverage.ts
+++ b/scripts/check-tool-coverage.ts
@@ -17,7 +17,13 @@
 
 import * as fs from 'fs';
 import * as path from 'path';
+import { fileURLToPath } from 'url';
+import { createRequire } from 'module';
 import ts from 'typescript';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const require = createRequire(import.meta.url);
 
 interface ManifestTool {
   name: string;

--- a/tests-e2e/src/test-taskpane.ts
+++ b/tests-e2e/src/test-taskpane.ts
@@ -959,7 +959,12 @@ async function testRangeToolVariants(): Promise<void> {
   try {
     await Excel.run(async context => {
       const sheet = context.workbook.worksheets.getItem(MAIN);
-      sheet.getRange('M1:M4').values = [['Alice Smith'], ['Bob Jones'], ['Cara Lane'], ['Dana Ray']];
+      sheet.getRange('M1:M4').values = [
+        ['Alice Smith'],
+        ['Bob Jones'],
+        ['Cara Lane'],
+        ['Dana Ray'],
+      ];
       sheet.getRange('N1:N2').values = [['Alice'], ['Bob']];
       await context.sync();
     });
@@ -2965,10 +2970,10 @@ async function testDataValidationToolVariants(): Promise<void> {
   }
 }
 
-// ─── Pivot Table Tools (16) ───────────────────────────────────────
+// ─── Pivot Table Tools (28) ───────────────────────────────────────
 
 async function testPivotTableTools(): Promise<void> {
-  log('── Pivot Table Tools (16) ──');
+  log('── Pivot Table Tools (28) ──');
 
   const PT_NAME = 'E2E_Pivot';
 
@@ -3002,7 +3007,37 @@ async function testPivotTableTools(): Promise<void> {
     return d.count >= 1 ? null : `Expected ≥1 PT, got ${d.count}`;
   });
 
-  // 3. refresh_pivot_table
+  // 3. get_pivot_table_count
+  await runTool(pivotTableConfigs, 'get_pivot_table_count', { sheetName: PIVOT_DST }, r => {
+    const d = r as { count: number };
+    return d.count >= 1 ? null : `Expected count >= 1, got ${d.count}`;
+  });
+
+  // 4. pivot_table_exists
+  await runTool(
+    pivotTableConfigs,
+    'pivot_table_exists',
+    { pivotTableName: PT_NAME, sheetName: PIVOT_DST },
+    r => {
+      const d = r as { exists: boolean };
+      return d.exists === true ? null : 'Expected exists === true';
+    }
+  );
+
+  // 5. get_pivot_table_location
+  await runTool(
+    pivotTableConfigs,
+    'get_pivot_table_location',
+    { pivotTableName: PT_NAME, sheetName: PIVOT_DST },
+    r => {
+      const d = r as { worksheetName?: string; rangeAddress?: string };
+      return d.worksheetName === PIVOT_DST && !!d.rangeAddress
+        ? null
+        : 'Expected worksheetName and rangeAddress';
+    }
+  );
+
+  // 6. refresh_pivot_table
   await runTool(
     pivotTableConfigs,
     'refresh_pivot_table',
@@ -3013,7 +3048,13 @@ async function testPivotTableTools(): Promise<void> {
     }
   );
 
-  // 4. get_pivot_table_source_info
+  // 7. refresh_all_pivot_tables
+  await runTool(pivotTableConfigs, 'refresh_all_pivot_tables', { sheetName: PIVOT_DST }, r => {
+    const d = r as { refreshed: boolean };
+    return d.refreshed ? null : 'Expected all pivots refreshed';
+  });
+
+  // 8. get_pivot_table_source_info
   await runTool(
     pivotTableConfigs,
     'get_pivot_table_source_info',
@@ -3024,7 +3065,33 @@ async function testPivotTableTools(): Promise<void> {
     }
   );
 
-  // 5. set_pivot_table_options
+  // 9. get_pivot_hierarchy_counts
+  await runTool(
+    pivotTableConfigs,
+    'get_pivot_hierarchy_counts',
+    { pivotTableName: PT_NAME, sheetName: PIVOT_DST },
+    r => {
+      const d = r as { rowHierarchyCount?: number; dataHierarchyCount?: number };
+      return typeof d.rowHierarchyCount === 'number' && typeof d.dataHierarchyCount === 'number'
+        ? null
+        : 'Expected numeric rowHierarchyCount and dataHierarchyCount';
+    }
+  );
+
+  // 10. get_pivot_hierarchies
+  await runTool(
+    pivotTableConfigs,
+    'get_pivot_hierarchies',
+    { pivotTableName: PT_NAME, sheetName: PIVOT_DST },
+    r => {
+      const d = r as { rowHierarchies?: unknown[]; dataHierarchies?: unknown[] };
+      return Array.isArray(d.rowHierarchies) && Array.isArray(d.dataHierarchies)
+        ? null
+        : 'Expected rowHierarchies and dataHierarchies arrays';
+    }
+  );
+
+  // 11. set_pivot_table_options
   await runTool(
     pivotTableConfigs,
     'set_pivot_table_options',
@@ -3048,7 +3115,7 @@ async function testPivotTableTools(): Promise<void> {
     }
   );
 
-  // 6. add_pivot_field
+  // 12. add_pivot_field
   await runTool(
     pivotTableConfigs,
     'add_pivot_field',
@@ -3059,7 +3126,7 @@ async function testPivotTableTools(): Promise<void> {
     }
   );
 
-  // 7. set_pivot_layout
+  // 13. set_pivot_layout
   await runTool(
     pivotTableConfigs,
     'set_pivot_layout',
@@ -3078,7 +3145,7 @@ async function testPivotTableTools(): Promise<void> {
     }
   );
 
-  // 8. get_pivot_field_filters (before apply)
+  // 14. get_pivot_field_filters (before apply)
   await runTool(
     pivotTableConfigs,
     'get_pivot_field_filters',
@@ -3089,7 +3156,7 @@ async function testPivotTableTools(): Promise<void> {
     }
   );
 
-  // 9. apply_pivot_label_filter
+  // 15. apply_pivot_label_filter
   await runTool(
     pivotTableConfigs,
     'apply_pivot_label_filter',
@@ -3106,7 +3173,7 @@ async function testPivotTableTools(): Promise<void> {
     }
   );
 
-  // 10. sort_pivot_field_labels
+  // 16. sort_pivot_field_labels
   await runTool(
     pivotTableConfigs,
     'sort_pivot_field_labels',
@@ -3117,7 +3184,7 @@ async function testPivotTableTools(): Promise<void> {
     }
   );
 
-  // 11. apply_pivot_manual_filter
+  // 17. apply_pivot_manual_filter
   await runTool(
     pivotTableConfigs,
     'apply_pivot_manual_filter',
@@ -3133,7 +3200,7 @@ async function testPivotTableTools(): Promise<void> {
     }
   );
 
-  // 12. sort_pivot_field_values
+  // 18. sort_pivot_field_values
   await runTool(
     pivotTableConfigs,
     'sort_pivot_field_values',
@@ -3152,7 +3219,7 @@ async function testPivotTableTools(): Promise<void> {
     }
   );
 
-  // 13. set_pivot_field_show_all_items
+  // 19. set_pivot_field_show_all_items
   await runTool(
     pivotTableConfigs,
     'set_pivot_field_show_all_items',
@@ -3163,7 +3230,102 @@ async function testPivotTableTools(): Promise<void> {
     }
   );
 
-  // 14. clear_pivot_field_filters
+  // 20. get_pivot_layout_ranges
+  const layoutRangesResult = await runTool(
+    pivotTableConfigs,
+    'get_pivot_layout_ranges',
+    { pivotTableName: PT_NAME, sheetName: PIVOT_DST },
+    r => {
+      const d = r as { tableRangeAddress?: string; dataBodyRangeAddress?: string };
+      return d.tableRangeAddress && d.dataBodyRangeAddress
+        ? null
+        : 'Expected pivot layout range addresses';
+    }
+  );
+
+  // 21. set_pivot_layout_display_options
+  await runTool(
+    pivotTableConfigs,
+    'set_pivot_layout_display_options',
+    {
+      pivotTableName: PT_NAME,
+      repeatAllItemLabels: true,
+      displayBlankLineAfterEachItem: false,
+      autoFormat: true,
+      preserveFormatting: true,
+      fillEmptyCells: true,
+      emptyCellText: '-',
+      enableFieldList: true,
+      altTextTitle: 'E2E Pivot',
+      altTextDescription: 'E2E pivot layout options',
+      sheetName: PIVOT_DST,
+    },
+    r => {
+      const d = r as { updated: boolean; autoFormat: boolean; fillEmptyCells: boolean };
+      return d.updated && d.autoFormat && d.fillEmptyCells
+        ? null
+        : 'Expected pivot layout display options updated';
+    }
+  );
+
+  // 22. get_pivot_data_hierarchy_for_cell
+  const rawDataBodyAddress =
+    ((layoutRangesResult as { dataBodyRangeAddress?: string } | null)?.dataBodyRangeAddress ?? '') ||
+    '';
+  const dataBodyAddress = rawDataBodyAddress.includes('!')
+    ? rawDataBodyAddress.split('!')[1]
+    : rawDataBodyAddress;
+  const dataCellAddress = (dataBodyAddress.split(':')[0] ?? 'B3').replace(/\$/g, '');
+
+  await runTool(
+    pivotTableConfigs,
+    'get_pivot_data_hierarchy_for_cell',
+    { pivotTableName: PT_NAME, cellAddress: dataCellAddress, sheetName: PIVOT_DST },
+    r => {
+      const d = r as { dataHierarchyName?: string };
+      return d.dataHierarchyName ? null : 'Expected data hierarchy for pivot data cell';
+    }
+  );
+
+  // 23. get_pivot_items_for_cell
+  await runTool(
+    pivotTableConfigs,
+    'get_pivot_items_for_cell',
+    { pivotTableName: PT_NAME, axis: 'Row', cellAddress: dataCellAddress, sheetName: PIVOT_DST },
+    r => {
+      const d = r as { count?: number };
+      return typeof d.count === 'number' ? null : 'Expected pivot items for row axis';
+    }
+  );
+
+  // 24. set_pivot_layout_auto_sort_on_cell
+  await runTool(
+    pivotTableConfigs,
+    'set_pivot_layout_auto_sort_on_cell',
+    {
+      pivotTableName: PT_NAME,
+      cellAddress: dataCellAddress,
+      sortBy: 'Descending',
+      sheetName: PIVOT_DST,
+    },
+    r => {
+      const d = r as { sorted: boolean; sortBy: string };
+      return d.sorted && d.sortBy === 'Descending' ? null : 'Expected pivot autosort by cell';
+    }
+  );
+
+  // 25. get_pivot_field_items
+  await runTool(
+    pivotTableConfigs,
+    'get_pivot_field_items',
+    { pivotTableName: PT_NAME, fieldName: 'Region', sheetName: PIVOT_DST },
+    r => {
+      const d = r as { count?: number };
+      return typeof d.count === 'number' ? null : 'Expected numeric count of pivot field items';
+    }
+  );
+
+  // 26. clear_pivot_field_filters
   await runTool(
     pivotTableConfigs,
     'clear_pivot_field_filters',
@@ -3174,7 +3336,7 @@ async function testPivotTableTools(): Promise<void> {
     }
   );
 
-  // 15. remove_pivot_field
+  // 27. remove_pivot_field
   await runTool(
     pivotTableConfigs,
     'remove_pivot_field',
@@ -3185,7 +3347,7 @@ async function testPivotTableTools(): Promise<void> {
     }
   );
 
-  // 16. delete_pivot_table
+  // 28. delete_pivot_table
   await runTool(
     pivotTableConfigs,
     'delete_pivot_table',

--- a/tests/unit/toolSchemas.test.ts
+++ b/tests/unit/toolSchemas.test.ts
@@ -139,22 +139,34 @@ const ALL_TOOL_NAMES = [
   'set_custom_validation',
   'get_data_validation',
   'clear_data_validation',
-  // pivot table (16)
+  // pivot table (28)
   'list_pivot_tables',
   'refresh_pivot_table',
+  'refresh_all_pivot_tables',
+  'get_pivot_table_count',
+  'pivot_table_exists',
   'get_pivot_table_source_info',
+  'get_pivot_table_location',
+  'get_pivot_hierarchy_counts',
+  'get_pivot_hierarchies',
   'set_pivot_table_options',
   'delete_pivot_table',
   'create_pivot_table',
   'add_pivot_field',
   'set_pivot_layout',
   'get_pivot_field_filters',
+  'get_pivot_field_items',
   'clear_pivot_field_filters',
   'apply_pivot_label_filter',
   'sort_pivot_field_labels',
   'apply_pivot_manual_filter',
   'sort_pivot_field_values',
   'set_pivot_field_show_all_items',
+  'get_pivot_layout_ranges',
+  'set_pivot_layout_display_options',
+  'get_pivot_data_hierarchy_for_cell',
+  'get_pivot_items_for_cell',
+  'set_pivot_layout_auto_sort_on_cell',
   'remove_pivot_field',
 ] as const;
 
@@ -728,8 +740,26 @@ describe('tool schemas — data validation tools (decomposed)', () => {
 });
 
 describe('tool schemas — pivot table tools', () => {
+  it('get_pivot_table_count accepts optional sheetName', () => {
+    const schema = excelTools.get_pivot_table_count.inputSchema;
+    expect(asZod(schema).safeParse({}).success).toBe(true);
+    expect(asZod(schema).safeParse({ sheetName: 'Data' }).success).toBe(true);
+  });
+
+  it('pivot_table_exists requires pivotTableName', () => {
+    const schema = excelTools.pivot_table_exists.inputSchema;
+    expect(asZod(schema).safeParse({ pivotTableName: 'PT1' }).success).toBe(true);
+    expect(asZod(schema).safeParse({}).success).toBe(false);
+  });
+
   it('get_pivot_table_source_info requires pivotTableName', () => {
     const schema = excelTools.get_pivot_table_source_info.inputSchema;
+    expect(asZod(schema).safeParse({ pivotTableName: 'PT1' }).success).toBe(true);
+    expect(asZod(schema).safeParse({}).success).toBe(false);
+  });
+
+  it('get_pivot_table_location requires pivotTableName', () => {
+    const schema = excelTools.get_pivot_table_location.inputSchema;
     expect(asZod(schema).safeParse({ pivotTableName: 'PT1' }).success).toBe(true);
     expect(asZod(schema).safeParse({}).success).toBe(false);
   });
@@ -791,6 +821,14 @@ describe('tool schemas — pivot table tools', () => {
 
   it('get_pivot_field_filters requires pivotTableName + fieldName', () => {
     const schema = excelTools.get_pivot_field_filters.inputSchema;
+    expect(asZod(schema).safeParse({ pivotTableName: 'PT1', fieldName: 'Region' }).success).toBe(
+      true
+    );
+    expect(asZod(schema).safeParse({ pivotTableName: 'PT1' }).success).toBe(false);
+  });
+
+  it('get_pivot_field_items requires pivotTableName + fieldName', () => {
+    const schema = excelTools.get_pivot_field_items.inputSchema;
     expect(asZod(schema).safeParse({ pivotTableName: 'PT1', fieldName: 'Region' }).success).toBe(
       true
     );
@@ -896,6 +934,68 @@ describe('tool schemas — pivot table tools', () => {
       false
     );
   });
+
+  it('get_pivot_layout_ranges requires pivotTableName', () => {
+    const schema = excelTools.get_pivot_layout_ranges.inputSchema;
+    expect(asZod(schema).safeParse({ pivotTableName: 'PT1' }).success).toBe(true);
+    expect(asZod(schema).safeParse({}).success).toBe(false);
+  });
+
+  it('set_pivot_layout_display_options requires pivotTableName and accepts optional display/formatting args', () => {
+    const schema = excelTools.set_pivot_layout_display_options.inputSchema;
+    expect(asZod(schema).safeParse({ pivotTableName: 'PT1' }).success).toBe(true);
+    expect(
+      asZod(schema).safeParse({
+        pivotTableName: 'PT1',
+        repeatAllItemLabels: true,
+        displayBlankLineAfterEachItem: false,
+        autoFormat: true,
+        preserveFormatting: true,
+        fillEmptyCells: true,
+        emptyCellText: '-',
+        enableFieldList: false,
+        altTextTitle: 'Sales Pivot',
+        altTextDescription: 'Quarterly sales by region',
+      }).success
+    ).toBe(true);
+    expect(asZod(schema).safeParse({ repeatAllItemLabels: true }).success).toBe(false);
+  });
+
+  it('get_pivot_data_hierarchy_for_cell requires pivotTableName + cellAddress', () => {
+    const schema = excelTools.get_pivot_data_hierarchy_for_cell.inputSchema;
+    expect(asZod(schema).safeParse({ pivotTableName: 'PT1', cellAddress: 'B5' }).success).toBe(
+      true
+    );
+    expect(asZod(schema).safeParse({ pivotTableName: 'PT1' }).success).toBe(false);
+  });
+
+  it('get_pivot_items_for_cell requires pivotTableName + axis + cellAddress', () => {
+    const schema = excelTools.get_pivot_items_for_cell.inputSchema;
+    expect(
+      asZod(schema).safeParse({
+        pivotTableName: 'PT1',
+        axis: 'Row',
+        cellAddress: 'B5',
+      }).success
+    ).toBe(true);
+    expect(asZod(schema).safeParse({ pivotTableName: 'PT1', cellAddress: 'B5' }).success).toBe(
+      false
+    );
+  });
+
+  it('set_pivot_layout_auto_sort_on_cell requires pivotTableName + cellAddress + sortBy', () => {
+    const schema = excelTools.set_pivot_layout_auto_sort_on_cell.inputSchema;
+    expect(
+      asZod(schema).safeParse({
+        pivotTableName: 'PT1',
+        cellAddress: 'B5',
+        sortBy: 'Ascending',
+      }).success
+    ).toBe(true);
+    expect(asZod(schema).safeParse({ pivotTableName: 'PT1', sortBy: 'Ascending' }).success).toBe(
+      false
+    );
+  });
 });
 
 describe('tool schemas — workbook tools', () => {
@@ -915,6 +1015,24 @@ describe('tool schemas — pivot table tools', () => {
 
   it('refresh_pivot_table requires pivotTableName', () => {
     const schema = excelTools.refresh_pivot_table.inputSchema;
+    expect(asZod(schema).safeParse({ pivotTableName: 'PT1' }).success).toBe(true);
+    expect(asZod(schema).safeParse({}).success).toBe(false);
+  });
+
+  it('refresh_all_pivot_tables accepts optional sheetName', () => {
+    const schema = excelTools.refresh_all_pivot_tables.inputSchema;
+    expect(asZod(schema).safeParse({}).success).toBe(true);
+    expect(asZod(schema).safeParse({ sheetName: 'PivotSheet' }).success).toBe(true);
+  });
+
+  it('get_pivot_hierarchy_counts requires pivotTableName', () => {
+    const schema = excelTools.get_pivot_hierarchy_counts.inputSchema;
+    expect(asZod(schema).safeParse({ pivotTableName: 'PT1' }).success).toBe(true);
+    expect(asZod(schema).safeParse({}).success).toBe(false);
+  });
+
+  it('get_pivot_hierarchies requires pivotTableName', () => {
+    const schema = excelTools.get_pivot_hierarchies.inputSchema;
     expect(asZod(schema).safeParse({ pivotTableName: 'PT1' }).success).toBe(true);
     expect(asZod(schema).safeParse({}).success).toBe(false);
   });


### PR DESCRIPTION
## Summary
- Add new Pivot introspection APIs: efresh_all_pivot_tables, get_pivot_hierarchy_counts, get_pivot_hierarchies, get_pivot_field_items, get_pivot_layout_ranges, set_pivot_layout_display_options, get_pivot_data_hierarchy_for_cell, get_pivot_items_for_cell, set_pivot_layout_auto_sort_on_cell, get_pivot_table_count, pivot_table_exists, and get_pivot_table_location.
- Extend tool coverage checks in scripts/check-tool-coverage.ts.
- Update unit schema coverage in 	ests/unit/toolSchemas.test.ts and E2E taskpane tool exposure in 	ests-e2e/src/test-taskpane.ts.

## Validation
- 	ests/unit/toolSchemas.test.ts: **117 unit schema tests passing**.