### PR TITLE
test: add MCP integration tests with local test server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@ playwright-report/
 
 # Local extensions (not published)
 local/extensions/
+local/*.json
 
 # OS generated files
 .DS_Store

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,6 +36,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.39.2",
+        "@modelcontextprotocol/sdk": "^1.26.0",
         "@playwright/test": "^1.58.2",
         "@tailwindcss/postcss": "^4.1.18",
         "@testing-library/jest-dom": "^6.9.1",
@@ -1973,6 +1974,19 @@
       "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.10.tgz",
       "integrity": "sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==",
       "license": "MIT"
+    },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.9",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.9.tgz",
+      "integrity": "sha512-vHL6w3ecZsky+8P5MD+eFfaGTyCeOHUIFYMGpQGbrBTSmNNoxv0if69rEZ5giu36weC5saFuznL411gRX7bJDw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
     },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
@@ -5206,6 +5220,365 @@
       "peer": true,
       "engines": {
         "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.26.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.26.0.tgz",
+      "integrity": "sha512-Y5RmPncpiDtTXDbLKswIJzTqu2hyBKxTNsgKqKclDbhIgg1wgtf1fRuvxgTnRfcnxtvvgbIEcqUOzZrJ6iSReg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/ajv": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/body-parser": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.2.tgz",
+      "integrity": "sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^1.0.5",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.0",
+        "iconv-lite": "^0.7.0",
+        "on-finished": "^2.4.1",
+        "qs": "^6.14.1",
+        "raw-body": "^3.0.1",
+        "type-is": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/content-disposition": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.1.tgz",
+      "integrity": "sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/iconv-lite": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.2.tgz",
+      "integrity": "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/media-typer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
+      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk/node_modules/type-is": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
+      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^1.0.5",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/@noble/hashes": {
@@ -10332,6 +10705,24 @@
       "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
       "license": "MIT"
     },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/cosmiconfig": {
       "version": "9.0.0",
       "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.0.tgz",
@@ -11823,6 +12214,19 @@
         "node": ">=0.8.x"
       }
     },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/eventsource-parser": {
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.0.6.tgz",
@@ -11899,6 +12303,25 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.2.1.tgz",
+      "integrity": "sha512-PCZEIEIxqwhzw4KF0n7QF4QqruVTcF73O5kFKUnGOyjbCCgizBBiFaYpd/fnBLUMPw/BWw9OsiN7GgrNYr7j6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ip-address": "10.0.1"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
       }
     },
     "node_modules/express/node_modules/debug": {
@@ -12750,6 +13173,16 @@
         "he": "bin/he"
       }
     },
+    "node_modules/hono": {
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.0.tgz",
+      "integrity": "sha512-NekXntS5M94pUfiVZ8oXXK/kkri+5WpX2/Ik+LVsl+uvw+soj4roXIsPqO+XsWrAw20mOzaXOZf3Q7PfB9A/IA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
     "node_modules/hpack.js": {
       "version": "2.1.6",
       "resolved": "https://registry.npmjs.org/hpack.js/-/hpack.js-2.1.6.tgz",
@@ -13368,6 +13801,16 @@
         "node": ">=10.13.0"
       }
     },
+    "node_modules/ip-address": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.0.1.tgz",
+      "integrity": "sha512-NWv9YLW4PoW2B7xtzaS3NCot75m6nK7Icdv0o3lfMceJVRfSoQwqD4wEH5rLwoKJwUiZ/rfpiVBhnaF0FK4HoA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
@@ -13616,6 +14059,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/is-retry-allowed": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-2.2.0.tgz",
@@ -13775,6 +14225,16 @@
         "jiti": "lib/jiti-cli.mjs"
       }
     },
+    "node_modules/jose": {
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.1.3.tgz",
+      "integrity": "sha512-0TpaTfihd4QMNwrz/ob2Bp7X04yuxJkjRGi4aKmOqwhov54i6u79oCv7T+C7lo70MKH6BesI3vscD1yb/yzKXQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
     "node_modules/js-base64": {
       "version": "3.7.8",
       "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-3.7.8.tgz",
@@ -13925,6 +14385,13 @@
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "dev": true,
+      "license": "BSD-2-Clause"
     },
     "node_modules/json-stable-stringify": {
       "version": "1.3.0",
@@ -16690,6 +17157,16 @@
         "node": ">= 6"
       }
     },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/object-inspect": {
       "version": "1.13.4",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
@@ -18100,7 +18577,6 @@
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
       "dev": true,
       "license": "ISC",
-      "peer": true,
       "dependencies": {
         "wrappy": "1"
       }
@@ -19818,6 +20294,34 @@
       "os": [
         "linux"
       ]
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/router/node_modules/path-to-regexp": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.3.0.tgz",
+      "integrity": "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
     },
     "node_modules/run-applescript": {
       "version": "7.1.0",
@@ -22781,8 +23285,7 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "dev": true,
-      "license": "ISC",
-      "peer": true
+      "license": "ISC"
     },
     "node_modules/ws": {
       "version": "8.19.0",
@@ -23014,6 +23517,16 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.1",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.1.tgz",
+      "integrity": "sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA==",
+      "dev": true,
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25 || ^4"
       }
     },
     "node_modules/zustand": {

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.39.2",
+    "@modelcontextprotocol/sdk": "^1.26.0",
     "@playwright/test": "^1.58.2",
     "@tailwindcss/postcss": "^4.1.18",
     "@testing-library/jest-dom": "^6.9.1",

--- a/tests/helpers/mcp-test-server.ts
+++ b/tests/helpers/mcp-test-server.ts
@@ -1,0 +1,94 @@
+/**
+ * Local HTTP MCP test server.
+ *
+ * Starts a minimal Streamable HTTP MCP server on a random port for use
+ * in integration tests. The server exposes two deterministic test tools:
+ *   - echo(message)  → returns the message as text
+ *   - add(a, b)      → returns the sum of two numbers
+ *
+ * Usage:
+ *   const server = await startMcpTestServer();
+ *   // server.url → 'http://127.0.0.1:<port>/mcp'
+ *   await server.stop();
+ */
+
+import * as http from 'http';
+import type { AddressInfo } from 'net';
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
+import { z } from 'zod';
+
+export interface McpTestServer {
+  /** Full URL to POST MCP requests to, e.g. http://127.0.0.1:12345/mcp */
+  url: string;
+  stop: () => Promise<void>;
+}
+
+function buildMcpServer(): McpServer {
+  const server = new McpServer({ name: 'test-server', version: '1.0.0' });
+
+  server.registerTool(
+    'echo',
+    { description: 'Returns the input message unchanged', inputSchema: { message: z.string() } },
+    async ({ message }) => ({ content: [{ type: 'text' as const, text: message }] })
+  );
+
+  server.registerTool(
+    'add',
+    { description: 'Adds two numbers and returns the result', inputSchema: { a: z.number(), b: z.number() } },
+    async ({ a, b }) => ({ content: [{ type: 'text' as const, text: String(a + b) }] })
+  );
+
+  return server;
+}
+
+async function readBody(req: http.IncomingMessage): Promise<unknown> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of req) {
+    chunks.push(chunk as Buffer);
+  }
+  return JSON.parse(Buffer.concat(chunks).toString()) as unknown;
+}
+
+export async function startMcpTestServer(): Promise<McpTestServer> {
+  const httpServer = http.createServer(async (req, res) => {
+    if (req.method !== 'POST') {
+      res.writeHead(405).end(
+        JSON.stringify({ jsonrpc: '2.0', error: { code: -32000, message: 'Method not allowed' }, id: null })
+      );
+      return;
+    }
+
+    try {
+      const body = await readBody(req);
+      const mcpServer = buildMcpServer();
+      const transport = new StreamableHTTPServerTransport({ sessionIdGenerator: undefined });
+      await mcpServer.connect(transport);
+      await transport.handleRequest(req, res, body);
+      res.on('close', () => {
+        void transport.close();
+        void mcpServer.close();
+      });
+    } catch (err) {
+      if (!res.headersSent) {
+        res.writeHead(500).end(
+          JSON.stringify({ jsonrpc: '2.0', error: { code: -32603, message: 'Internal error' }, id: null })
+        );
+      }
+    }
+  });
+
+  await new Promise<void>(resolve => {
+    httpServer.listen(0, '127.0.0.1', resolve);
+  });
+
+  const { port } = httpServer.address() as AddressInfo;
+
+  return {
+    url: `http://127.0.0.1:${port}/mcp`,
+    stop: () =>
+      new Promise<void>((resolve, reject) => {
+        httpServer.close(err => (err ? reject(err) : resolve()));
+      }),
+  };
+}

--- a/tests/integration/mcp-manager-dialog.test.tsx
+++ b/tests/integration/mcp-manager-dialog.test.tsx
@@ -1,0 +1,167 @@
+/**
+ * Integration test: McpManagerDialog component.
+ *
+ * Renders the real McpManagerDialog with the real Zustand store.
+ * Tests import, toggle, and remove flows without a live MCP server.
+ */
+import React from 'react';
+import { describe, it, expect, beforeEach } from 'vitest';
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { renderWithProviders } from '../test-utils';
+import { McpManagerDialog } from '@/components/McpManagerDialog';
+import { useSettingsStore } from '@/stores/settingsStore';
+
+function makeJsonFile(content: unknown, name = 'mcp.json'): File {
+  return new File([JSON.stringify(content)], name, { type: 'application/json' });
+}
+
+const validMcpJson = {
+  mcpServers: {
+    'my-server': {
+      url: 'https://example.com/mcp/sse',
+      type: 'sse',
+      description: 'Example MCP server',
+    },
+    'another-server': {
+      url: 'https://example.com/mcp',
+      type: 'http',
+    },
+  },
+};
+
+const OpenDialog: React.FC = () => {
+  const [open, setOpen] = React.useState(true);
+  return <McpManagerDialog open={open} onOpenChange={setOpen} />;
+};
+
+beforeEach(() => {
+  useSettingsStore.getState().reset();
+});
+
+describe('Integration: McpManagerDialog', () => {
+  it('renders empty state with import button', () => {
+    renderWithProviders(<OpenDialog />);
+
+    expect(screen.getByRole('dialog', { name: 'MCP Servers' })).toBeInTheDocument();
+    expect(screen.getByText(/No MCP servers configured/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Import mcp\.json/i })).toBeInTheDocument();
+  });
+
+  it('imports servers from a valid mcp.json file', async () => {
+    renderWithProviders(<OpenDialog />);
+
+    const fileInput = screen.getByLabelText('Import mcp.json file');
+    await userEvent.upload(fileInput, makeJsonFile(validMcpJson));
+
+    await waitFor(() => {
+      expect(screen.getByText('my-server')).toBeInTheDocument();
+    });
+
+    expect(screen.getByText('another-server')).toBeInTheDocument();
+    expect(screen.getByRole('status')).toHaveTextContent('Imported 2 servers from mcp.json');
+  });
+
+  it('shows the server description when available', async () => {
+    renderWithProviders(<OpenDialog />);
+
+    const fileInput = screen.getByLabelText('Import mcp.json file');
+    await userEvent.upload(fileInput, makeJsonFile(validMcpJson));
+
+    await waitFor(() => {
+      expect(screen.getByText('Example MCP server')).toBeInTheDocument();
+    });
+  });
+
+  it('shows error for invalid JSON', async () => {
+    renderWithProviders(<OpenDialog />);
+
+    const file = new File(['not-json'], 'mcp.json', { type: 'application/json' });
+    const fileInput = screen.getByLabelText('Import mcp.json file');
+    await userEvent.upload(fileInput, file);
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toBeInTheDocument();
+    });
+  });
+
+  it('shows error when all entries are stdio (no valid HTTP/SSE servers)', async () => {
+    renderWithProviders(<OpenDialog />);
+
+    const stdioOnly = { mcpServers: { srv: { command: 'node', args: ['server.js'] } } };
+    const fileInput = screen.getByLabelText('Import mcp.json file');
+    await userEvent.upload(fileInput, makeJsonFile(stdioOnly));
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toHaveTextContent(/No valid HTTP\/SSE/i);
+    });
+  });
+
+  it('servers are active (aria-pressed=true) by default after import', async () => {
+    renderWithProviders(<OpenDialog />);
+
+    const fileInput = screen.getByLabelText('Import mcp.json file');
+    await userEvent.upload(fileInput, makeJsonFile(validMcpJson));
+
+    await waitFor(() => {
+      expect(screen.getByText('my-server')).toBeInTheDocument();
+    });
+
+    // Toggle button name includes description text — use regex
+    const toggleButton = screen.getByRole('button', { name: /my-server/ });
+    expect(toggleButton).toHaveAttribute('aria-pressed', 'true');
+  });
+
+  it('clicking a server button toggles it off', async () => {
+    renderWithProviders(<OpenDialog />);
+
+    const fileInput = screen.getByLabelText('Import mcp.json file');
+    await userEvent.upload(fileInput, makeJsonFile(validMcpJson));
+
+    await waitFor(() => {
+      expect(screen.getByText('my-server')).toBeInTheDocument();
+    });
+
+    const toggleButton = screen.getByRole('button', { name: /my-server/ });
+    await userEvent.click(toggleButton);
+
+    expect(toggleButton).toHaveAttribute('aria-pressed', 'false');
+    expect(useSettingsStore.getState().activeMcpServerNames).toEqual(['another-server']);
+  });
+
+  it('clicking a disabled server toggles it back on', async () => {
+    useSettingsStore.getState().importMcpServers([
+      { name: 'srv', url: 'https://example.com/mcp', transport: 'http' },
+    ]);
+    useSettingsStore.setState({ activeMcpServerNames: [] });
+
+    renderWithProviders(<OpenDialog />);
+
+    // Toggle button name includes URL — use regex
+    const toggleButton = screen.getByRole('button', { name: /^srv/ });
+    expect(toggleButton).toHaveAttribute('aria-pressed', 'false');
+
+    await userEvent.click(toggleButton);
+    expect(toggleButton).toHaveAttribute('aria-pressed', 'true');
+  });
+
+  it('Remove button removes a server from the list and store', async () => {
+    useSettingsStore.getState().importMcpServers([
+      { name: 'to-remove', url: 'https://example.com/mcp', transport: 'http' },
+      { name: 'keep', url: 'https://example.com/keep', transport: 'http' },
+    ]);
+
+    renderWithProviders(<OpenDialog />);
+
+    expect(screen.getByText('to-remove')).toBeInTheDocument();
+
+    const removeButtons = screen.getAllByRole('button', { name: 'Remove' });
+    await userEvent.click(removeButtons[0]);
+
+    await waitFor(() => {
+      expect(screen.queryByText('to-remove')).not.toBeInTheDocument();
+    });
+    expect(screen.getByText('keep')).toBeInTheDocument();
+    expect(useSettingsStore.getState().importedMcpServers).toHaveLength(1);
+  });
+});

--- a/tests/integration/mcp-tools.integration.test.ts
+++ b/tests/integration/mcp-tools.integration.test.ts
@@ -1,0 +1,91 @@
+/**
+ * Integration test: MCP client ↔ local test server.
+ *
+ * Starts a real Streamable HTTP MCP server in-process, then uses
+ * @ai-sdk/mcp createMCPClient to connect, discover tools, and execute them.
+ *
+ * This tests the full round-trip: useMcpTools hook logic (createMCPClient +
+ * .tools() + .execute()) against a real server — no public API needed.
+ */
+
+import { describe, it, expect, beforeAll, afterAll, afterEach } from 'vitest';
+import { createMCPClient } from '@ai-sdk/mcp';
+import { startMcpTestServer, type McpTestServer } from '../helpers/mcp-test-server';
+
+let server: McpTestServer;
+let client: Awaited<ReturnType<typeof createMCPClient>> | undefined;
+
+beforeAll(async () => {
+  server = await startMcpTestServer();
+});
+
+afterAll(async () => {
+  await server.stop();
+});
+
+afterEach(async () => {
+  if (client) {
+    await client.close();
+    client = undefined;
+  }
+});
+
+describe('MCP integration: local test server', () => {
+  it('connects and retrieves the tool list', async () => {
+    client = await createMCPClient({
+      transport: { type: 'http', url: server.url },
+    });
+
+    const tools = await client.tools();
+    expect(Object.keys(tools)).toContain('echo');
+    expect(Object.keys(tools)).toContain('add');
+  });
+
+  it('each tool has a description and execute function', async () => {
+    client = await createMCPClient({
+      transport: { type: 'http', url: server.url },
+    });
+
+    const tools = await client.tools();
+    for (const tool of Object.values(tools)) {
+      expect(tool).toHaveProperty('description');
+      expect(tool).toHaveProperty('execute');
+      expect(typeof tool.execute).toBe('function');
+    }
+  });
+
+  it('echo tool returns the input message', async () => {
+    client = await createMCPClient({
+      transport: { type: 'http', url: server.url },
+    });
+
+    const tools = await client.tools();
+    const result = await tools.echo.execute({ message: 'hello mcp' }, { messages: [], toolCallId: 'test-1' });
+    expect(result).toMatchObject({ content: [{ type: 'text', text: 'hello mcp' }] });
+  });
+
+  it('add tool returns the correct sum', async () => {
+    client = await createMCPClient({
+      transport: { type: 'http', url: server.url },
+    });
+
+    const tools = await client.tools();
+    const result = await tools.add.execute({ a: 7, b: 35 }, { messages: [], toolCallId: 'test-2' });
+    expect(result).toMatchObject({ content: [{ type: 'text', text: '42' }] });
+  });
+
+  it('multiple clients can connect concurrently', async () => {
+    const [c1, c2] = await Promise.all([
+      createMCPClient({ transport: { type: 'http', url: server.url } }),
+      createMCPClient({ transport: { type: 'http', url: server.url } }),
+    ]);
+
+    try {
+      const [t1, t2] = await Promise.all([c1.tools(), c2.tools()]);
+      expect(Object.keys(t1)).toContain('echo');
+      expect(Object.keys(t2)).toContain('add');
+    } finally {
+      await Promise.all([c1.close(), c2.close()]);
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Adds integration tests for the MCP feature using a self-contained local HTTP server — no external API keys or services needed.

### New files
- **\	ests/helpers/mcp-test-server.ts\** — reusable test fixture: starts a Streamable HTTP MCP server on a random port with \cho\ and \dd\ tools
- **\	ests/integration/mcp-tools.integration.test.ts\** — 5 tests: tool discovery, tool execution (echo, add), concurrent clients
- **\	ests/integration/mcp-manager-dialog.test.tsx\** — 9 component tests: import mcp.json, toggle servers, remove servers, error handling

### Dependencies
- \@modelcontextprotocol/sdk\ added as devDependency (server-side SDK for the test fixture)

### Test results
421 tests pass (34 test files)

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>