### PR TITLE
fix: add min-h-0 to Thread root and viewport to restore scroll and toolbar

### DIFF
--- a/src/components/assistant-ui/thread.tsx
+++ b/src/components/assistant-ui/thread.tsx
@@ -23,10 +23,10 @@ import type { FC } from 'react';
 
 export const Thread: FC = () => {
   return (
-    <ThreadPrimitive.Root className="aui-root aui-thread-root flex flex-1 flex-col bg-background">
+    <ThreadPrimitive.Root className="aui-root aui-thread-root flex flex-1 min-h-0 flex-col bg-background">
       <ThreadPrimitive.Viewport
         turnAnchor="top"
-        className="aui-thread-viewport relative flex flex-1 flex-col overflow-x-hidden overflow-y-auto scroll-smooth px-3 pt-3"
+        className="aui-thread-viewport relative flex flex-1 min-h-0 flex-col overflow-x-hidden overflow-y-auto scroll-smooth px-3 pt-3"
       >
         <AuiIf condition={s => s.thread.isEmpty}>
           <ThreadWelcome />


### PR DESCRIPTION
Fixes two regressions introduced by the h-full -> flex-1 change.

Without min-h-0, flex-1 items use min-height: auto which lets them grow to full content size:
- Toolbar (AgentPicker/ModelPicker) disappears after first message
- Scrolling stops working

Adding min-h-0 to both ThreadPrimitive.Root and Viewport lets the flex constraint propagate so overflow-y-auto can trigger.