### PR TITLE
feat: add MCP server support via mcp.json import

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "license": "MIT",
       "dependencies": {
         "@ai-sdk/azure": "^3.0.29",
+        "@ai-sdk/mcp": "^1.0.21",
         "@ai-sdk/react": "^3.0.87",
         "@assistant-ui/react": "^0.12.10",
         "@assistant-ui/react-ai-sdk": "^1.3.7",
@@ -124,6 +125,23 @@
         "@ai-sdk/provider": "3.0.8",
         "@ai-sdk/provider-utils": "4.0.15",
         "@vercel/oidc": "3.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/mcp": {
+      "version": "1.0.21",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/mcp/-/mcp-1.0.21.tgz",
+      "integrity": "sha512-dRX2X6GDadZNpiylNnw0HP7zJC8ggVOOJV/JtxuF6CgtP8CKnc7a/wEzpUw1m/4AGdD3mTDhKnKFwC4y10a8FQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "3.0.8",
+        "@ai-sdk/provider-utils": "4.0.15",
+        "pkce-challenge": "^5.0.0"
       },
       "engines": {
         "node": ">=18"
@@ -18561,6 +18579,15 @@
       },
       "engines": {
         "node": ">=0.10"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
       }
     },
     "node_modules/pkg-dir": {

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
   },
   "dependencies": {
     "@ai-sdk/azure": "^3.0.29",
+    "@ai-sdk/mcp": "^1.0.21",
     "@ai-sdk/react": "^3.0.87",
     "@assistant-ui/react": "^0.12.10",
     "@assistant-ui/react-ai-sdk": "^1.3.7",
@@ -118,7 +119,12 @@
     "@noble/hashes": "2.0.1"
   },
   "lint-staged": {
-    "src/**/*.{ts,tsx}": ["eslint --fix", "prettier --write"],
-    "src/**/*.css": ["prettier --write"]
+    "src/**/*.{ts,tsx}": [
+      "eslint --fix",
+      "prettier --write"
+    ],
+    "src/**/*.css": [
+      "prettier --write"
+    ]
   }
 }

--- a/src/components/ChatHeader.tsx
+++ b/src/components/ChatHeader.tsx
@@ -1,7 +1,8 @@
-import React from 'react';
-import { RotateCcw } from 'lucide-react';
+import React, { useState } from 'react';
+import { RotateCcw, ServerIcon } from 'lucide-react';
 import { SkillPicker } from './SkillPicker';
 import { SettingsDialog } from './SettingsDialog';
+import { McpManagerDialog } from './McpManagerDialog';
 
 export interface ChatHeaderProps {
   onClearMessages: () => void;
@@ -14,6 +15,8 @@ export const ChatHeader: React.FC<ChatHeaderProps> = ({
   settingsOpen,
   onSettingsOpenChange,
 }) => {
+  const [mcpOpen, setMcpOpen] = useState(false);
+
   return (
     <div className="flex items-center justify-between border-b border-border bg-background px-3 py-1.5">
       <div className="flex items-center gap-2 min-w-0">
@@ -22,6 +25,14 @@ export const ChatHeader: React.FC<ChatHeaderProps> = ({
       </div>
 
       <div className="flex items-center gap-0.5">
+        <button
+          onClick={() => setMcpOpen(true)}
+          className="inline-flex h-8 w-8 items-center justify-center rounded-md text-muted-foreground hover:bg-accent hover:text-accent-foreground transition-colors"
+          aria-label="MCP servers"
+          title="MCP servers"
+        >
+          <ServerIcon className="size-4" />
+        </button>
         <button
           onClick={onClearMessages}
           className="inline-flex h-8 w-8 items-center justify-center rounded-md text-muted-foreground hover:bg-accent hover:text-accent-foreground transition-colors"
@@ -32,6 +43,7 @@ export const ChatHeader: React.FC<ChatHeaderProps> = ({
         </button>
         <div className="mx-1 h-4 w-px bg-border" />
         <SettingsDialog open={settingsOpen} onOpenChange={onSettingsOpenChange} />
+        <McpManagerDialog open={mcpOpen} onOpenChange={setMcpOpen} />
       </div>
     </div>
   );

--- a/src/components/McpManagerDialog.tsx
+++ b/src/components/McpManagerDialog.tsx
@@ -1,0 +1,162 @@
+import React, { useCallback, useRef, useState } from 'react';
+import { Loader2, ServerIcon, Trash2, Upload } from 'lucide-react';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { parseMcpJsonFile } from '@/services/mcp';
+import { useSettingsStore } from '@/stores';
+
+interface McpManagerDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+export const McpManagerDialog: React.FC<McpManagerDialogProps> = ({ open, onOpenChange }) => {
+  const [importStatus, setImportStatus] = useState<string | null>(null);
+  const [importError, setImportError] = useState<string | null>(null);
+  const [isImporting, setIsImporting] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const importedMcpServers = useSettingsStore(s => s.importedMcpServers);
+  const activeMcpServerNames = useSettingsStore(s => s.activeMcpServerNames);
+  const importMcpServers = useSettingsStore(s => s.importMcpServers);
+  const removeMcpServer = useSettingsStore(s => s.removeMcpServer);
+  const toggleMcpServer = useSettingsStore(s => s.toggleMcpServer);
+
+  const isServerActive = (name: string) =>
+    activeMcpServerNames === null || activeMcpServerNames.includes(name);
+
+  const handleImportJson = useCallback(
+    async (event: React.ChangeEvent<HTMLInputElement>) => {
+      const file = event.target.files?.[0];
+      if (!file) return;
+
+      setImportStatus(null);
+      setImportError(null);
+      setIsImporting(true);
+
+      try {
+        const servers = await parseMcpJsonFile(file);
+        importMcpServers(servers);
+        setImportStatus(
+          `Imported ${servers.length} server${servers.length === 1 ? '' : 's'} from ${file.name}.`
+        );
+      } catch (error) {
+        setImportError(error instanceof Error ? error.message : 'Failed to import mcp.json.');
+      } finally {
+        setIsImporting(false);
+        event.target.value = '';
+      }
+    },
+    [importMcpServers]
+  );
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-[420px] max-h-[85vh] flex flex-col">
+        <DialogHeader>
+          <DialogTitle>MCP Servers</DialogTitle>
+          <DialogDescription>
+            Import a <code>mcp.json</code> file to connect AI tools from external MCP servers (HTTP
+            or SSE transport).
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="flex-1 overflow-y-auto space-y-3 pr-1">
+          <div className="flex items-center justify-between gap-2">
+            <h4 className="text-xs font-medium text-muted-foreground">Configured Servers</h4>
+            <>
+              <input
+                ref={inputRef}
+                type="file"
+                accept=".json,application/json"
+                className="hidden"
+                aria-label="Import mcp.json file"
+                onChange={event => void handleImportJson(event)}
+              />
+              <Button
+                variant="secondary"
+                size="sm"
+                onClick={() => inputRef.current?.click()}
+                disabled={isImporting}
+                aria-busy={isImporting}
+              >
+                {isImporting ? (
+                  <Loader2 className="size-3.5 animate-spin" />
+                ) : (
+                  <Upload className="size-3.5" />
+                )}
+                {isImporting ? 'Importing…' : 'Import mcp.json'}
+              </Button>
+            </>
+          </div>
+
+          {importStatus && (
+            <div
+              role="status"
+              aria-live="polite"
+              className="rounded-md border border-emerald-300 bg-emerald-50 px-3 py-2 text-xs text-emerald-900 dark:border-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-100"
+            >
+              {importStatus}
+            </div>
+          )}
+          {importError && (
+            <div
+              role="alert"
+              aria-live="assertive"
+              className="rounded-md border border-red-300 bg-red-50 px-3 py-2 text-xs text-red-900 dark:border-red-700 dark:bg-red-900/30 dark:text-red-100"
+            >
+              {importError}
+            </div>
+          )}
+
+          <div className="space-y-1">
+            {importedMcpServers.length === 0 ? (
+              <p className="text-xs text-muted-foreground">
+                No MCP servers configured. Import a <code>mcp.json</code> to get started.
+              </p>
+            ) : (
+              importedMcpServers.map(server => (
+                <div
+                  key={`mcp-server-${server.name}`}
+                  className="flex items-center justify-between rounded-md border border-border px-2 py-1.5 gap-2"
+                >
+                  <button
+                    className="flex items-center gap-2 min-w-0 flex-1 text-left"
+                    onClick={() => toggleMcpServer(server.name)}
+                    aria-pressed={isServerActive(server.name)}
+                    title={isServerActive(server.name) ? 'Click to disable' : 'Click to enable'}
+                  >
+                    <ServerIcon
+                      className={`size-3.5 shrink-0 ${isServerActive(server.name) ? 'text-emerald-500' : 'text-muted-foreground'}`}
+                    />
+                    <div className="min-w-0">
+                      <p className="truncate text-sm font-medium">{server.name}</p>
+                      <p className="truncate text-xs text-muted-foreground">
+                        {server.description ?? server.url}
+                      </p>
+                    </div>
+                  </button>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    className="h-7 px-2 text-destructive hover:text-destructive shrink-0"
+                    onClick={() => removeMcpServer(server.name)}
+                  >
+                    <Trash2 className="size-3.5" />
+                    Remove
+                  </Button>
+                </div>
+              ))
+            )}
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+};

--- a/src/hooks/useMcpTools.ts
+++ b/src/hooks/useMcpTools.ts
@@ -1,0 +1,67 @@
+import { useEffect, useRef, useState } from 'react';
+import { createMCPClient } from '@ai-sdk/mcp';
+import type { ToolSet } from 'ai';
+import type { McpServerConfig } from '@/types';
+
+/**
+ * Connects to a list of MCP servers and returns a merged ToolSet.
+ *
+ * - Re-connects whenever the server list meaningfully changes (name, url, or transport).
+ * - Silently skips servers that fail to connect (logs a warning).
+ * - Closes all connections on cleanup.
+ */
+export function useMcpTools(configs: McpServerConfig[]): ToolSet {
+  const [tools, setTools] = useState<ToolSet>({});
+
+  // Stable key: re-run effect only when connection parameters change.
+  const configKey = configs.map(c => `${c.name}|${c.url}|${c.transport}`).join(',');
+
+  // Ref lets the async load function see the latest configs even after re-renders.
+  const configsRef = useRef(configs);
+  configsRef.current = configs;
+
+  useEffect(() => {
+    const currentConfigs = configsRef.current;
+
+    if (currentConfigs.length === 0) {
+      setTools({});
+      return;
+    }
+
+    let cancelled = false;
+    const clients: { close: () => Promise<void> }[] = [];
+
+    async function loadTools() {
+      const merged: ToolSet = {};
+
+      for (const config of currentConfigs) {
+        try {
+          const client = await createMCPClient({
+            transport: { type: config.transport, url: config.url, headers: config.headers },
+            name: config.name,
+          });
+          clients.push(client);
+          const serverTools = await client.tools();
+          Object.assign(merged, serverTools);
+        } catch (err) {
+          console.warn(`[MCP] Failed to connect to "${config.name}":`, err);
+        }
+      }
+
+      if (!cancelled) {
+        setTools(merged);
+      }
+    }
+
+    void loadTools();
+
+    return () => {
+      cancelled = true;
+      for (const c of clients) {
+        void c.close();
+      }
+    };
+  }, [configKey]);
+
+  return tools;
+}

--- a/src/services/mcp/index.ts
+++ b/src/services/mcp/index.ts
@@ -1,0 +1,1 @@
+export { parseMcpJsonFile, resolveActiveMcpServers } from './mcpService';

--- a/src/services/mcp/mcpService.ts
+++ b/src/services/mcp/mcpService.ts
@@ -1,0 +1,86 @@
+import type { McpServerConfig, McpTransportType } from '@/types';
+
+/** Shape accepted from both Claude Desktop and VS Code mcp.json formats */
+interface RawMcpEntry {
+  url?: string;
+  type?: string;
+  transport?: string;
+  headers?: Record<string, string>;
+  description?: string;
+}
+
+/**
+ * Parse a `mcp.json` File into a normalized McpServerConfig array.
+ *
+ * Supports:
+ *   - Claude Desktop format: `{ mcpServers: { name: { url, type, headers } } }`
+ *   - VS Code format:        `{ servers:    { name: { url, type, headers } } }`
+ *
+ * Only HTTP/SSE entries are included (stdio entries are silently skipped because
+ * they require a Node.js child process and do not work in a browser runtime).
+ */
+export async function parseMcpJsonFile(file: File): Promise<McpServerConfig[]> {
+  if (!file.name.endsWith('.json')) {
+    throw new Error('File must be a .json file.');
+  }
+
+  const text = await file.text();
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(text) as unknown;
+  } catch {
+    throw new Error('Invalid JSON: could not parse mcp.json.');
+  }
+
+  if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+    throw new Error('mcp.json must be a JSON object.');
+  }
+
+  // Support both { mcpServers: {...} } and { servers: {...} }
+  const raw = parsed as Record<string, unknown>;
+  const serversMap =
+    (raw.mcpServers as Record<string, RawMcpEntry> | undefined) ??
+    (raw.servers as Record<string, RawMcpEntry> | undefined);
+
+  if (!serversMap || typeof serversMap !== 'object' || Array.isArray(serversMap)) {
+    throw new Error('mcp.json must contain a "mcpServers" or "servers" object.');
+  }
+
+  const configs: McpServerConfig[] = [];
+
+  for (const [name, entry] of Object.entries(serversMap)) {
+    if (typeof entry !== 'object' || entry === null) continue;
+
+    const url = entry.url;
+    if (typeof url !== 'string' || !url) continue; // skip stdio entries (no url)
+
+    const rawTransport = (entry.type ?? entry.transport ?? 'http').toLowerCase();
+    if (rawTransport !== 'http' && rawTransport !== 'sse') continue; // skip unknown/stdio
+
+    configs.push({
+      name,
+      description: typeof entry.description === 'string' ? entry.description : undefined,
+      url,
+      transport: rawTransport as McpTransportType,
+      headers: entry.headers,
+    });
+  }
+
+  if (configs.length === 0) {
+    throw new Error(
+      'No valid HTTP/SSE MCP servers found in mcp.json. ' +
+        'Make sure each entry has a "url" and an optional "type" of "http" or "sse".'
+    );
+  }
+
+  return configs;
+}
+
+/** Return only the servers that are currently active (null = all active). */
+export function resolveActiveMcpServers(
+  servers: McpServerConfig[],
+  activeNames: string[] | null
+): McpServerConfig[] {
+  if (activeNames === null) return servers;
+  return servers.filter(s => activeNames.includes(s.name));
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -17,3 +17,4 @@ export type {
 } from './excel';
 export type { AgentSkill, SkillMetadata } from './skill';
 export type { AgentConfig, AgentMetadata } from './agent';
+export type { McpServerConfig, McpTransportType } from './mcp';

--- a/src/types/mcp.ts
+++ b/src/types/mcp.ts
@@ -1,0 +1,16 @@
+/** Transport type for an MCP server (browser-compatible options only; no stdio) */
+export type McpTransportType = 'http' | 'sse';
+
+/** A configured MCP server imported from a mcp.json file */
+export interface McpServerConfig {
+  /** Display name (used as identifier) */
+  name: string;
+  /** Optional description shown in the UI */
+  description?: string;
+  /** MCP server endpoint URL */
+  url: string;
+  /** Transport protocol */
+  transport: McpTransportType;
+  /** Optional HTTP headers (e.g. Authorization) */
+  headers?: Record<string, string>;
+}

--- a/src/types/settings.ts
+++ b/src/types/settings.ts
@@ -1,6 +1,7 @@
 /** Authentication method for an endpoint */
 import type { AgentConfig } from './agent';
 import type { AgentSkill } from './skill';
+import type { McpServerConfig } from './mcp';
 
 /** Authentication method for an endpoint */
 export type AuthMethod = 'apiKey';
@@ -64,6 +65,10 @@ export interface UserSettings {
   importedSkills: AgentSkill[];
   /** Imported agents loaded from local ZIP files. Bundled agents are managed separately and read-only. */
   importedAgents: AgentConfig[];
+  /** MCP servers imported from a mcp.json file. */
+  importedMcpServers: McpServerConfig[];
+  /** Names of currently active MCP servers. null = all servers enabled (default). */
+  activeMcpServerNames: string[] | null;
 }
 
 /** Default settings applied on first run */
@@ -77,4 +82,6 @@ export const DEFAULT_SETTINGS: UserSettings = {
   activeAgentId: 'Excel',
   importedSkills: [],
   importedAgents: [],
+  importedMcpServers: [],
+  activeMcpServerNames: null,
 };

--- a/tests/unit/mcpService.test.ts
+++ b/tests/unit/mcpService.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect } from 'vitest';
+import { parseMcpJsonFile, resolveActiveMcpServers } from '@/services/mcp';
+import type { McpServerConfig } from '@/types';
+
+function makeFile(content: unknown, name = 'mcp.json'): File {
+  return new File([JSON.stringify(content)], name, { type: 'application/json' });
+}
+
+describe('parseMcpJsonFile', () => {
+  it('parses Claude Desktop mcpServers format', async () => {
+    const file = makeFile({
+      mcpServers: {
+        'my-server': { url: 'https://example.com/mcp', type: 'http' },
+      },
+    });
+    const result = await parseMcpJsonFile(file);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({ name: 'my-server', url: 'https://example.com/mcp', transport: 'http' });
+  });
+
+  it('parses VS Code servers format', async () => {
+    const file = makeFile({
+      servers: {
+        'sse-server': { url: 'https://example.com/sse', type: 'sse' },
+      },
+    });
+    const result = await parseMcpJsonFile(file);
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({ name: 'sse-server', transport: 'sse' });
+  });
+
+  it('defaults transport to http when type is omitted', async () => {
+    const file = makeFile({ mcpServers: { srv: { url: 'https://example.com/mcp' } } });
+    const result = await parseMcpJsonFile(file);
+    expect(result[0].transport).toBe('http');
+  });
+
+  it('preserves headers and description', async () => {
+    const file = makeFile({
+      mcpServers: {
+        srv: {
+          url: 'https://example.com/mcp',
+          type: 'http',
+          headers: { Authorization: 'Bearer tok' },
+          description: 'My server',
+        },
+      },
+    });
+    const result = await parseMcpJsonFile(file);
+    expect(result[0].headers).toEqual({ Authorization: 'Bearer tok' });
+    expect(result[0].description).toBe('My server');
+  });
+
+  it('skips entries without a url (stdio entries)', async () => {
+    const file = makeFile({
+      mcpServers: {
+        stdio: { command: 'node', args: ['server.js'] },
+        web: { url: 'https://example.com/mcp', type: 'http' },
+      },
+    });
+    const result = await parseMcpJsonFile(file);
+    expect(result).toHaveLength(1);
+    expect(result[0].name).toBe('web');
+  });
+
+  it('skips unknown transport types', async () => {
+    const file = makeFile({
+      mcpServers: {
+        bad: { url: 'https://example.com/mcp', type: 'grpc' },
+        good: { url: 'https://example.com/mcp', type: 'sse' },
+      },
+    });
+    const result = await parseMcpJsonFile(file);
+    expect(result).toHaveLength(1);
+    expect(result[0].name).toBe('good');
+  });
+
+  it('throws on invalid JSON', async () => {
+    const file = new File(['not-json'], 'mcp.json');
+    await expect(parseMcpJsonFile(file)).rejects.toThrow('Invalid JSON');
+  });
+
+  it('throws when no mcpServers/servers key exists', async () => {
+    const file = makeFile({ foo: 'bar' });
+    await expect(parseMcpJsonFile(file)).rejects.toThrow();
+  });
+
+  it('throws when all entries are skipped (no valid HTTP/SSE servers)', async () => {
+    const file = makeFile({
+      mcpServers: {
+        stdio: { command: 'node' },
+      },
+    });
+    await expect(parseMcpJsonFile(file)).rejects.toThrow('No valid HTTP/SSE');
+  });
+
+  it('throws on non-.json file extension', async () => {
+    const file = new File(['{}'], 'mcp.txt');
+    await expect(parseMcpJsonFile(file)).rejects.toThrow('.json');
+  });
+
+  it.each([
+    ['mcpServers', { mcpServers: { a: { url: 'https://a.com', type: 'http' }, b: { url: 'https://b.com', type: 'sse' } } }],
+    ['servers', { servers: { a: { url: 'https://a.com', type: 'http' }, b: { url: 'https://b.com', type: 'sse' } } }],
+  ])('handles multiple servers in %s format', async (_fmt, content) => {
+    const file = makeFile(content);
+    const result = await parseMcpJsonFile(file);
+    expect(result).toHaveLength(2);
+  });
+});
+
+describe('resolveActiveMcpServers', () => {
+  const servers: McpServerConfig[] = [
+    { name: 'a', url: 'https://a.com', transport: 'http' },
+    { name: 'b', url: 'https://b.com', transport: 'sse' },
+    { name: 'c', url: 'https://c.com', transport: 'http' },
+  ];
+
+  it('returns all servers when activeNames is null', () => {
+    expect(resolveActiveMcpServers(servers, null)).toHaveLength(3);
+  });
+
+  it('filters to only active server names', () => {
+    const result = resolveActiveMcpServers(servers, ['a', 'c']);
+    expect(result.map(s => s.name)).toEqual(['a', 'c']);
+  });
+
+  it('returns empty when activeNames is empty array', () => {
+    expect(resolveActiveMcpServers(servers, [])).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
Adds MCP server support using the official @ai-sdk/mcp SDK. Import a mcp.json file (Claude Desktop or VS Code format) to configure external MCP servers. Tools from connected servers merge automatically with Excel tools in the AI agent.

## New files
- src/types/mcp.ts - McpServerConfig type
- src/services/mcp/mcpService.ts - parseMcpJsonFile + resolveActiveMcpServers
- src/hooks/useMcpTools.ts - async hook connecting to MCP servers, returns ToolSet
- src/components/McpManagerDialog.tsx - import/toggle/remove UI (Server icon in header)

## Modified files
- src/types/settings.ts - importedMcpServers, activeMcpServerNames
- src/stores/settingsStore.ts - importMcpServers, removeMcpServer, toggleMcpServer + persist
- src/hooks/useOfficeChat.ts - merges MCP tools with Excel tools
- src/components/ChatHeader.tsx - Server icon button opens McpManagerDialog

## Tests
23 new tests (mcpService.test.ts + settingsStore MCP CRUD). All 412 pass. typecheck and lint clean.