### PR TITLE
fix: officeStorage getItem checks localStorage when OfficeRuntime returns null

### DIFF
--- a/src/stores/officeStorage.ts
+++ b/src/stores/officeStorage.ts
@@ -60,7 +60,15 @@ export const officeStorage: StateStorage = {
     if (storage) {
       try {
         const value = await storage.getItem(name);
-        return value ?? null;
+        // treat both null and undefined as "key not found"
+        if (value != null) {
+          return value;
+        }
+        // OfficeRuntime.storage has no value for this key.
+        // Check localStorage as a last resort — handles the case where a
+        // previous setItem() failed and wrote to localStorage instead, so
+        // we don't silently lose data the next time we read.
+        return localStorage.getItem(name);
       } catch (err) {
         console.warn('[officeStorage] getItem failed, falling back to localStorage:', err);
       }


### PR DESCRIPTION
Fixes state not persisting across Excel restarts. getItem had an asymmetric fallback: if setItem failed and wrote to localStorage, the next getItem (with OfficeRuntime available) returned null without checking localStorage. Fix: when OfficeRuntime returns null/undefined, also check localStorage as last resort. Adds 3 new tests for the recovery scenario.