### PR TITLE
fix: UI cleanup, rename to Coding Agent, fix imported skill injection

### DIFF
--- a/manifests/manifest.dev.xml
+++ b/manifests/manifest.dev.xml
@@ -93,12 +93,12 @@
       </bt:Urls>
       <bt:ShortStrings>
         <bt:String id="GetStarted.Title" DefaultValue="Office Coding Agent" />
-        <bt:String id="CommandsGroup.Label" DefaultValue="AI Assistant" />
-        <bt:String id="TaskpaneButton.Label" DefaultValue="AI Chat" />
+        <bt:String id="CommandsGroup.Label" DefaultValue="Coding Agent" />
+        <bt:String id="TaskpaneButton.Label" DefaultValue="Coding Agent" />
       </bt:ShortStrings>
       <bt:LongStrings>
         <bt:String id="GetStarted.Description" DefaultValue="AI-powered Office coding assistant" />
-        <bt:String id="TaskpaneButton.Tooltip" DefaultValue="Open the AI assistant chat panel" />
+        <bt:String id="TaskpaneButton.Tooltip" DefaultValue="Open the Coding Agent" />
       </bt:LongStrings>
     </Resources>
 

--- a/manifests/manifest.prod.xml
+++ b/manifests/manifest.prod.xml
@@ -93,12 +93,12 @@
       </bt:Urls>
       <bt:ShortStrings>
         <bt:String id="GetStarted.Title" DefaultValue="Office Coding Agent" />
-        <bt:String id="CommandsGroup.Label" DefaultValue="AI Assistant" />
-        <bt:String id="TaskpaneButton.Label" DefaultValue="AI Chat" />
+        <bt:String id="CommandsGroup.Label" DefaultValue="Coding Agent" />
+        <bt:String id="TaskpaneButton.Label" DefaultValue="Coding Agent" />
       </bt:ShortStrings>
       <bt:LongStrings>
         <bt:String id="GetStarted.Description" DefaultValue="AI-powered Office coding assistant" />
-        <bt:String id="TaskpaneButton.Tooltip" DefaultValue="Open the AI assistant chat panel" />
+        <bt:String id="TaskpaneButton.Tooltip" DefaultValue="Open the Coding Agent" />
       </bt:LongStrings>
     </Resources>
 

--- a/manifests/manifest.staging.xml
+++ b/manifests/manifest.staging.xml
@@ -93,12 +93,12 @@
       </bt:Urls>
       <bt:ShortStrings>
         <bt:String id="GetStarted.Title" DefaultValue="Office Coding Agent (Staging)" />
-        <bt:String id="CommandsGroup.Label" DefaultValue="AI Assistant STG" />
-        <bt:String id="TaskpaneButton.Label" DefaultValue="AI Chat STG" />
+        <bt:String id="CommandsGroup.Label" DefaultValue="Coding Agent STG" />
+        <bt:String id="TaskpaneButton.Label" DefaultValue="Coding Agent STG" />
       </bt:ShortStrings>
       <bt:LongStrings>
         <bt:String id="GetStarted.Description" DefaultValue="AI-powered Office coding assistant" />
-        <bt:String id="TaskpaneButton.Tooltip" DefaultValue="Open the AI assistant chat panel" />
+        <bt:String id="TaskpaneButton.Tooltip" DefaultValue="Open the Coding Agent" />
       </bt:LongStrings>
     </Resources>
 

--- a/src/components/ChatHeader.tsx
+++ b/src/components/ChatHeader.tsx
@@ -20,7 +20,6 @@ export const ChatHeader: React.FC<ChatHeaderProps> = ({
   return (
     <div className="flex items-center justify-between border-b border-border bg-background px-3 py-1.5">
       <div className="flex items-center gap-2 min-w-0">
-        <span className="font-semibold text-sm whitespace-nowrap text-foreground">AI Chat</span>
         <SkillPicker />
       </div>
 

--- a/src/components/assistant-ui/thread.tsx
+++ b/src/components/assistant-ui/thread.tsx
@@ -23,7 +23,7 @@ import type { FC } from 'react';
 
 export const Thread: FC = () => {
   return (
-    <ThreadPrimitive.Root className="aui-root aui-thread-root flex h-full flex-col bg-background">
+    <ThreadPrimitive.Root className="aui-root aui-thread-root flex flex-1 flex-col bg-background">
       <ThreadPrimitive.Viewport
         turnAnchor="top"
         className="aui-thread-viewport relative flex flex-1 flex-col overflow-x-hidden overflow-y-auto scroll-smooth px-3 pt-3"

--- a/src/hooks/useOfficeChat.ts
+++ b/src/hooks/useOfficeChat.ts
@@ -22,6 +22,7 @@ export function useOfficeChat(
   tools?: ToolSet
 ) {
   const activeSkillNames = useSettingsStore(s => s.activeSkillNames);
+  const importedSkills = useSettingsStore(s => s.importedSkills);
   const activeAgentId = useSettingsStore(s => s.activeAgentId);
   const importedMcpServers = useSettingsStore(s => s.importedMcpServers);
   const activeMcpServerNames = useSettingsStore(s => s.activeMcpServerNames);
@@ -47,7 +48,7 @@ export function useOfficeChat(
       stopWhen: stepCountIs(10),
       maxRetries: 4,
     });
-  }, [provider, modelId, host, tools, activeSkillNames, activeAgentId, mcpTools]);
+  }, [provider, modelId, host, tools, activeSkillNames, importedSkills, activeAgentId, mcpTools]);
 
   const transport = useMemo(() => {
     if (!agent) return null;

--- a/tests/integration/app-error-boundary.test.tsx
+++ b/tests/integration/app-error-boundary.test.tsx
@@ -31,12 +31,7 @@ vi.mock('@/components/ChatHeader', () => ({
     React.createElement(
       'div',
       { 'data-testid': 'chat-header' },
-      React.createElement(
-        'button',
-        { 'data-testid': 'clear-btn', onClick: onClearMessages },
-        'New conversation'
-      ),
-      React.createElement('span', null, 'AI Chat')
+      React.createElement('button', { 'data-testid': 'clear-btn', onClick: onClearMessages }, 'New conversation')
     ),
 }));
 
@@ -128,7 +123,6 @@ describe('App — error boundary integration', () => {
     await waitFor(() => {
       // Header should still be visible
       expect(screen.getByTestId('chat-header')).toBeInTheDocument();
-      expect(screen.getByText('AI Chat')).toBeInTheDocument();
       expect(screen.getByText('New conversation')).toBeInTheDocument();
 
       // Chat panel should NOT be visible

--- a/tests/integration/chat-header-settings-flow.test.tsx
+++ b/tests/integration/chat-header-settings-flow.test.tsx
@@ -1,7 +1,7 @@
 /**
  * Integration test: ChatHeader — SkillPicker, New Conversation, SettingsDialog.
  *
- * ChatHeader now contains: "AI Chat" title, SkillPicker, New Conversation
+ * ChatHeader contains: SkillPicker, New Conversation
  * button, and SettingsDialog. The ModelPicker and AgentPicker have moved
  * to ChatPanel's input toolbar.
  */
@@ -42,7 +42,6 @@ describe('Integration: ChatHeader', () => {
   it('renders title, skill picker, and toolbar buttons', () => {
     renderWithProviders(<StatefulChatHeader onClearMessages={mockClearMessages} />);
 
-    expect(screen.getByText('AI Chat')).toBeInTheDocument();
     expect(screen.getByLabelText('Agent skills')).toBeInTheDocument();
     expect(screen.getByLabelText('New conversation')).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'Settings' })).toBeInTheDocument();

--- a/tests/integration/useOfficeChat-skill-injection.test.ts
+++ b/tests/integration/useOfficeChat-skill-injection.test.ts
@@ -1,0 +1,121 @@
+/**
+ * Integration test: useOfficeChat — imported skill injection.
+ *
+ * Regression test for the `importedSkills` memo-dep bug:
+ * When a skill is imported while `activeSkillNames` is null (all ON),
+ * the agent must rebuild with the new skill's content in its instructions.
+ *
+ * Root cause: `useMemo` for `agent` in useOfficeChat did not include
+ * `importedSkills` in its dep array, so importing a skill (which doesn't
+ * change `activeSkillNames`) never triggered a rebuild.
+ *
+ * Fix: Added `importedSkills` to the dep array.
+ */
+
+import { renderHook, act } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { AzureOpenAIProvider } from '@ai-sdk/azure';
+import type { AgentSkill } from '@/types';
+import { useOfficeChat } from '@/hooks/useOfficeChat';
+import { useSettingsStore } from '@/stores/settingsStore';
+import { setImportedSkills } from '@/services/skills/skillService';
+
+// ─── Mocks ─────────────────────────────────────────────────────────────────────
+
+// Capture instructions each time ToolLoopAgent is constructed.
+const constructedInstructions: string[] = [];
+
+vi.mock('ai', async importOriginal => {
+  const real = (await importOriginal()) as Record<string, unknown>;
+  return {
+    ...real,
+    ToolLoopAgent: class MockToolLoopAgent {
+      constructor(opts: { instructions: string }) {
+        constructedInstructions.push(opts.instructions);
+      }
+    },
+    DirectChatTransport: class MockDirectChatTransport {
+      constructor() {}
+    },
+  };
+});
+
+vi.mock('@ai-sdk/react', () => ({
+  useChat: vi.fn(() => ({})),
+}));
+
+vi.mock('@/hooks/useMcpTools', () => ({
+  useMcpTools: vi.fn(() => ({})),
+}));
+
+// ─── Fixtures ──────────────────────────────────────────────────────────────────
+
+const fakeProvider = { chat: vi.fn(() => ({})) } as unknown as AzureOpenAIProvider;
+
+const importedSkill: AgentSkill = {
+  metadata: {
+    name: 'My Custom Skill',
+    description: 'A custom skill for testing.',
+    version: '1.0.0',
+    tags: [],
+  },
+  content: 'Custom skill content injected here.',
+};
+
+// ─── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('useOfficeChat — imported skill injection', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    constructedInstructions.length = 0;
+    useSettingsStore.getState().reset();
+    setImportedSkills([]);
+  });
+
+  it('does not include imported skill content before the skill is imported', () => {
+    renderHook(() => useOfficeChat(fakeProvider, 'gpt-4', 'excel'));
+
+    expect(constructedInstructions.at(-1)).not.toContain('My Custom Skill');
+    expect(constructedInstructions.at(-1)).not.toContain('Custom skill content injected here.');
+  });
+
+  it('rebuilds agent instructions when a new skill is imported (null activeSkillNames = all ON)', () => {
+    const { rerender } = renderHook(() => useOfficeChat(fakeProvider, 'gpt-4', 'excel'));
+
+    // Confirm activeSkillNames is null (all ON) — importing should be immediately active
+    expect(useSettingsStore.getState().activeSkillNames).toBeNull();
+
+    const callsBefore = constructedInstructions.length;
+    expect(constructedInstructions.at(-1)).not.toContain('My Custom Skill');
+
+    // Import the skill via the store action (simulates user importing a .md file)
+    act(() => {
+      useSettingsStore.getState().importSkills([importedSkill]);
+    });
+    rerender();
+
+    // Agent must have been rebuilt (new constructor call)
+    expect(constructedInstructions.length).toBeGreaterThan(callsBefore);
+    // New instructions must include the imported skill's content
+    expect(constructedInstructions.at(-1)).toContain('My Custom Skill');
+    expect(constructedInstructions.at(-1)).toContain('Custom skill content injected here.');
+  });
+
+  it('removing the skill causes agent to rebuild without its content', () => {
+    const { rerender } = renderHook(() => useOfficeChat(fakeProvider, 'gpt-4', 'excel'));
+
+    act(() => {
+      useSettingsStore.getState().importSkills([importedSkill]);
+    });
+    rerender();
+    expect(constructedInstructions.at(-1)).toContain('My Custom Skill');
+
+    act(() => {
+      useSettingsStore.getState().removeImportedSkill('My Custom Skill');
+    });
+    rerender();
+
+    expect(constructedInstructions.at(-1)).not.toContain('My Custom Skill');
+    expect(constructedInstructions.at(-1)).not.toContain('Custom skill content injected here.');
+  });
+});


### PR DESCRIPTION
## Changes

### Bug fixes
- Fix hidden toolbar (thread.tsx): h-full to flex-1 on ThreadPrimitive.Root
- Fix imported skill not used (useOfficeChat.ts): add importedSkills to useMemo deps

### UI cleanup
- Remove AI Chat label from ChatHeader
- Rename ribbon labels to Coding Agent in all 3 manifests

### Tests
- Add 3 regression tests in useOfficeChat-skill-injection.test.ts

424/424 tests passing.