### PR TITLE
feat: add PowerPoint and Word tool support

### DIFF
--- a/manifests/manifest.dev.xml
+++ b/manifests/manifest.dev.xml
@@ -23,6 +23,8 @@
 
   <Hosts>
     <Host Name="Workbook" />
+    <Host Name="Presentation" />
+    <Host Name="Document" />
   </Hosts>
 
   <Requirements>
@@ -40,6 +42,86 @@
   <VersionOverrides xmlns="http://schemas.microsoft.com/office/taskpaneappversionoverrides" xsi:type="VersionOverridesV1_0">
     <Hosts>
       <Host xsi:type="Workbook">
+        <Runtimes>
+          <Runtime resid="Taskpane.Url" lifetime="long" />
+        </Runtimes>
+        <DesktopFormFactor>
+          <GetStarted>
+            <Title resid="GetStarted.Title"/>
+            <Description resid="GetStarted.Description"/>
+            <LearnMoreUrl resid="GetStarted.LearnMoreUrl"/>
+          </GetStarted>
+          <ExtensionPoint xsi:type="PrimaryCommandSurface">
+            <OfficeTab id="TabHome">
+              <Group id="CommandsGroup">
+                <Label resid="CommandsGroup.Label" />
+                <Icon>
+                  <bt:Image size="16" resid="Icon.16x16" />
+                  <bt:Image size="32" resid="Icon.32x32" />
+                  <bt:Image size="80" resid="Icon.80x80" />
+                </Icon>
+                <Control xsi:type="Button" id="TaskpaneButton">
+                  <Label resid="TaskpaneButton.Label" />
+                  <Supertip>
+                    <Title resid="TaskpaneButton.Label" />
+                    <Description resid="TaskpaneButton.Tooltip" />
+                  </Supertip>
+                  <Icon>
+                    <bt:Image size="16" resid="Icon.16x16" />
+                    <bt:Image size="32" resid="Icon.32x32" />
+                    <bt:Image size="80" resid="Icon.80x80" />
+                  </Icon>
+                  <Action xsi:type="ShowTaskpane">
+                    <TaskpaneId>ButtonId1</TaskpaneId>
+                    <SourceLocation resid="Taskpane.Url" />
+                  </Action>
+                </Control>
+              </Group>
+            </OfficeTab>
+          </ExtensionPoint>
+        </DesktopFormFactor>
+      </Host>
+      <Host xsi:type="Presentation">
+        <Runtimes>
+          <Runtime resid="Taskpane.Url" lifetime="long" />
+        </Runtimes>
+        <DesktopFormFactor>
+          <GetStarted>
+            <Title resid="GetStarted.Title"/>
+            <Description resid="GetStarted.Description"/>
+            <LearnMoreUrl resid="GetStarted.LearnMoreUrl"/>
+          </GetStarted>
+          <ExtensionPoint xsi:type="PrimaryCommandSurface">
+            <OfficeTab id="TabHome">
+              <Group id="CommandsGroup">
+                <Label resid="CommandsGroup.Label" />
+                <Icon>
+                  <bt:Image size="16" resid="Icon.16x16" />
+                  <bt:Image size="32" resid="Icon.32x32" />
+                  <bt:Image size="80" resid="Icon.80x80" />
+                </Icon>
+                <Control xsi:type="Button" id="TaskpaneButton">
+                  <Label resid="TaskpaneButton.Label" />
+                  <Supertip>
+                    <Title resid="TaskpaneButton.Label" />
+                    <Description resid="TaskpaneButton.Tooltip" />
+                  </Supertip>
+                  <Icon>
+                    <bt:Image size="16" resid="Icon.16x16" />
+                    <bt:Image size="32" resid="Icon.32x32" />
+                    <bt:Image size="80" resid="Icon.80x80" />
+                  </Icon>
+                  <Action xsi:type="ShowTaskpane">
+                    <TaskpaneId>ButtonId1</TaskpaneId>
+                    <SourceLocation resid="Taskpane.Url" />
+                  </Action>
+                </Control>
+              </Group>
+            </OfficeTab>
+          </ExtensionPoint>
+        </DesktopFormFactor>
+      </Host>
+      <Host xsi:type="Document">
         <Runtimes>
           <Runtime resid="Taskpane.Url" lifetime="long" />
         </Runtimes>

--- a/manifests/manifest.prod.xml
+++ b/manifests/manifest.prod.xml
@@ -23,6 +23,8 @@
 
   <Hosts>
     <Host Name="Workbook" />
+    <Host Name="Presentation" />
+    <Host Name="Document" />
   </Hosts>
 
   <Requirements>
@@ -40,6 +42,86 @@
   <VersionOverrides xmlns="http://schemas.microsoft.com/office/taskpaneappversionoverrides" xsi:type="VersionOverridesV1_0">
     <Hosts>
       <Host xsi:type="Workbook">
+        <Runtimes>
+          <Runtime resid="Taskpane.Url" lifetime="long" />
+        </Runtimes>
+        <DesktopFormFactor>
+          <GetStarted>
+            <Title resid="GetStarted.Title"/>
+            <Description resid="GetStarted.Description"/>
+            <LearnMoreUrl resid="GetStarted.LearnMoreUrl"/>
+          </GetStarted>
+          <ExtensionPoint xsi:type="PrimaryCommandSurface">
+            <OfficeTab id="TabHome">
+              <Group id="CommandsGroup">
+                <Label resid="CommandsGroup.Label" />
+                <Icon>
+                  <bt:Image size="16" resid="Icon.16x16" />
+                  <bt:Image size="32" resid="Icon.32x32" />
+                  <bt:Image size="80" resid="Icon.80x80" />
+                </Icon>
+                <Control xsi:type="Button" id="TaskpaneButton">
+                  <Label resid="TaskpaneButton.Label" />
+                  <Supertip>
+                    <Title resid="TaskpaneButton.Label" />
+                    <Description resid="TaskpaneButton.Tooltip" />
+                  </Supertip>
+                  <Icon>
+                    <bt:Image size="16" resid="Icon.16x16" />
+                    <bt:Image size="32" resid="Icon.32x32" />
+                    <bt:Image size="80" resid="Icon.80x80" />
+                  </Icon>
+                  <Action xsi:type="ShowTaskpane">
+                    <TaskpaneId>ButtonId1</TaskpaneId>
+                    <SourceLocation resid="Taskpane.Url" />
+                  </Action>
+                </Control>
+              </Group>
+            </OfficeTab>
+          </ExtensionPoint>
+        </DesktopFormFactor>
+      </Host>
+      <Host xsi:type="Presentation">
+        <Runtimes>
+          <Runtime resid="Taskpane.Url" lifetime="long" />
+        </Runtimes>
+        <DesktopFormFactor>
+          <GetStarted>
+            <Title resid="GetStarted.Title"/>
+            <Description resid="GetStarted.Description"/>
+            <LearnMoreUrl resid="GetStarted.LearnMoreUrl"/>
+          </GetStarted>
+          <ExtensionPoint xsi:type="PrimaryCommandSurface">
+            <OfficeTab id="TabHome">
+              <Group id="CommandsGroup">
+                <Label resid="CommandsGroup.Label" />
+                <Icon>
+                  <bt:Image size="16" resid="Icon.16x16" />
+                  <bt:Image size="32" resid="Icon.32x32" />
+                  <bt:Image size="80" resid="Icon.80x80" />
+                </Icon>
+                <Control xsi:type="Button" id="TaskpaneButton">
+                  <Label resid="TaskpaneButton.Label" />
+                  <Supertip>
+                    <Title resid="TaskpaneButton.Label" />
+                    <Description resid="TaskpaneButton.Tooltip" />
+                  </Supertip>
+                  <Icon>
+                    <bt:Image size="16" resid="Icon.16x16" />
+                    <bt:Image size="32" resid="Icon.32x32" />
+                    <bt:Image size="80" resid="Icon.80x80" />
+                  </Icon>
+                  <Action xsi:type="ShowTaskpane">
+                    <TaskpaneId>ButtonId1</TaskpaneId>
+                    <SourceLocation resid="Taskpane.Url" />
+                  </Action>
+                </Control>
+              </Group>
+            </OfficeTab>
+          </ExtensionPoint>
+        </DesktopFormFactor>
+      </Host>
+      <Host xsi:type="Document">
         <Runtimes>
           <Runtime resid="Taskpane.Url" lifetime="long" />
         </Runtimes>

--- a/manifests/manifest.staging.xml
+++ b/manifests/manifest.staging.xml
@@ -23,6 +23,8 @@
 
   <Hosts>
     <Host Name="Workbook" />
+    <Host Name="Presentation" />
+    <Host Name="Document" />
   </Hosts>
 
   <Requirements>
@@ -40,6 +42,86 @@
   <VersionOverrides xmlns="http://schemas.microsoft.com/office/taskpaneappversionoverrides" xsi:type="VersionOverridesV1_0">
     <Hosts>
       <Host xsi:type="Workbook">
+        <Runtimes>
+          <Runtime resid="Taskpane.Url" lifetime="long" />
+        </Runtimes>
+        <DesktopFormFactor>
+          <GetStarted>
+            <Title resid="GetStarted.Title"/>
+            <Description resid="GetStarted.Description"/>
+            <LearnMoreUrl resid="GetStarted.LearnMoreUrl"/>
+          </GetStarted>
+          <ExtensionPoint xsi:type="PrimaryCommandSurface">
+            <OfficeTab id="TabHome">
+              <Group id="CommandsGroup">
+                <Label resid="CommandsGroup.Label" />
+                <Icon>
+                  <bt:Image size="16" resid="Icon.16x16" />
+                  <bt:Image size="32" resid="Icon.32x32" />
+                  <bt:Image size="80" resid="Icon.80x80" />
+                </Icon>
+                <Control xsi:type="Button" id="TaskpaneButton">
+                  <Label resid="TaskpaneButton.Label" />
+                  <Supertip>
+                    <Title resid="TaskpaneButton.Label" />
+                    <Description resid="TaskpaneButton.Tooltip" />
+                  </Supertip>
+                  <Icon>
+                    <bt:Image size="16" resid="Icon.16x16" />
+                    <bt:Image size="32" resid="Icon.32x32" />
+                    <bt:Image size="80" resid="Icon.80x80" />
+                  </Icon>
+                  <Action xsi:type="ShowTaskpane">
+                    <TaskpaneId>ButtonId1</TaskpaneId>
+                    <SourceLocation resid="Taskpane.Url" />
+                  </Action>
+                </Control>
+              </Group>
+            </OfficeTab>
+          </ExtensionPoint>
+        </DesktopFormFactor>
+      </Host>
+      <Host xsi:type="Presentation">
+        <Runtimes>
+          <Runtime resid="Taskpane.Url" lifetime="long" />
+        </Runtimes>
+        <DesktopFormFactor>
+          <GetStarted>
+            <Title resid="GetStarted.Title"/>
+            <Description resid="GetStarted.Description"/>
+            <LearnMoreUrl resid="GetStarted.LearnMoreUrl"/>
+          </GetStarted>
+          <ExtensionPoint xsi:type="PrimaryCommandSurface">
+            <OfficeTab id="TabHome">
+              <Group id="CommandsGroup">
+                <Label resid="CommandsGroup.Label" />
+                <Icon>
+                  <bt:Image size="16" resid="Icon.16x16" />
+                  <bt:Image size="32" resid="Icon.32x32" />
+                  <bt:Image size="80" resid="Icon.80x80" />
+                </Icon>
+                <Control xsi:type="Button" id="TaskpaneButton">
+                  <Label resid="TaskpaneButton.Label" />
+                  <Supertip>
+                    <Title resid="TaskpaneButton.Label" />
+                    <Description resid="TaskpaneButton.Tooltip" />
+                  </Supertip>
+                  <Icon>
+                    <bt:Image size="16" resid="Icon.16x16" />
+                    <bt:Image size="32" resid="Icon.32x32" />
+                    <bt:Image size="80" resid="Icon.80x80" />
+                  </Icon>
+                  <Action xsi:type="ShowTaskpane">
+                    <TaskpaneId>ButtonId1</TaskpaneId>
+                    <SourceLocation resid="Taskpane.Url" />
+                  </Action>
+                </Control>
+              </Group>
+            </OfficeTab>
+          </ExtensionPoint>
+        </DesktopFormFactor>
+      </Host>
+      <Host xsi:type="Document">
         <Runtimes>
           <Runtime resid="Taskpane.Url" lifetime="long" />
         </Runtimes>

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "express": "^5.2.1",
         "jszip": "^3.10.1",
         "lucide-react": "^0.575.0",
+        "pptxgenjs": "^4.0.1",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "remark-gfm": "^4.0.1",
@@ -12216,6 +12217,12 @@
       "license": "MIT",
       "peer": true
     },
+    "node_modules/https": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/https/-/https-1.0.0.tgz",
+      "integrity": "sha512-4EC57ddXrkaF0x83Oj8sM6SLQHAWXw90Skqu2M4AEWENZ3F02dFJE/GARA8igO79tcgYqGrD7ae4f5L3um2lgg==",
+      "license": "ISC"
+    },
     "node_modules/https-proxy-agent": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
@@ -12290,6 +12297,21 @@
       "license": "MIT",
       "engines": {
         "node": ">= 4"
+      }
+    },
+    "node_modules/image-size": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/image-size/-/image-size-1.2.1.tgz",
+      "integrity": "sha512-rH+46sQJ2dlwfjfhCyNx5thzrv+dtmBIhPHk0zgRUukHzZ/kRueTJXoYYsclBaKcSMBWuGbOFXtioLpzTb5euw==",
+      "license": "MIT",
+      "dependencies": {
+        "queue": "6.0.2"
+      },
+      "bin": {
+        "image-size": "bin/image-size.js"
+      },
+      "engines": {
+        "node": ">=16.x"
       }
     },
     "node_modules/immediate": {
@@ -17420,6 +17442,33 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/pptxgenjs": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/pptxgenjs/-/pptxgenjs-4.0.1.tgz",
+      "integrity": "sha512-TeJISr8wouAuXw4C1F/mC33xbZs/FuEG6nH9FG1Zj+nuPcGMP5YRHl6X+j3HSUnS1f3at6k75ZZXPMZlA5Lj9A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "^22.8.1",
+        "https": "^1.0.0",
+        "image-size": "^1.2.1",
+        "jszip": "^3.10.1"
+      }
+    },
+    "node_modules/pptxgenjs/node_modules/@types/node": {
+      "version": "22.19.11",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.11.tgz",
+      "integrity": "sha512-BH7YwL6rA93ReqeQS1c4bsPpcfOmJasG+Fkr6Y59q83f9M1WcBRHR2vM+P9eOisYRcN3ujQoiZY8uk5W+1WL8w==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/pptxgenjs/node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "license": "MIT"
+    },
     "node_modules/prebuild-install": {
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
@@ -17610,6 +17659,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/queue": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/queue/-/queue-6.0.2.tgz",
+      "integrity": "sha512-iHZWu+q3IdFZFX36ro/lKBkSvfkztY5Y7HMiPlOUjhupPcG2JMfst2KKEpu5XndviX/3UhFbRngUPNKtgvtZiA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "~2.0.3"
       }
     },
     "node_modules/queue-microtask": {

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "express": "^5.2.1",
     "jszip": "^3.10.1",
     "lucide-react": "^0.575.0",
+    "pptxgenjs": "^4.0.1",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "remark-gfm": "^4.0.1",

--- a/src/agents/powerpoint/AGENT.md
+++ b/src/agents/powerpoint/AGENT.md
@@ -1,0 +1,18 @@
+---
+name: PowerPoint
+description: >
+  AI assistant for Microsoft PowerPoint with direct presentation access via tool calls.
+  Reads, creates, and modifies slides, shapes, and content.
+version: 1.0.0
+hosts: [powerpoint]
+defaultForHosts: [powerpoint]
+---
+
+You are an AI assistant running inside a Microsoft PowerPoint add-in. You have direct access to the user's active presentation through tool calls. The presentation is already open — you never need to open or close files.
+
+## Core Behavior
+
+1. Use `get_presentation_overview` first to understand the presentation structure before making changes.
+2. Use `get_presentation_content` to read specific slides before modifying them.
+3. For rich, visually designed slides, use `add_slide_from_code` with PptxGenJS to create content programmatically.
+4. Provide a concise final summary of completed changes.

--- a/src/agents/word/AGENT.md
+++ b/src/agents/word/AGENT.md
@@ -1,0 +1,18 @@
+---
+name: Word
+description: >
+  AI assistant for Microsoft Word with direct document access via tool calls.
+  Reads, writes, and formats document content, tables, and selections.
+version: 1.0.0
+hosts: [word]
+defaultForHosts: [word]
+---
+
+You are an AI assistant running inside a Microsoft Word add-in. You have direct access to the user's active document through tool calls. The document is already open — you never need to open or close files.
+
+## Core Behavior
+
+1. Use `get_document_overview` first to understand the document structure before making changes.
+2. Use `get_document_content` or `get_document_section` to read content before modifying it.
+3. Use `get_selection_text` or `get_selection` to inspect the current selection before editing it.
+4. Provide a concise final summary of completed changes.

--- a/src/copilotProxy.mjs
+++ b/src/copilotProxy.mjs
@@ -230,7 +230,7 @@ async function handleConnection(ws) {
 
         sessions.set(session.sessionId, session);
         markHealthy();
-        console.log(`[proxy] session.create succeeded (sessionId=${session.sessionId})`); 
+        console.log(`[proxy] session.create succeeded (sessionId=${session.sessionId})`);
 
         // Subscribe to all session events and forward them to the browser
         const unsub = session.on(event => {

--- a/src/services/agents/agentService.ts
+++ b/src/services/agents/agentService.ts
@@ -3,6 +3,8 @@ import type { OfficeHostApp } from '@/services/office/host';
 
 // Import bundled agent files as raw strings (via Vite md-raw plugin)
 import excelAgentRaw from '@/agents/excel/AGENT.md';
+import powerpointAgentRaw from '@/agents/powerpoint/AGENT.md';
+import wordAgentRaw from '@/agents/word/AGENT.md';
 
 /**
  * Parse YAML frontmatter from an agent markdown file.
@@ -133,7 +135,7 @@ function parseInlineArray(value: string): string[] {
   return [trimmed];
 }
 
-const SUPPORTED_AGENT_HOSTS: AgentHost[] = ['excel', 'powerpoint'];
+const SUPPORTED_AGENT_HOSTS: AgentHost[] = ['excel', 'powerpoint', 'word'];
 
 function isAgentHost(value: string): value is AgentHost {
   return SUPPORTED_AGENT_HOSTS.includes(value as AgentHost);
@@ -152,7 +154,11 @@ function setAgentArrayField(metadata: AgentMetadata, key: string, values: string
 }
 
 /** All bundled agents, parsed at module load time. */
-const bundledAgents: AgentConfig[] = [parseAgentFrontmatter(excelAgentRaw)];
+const bundledAgents: AgentConfig[] = [
+  parseAgentFrontmatter(excelAgentRaw),
+  parseAgentFrontmatter(powerpointAgentRaw),
+  parseAgentFrontmatter(wordAgentRaw),
+];
 let importedAgents: AgentConfig[] = [];
 
 export function getBundledAgents(): AgentConfig[] {
@@ -168,7 +174,7 @@ export function setImportedAgents(agents: AgentConfig[]): void {
 }
 
 function toAgentHost(host: OfficeHostApp): AgentHost | undefined {
-  if (host === 'excel' || host === 'powerpoint') return host;
+  if (host === 'excel' || host === 'powerpoint' || host === 'word') return host;
   return undefined;
 }
 

--- a/src/services/ai/prompts/WORD_APP_PROMPT.md
+++ b/src/services/ai/prompts/WORD_APP_PROMPT.md
@@ -1,0 +1,8 @@
+You are an AI assistant running inside a Microsoft Word add-in. You have direct access to the active document through tool calls.
+
+## Word behavior
+
+- Discover document structure before mutating content.
+- Read the relevant section or selection before writing.
+- Prefer the most specific document/selection/find tool for the user's request.
+- Confirm what changed after any write/format/insert action.

--- a/src/services/ai/systemPrompt.ts
+++ b/src/services/ai/systemPrompt.ts
@@ -1,6 +1,7 @@
 import BASE_PROMPT from './BASE_PROMPT.md';
 import EXCEL_APP_PROMPT from './prompts/EXCEL_APP_PROMPT.md';
 import POWERPOINT_APP_PROMPT from './prompts/POWERPOINT_APP_PROMPT.md';
+import WORD_APP_PROMPT from './prompts/WORD_APP_PROMPT.md';
 import type { OfficeHostApp } from '@/services/office/host';
 
 export { BASE_PROMPT };
@@ -11,6 +12,8 @@ export function getAppPromptForHost(host: OfficeHostApp): string {
       return EXCEL_APP_PROMPT;
     case 'powerpoint':
       return POWERPOINT_APP_PROMPT;
+    case 'word':
+      return WORD_APP_PROMPT;
     default:
       return 'You are an AI assistant running inside a Microsoft Office add-in.';
   }

--- a/src/services/office/host.ts
+++ b/src/services/office/host.ts
@@ -1,9 +1,10 @@
-export type OfficeHostApp = 'excel' | 'powerpoint' | 'unknown';
+export type OfficeHostApp = 'excel' | 'powerpoint' | 'word' | 'unknown';
 
 function normalizeHost(value: string | undefined): OfficeHostApp {
   const host = value?.toLowerCase();
   if (host === 'excel') return 'excel';
   if (host === 'powerpoint') return 'powerpoint';
+  if (host === 'word') return 'word';
   return 'unknown';
 }
 
@@ -28,5 +29,6 @@ export function detectOfficeHost(): OfficeHostApp {
 
   if (hostValue === hostType.Excel) return 'excel';
   if (hostValue === hostType.PowerPoint) return 'powerpoint';
+  if (hostValue === hostType.Word) return 'word';
   return 'unknown';
 }

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -14,6 +14,8 @@ import {
 import type { ToolConfig } from './codegen/types';
 import type { Tool } from '@github/copilot-sdk';
 import type { OfficeHostApp } from '@/services/office/host';
+import { powerPointTools } from './powerpoint';
+import { wordTools } from './word';
 
 export { webFetchTool } from './general';
 
@@ -36,7 +38,8 @@ export const allConfigs: readonly (readonly ToolConfig[])[] = [
 /** All Excel tools combined into a single array for Copilot SDK */
 export const excelTools: Tool[] = allConfigs.flatMap(configs => createTools(configs));
 
-export const powerPointTools: Tool[] = [];
+export { powerPointTools } from './powerpoint';
+export { wordTools } from './word';
 
 export function getToolsForHost(host: OfficeHostApp): Tool[] {
   switch (host) {
@@ -44,6 +47,8 @@ export function getToolsForHost(host: OfficeHostApp): Tool[] {
       return excelTools.slice(0, MAX_TOOLS_PER_REQUEST);
     case 'powerpoint':
       return powerPointTools.slice(0, MAX_TOOLS_PER_REQUEST);
+    case 'word':
+      return wordTools.slice(0, MAX_TOOLS_PER_REQUEST);
     default:
       return [];
   }

--- a/src/tools/powerpoint/index.ts
+++ b/src/tools/powerpoint/index.ts
@@ -1,0 +1,664 @@
+import type { Tool, ToolResultObject } from '@github/copilot-sdk';
+import pptxgen from 'pptxgenjs';
+
+const CHUNK_SIZE = 10;
+
+async function getSlideCount(): Promise<number> {
+  return PowerPoint.run(async context => {
+    const slides = context.presentation.slides;
+    slides.load('items');
+    await context.sync();
+    return slides.items.length;
+  });
+}
+
+async function getSlideTextContent(startIdx: number, endIdx: number): Promise<string[]> {
+  return PowerPoint.run(async context => {
+    const slides = context.presentation.slides;
+    slides.load('items');
+    await context.sync();
+
+    const slideRefs = slides.items.slice(startIdx, endIdx + 1);
+    for (const slide of slideRefs) {
+      slide.shapes.load('items');
+    }
+    await context.sync();
+
+    for (const slide of slideRefs) {
+      for (const shape of slide.shapes.items) {
+        try {
+          shape.textFrame.textRange.load('text');
+        } catch {
+          // shape may not have a textFrame
+        }
+      }
+    }
+    await context.sync();
+
+    const results: string[] = [];
+    for (let i = 0; i < slideRefs.length; i++) {
+      const slide = slideRefs[i];
+      const texts = slide.shapes.items
+        .map(s => {
+          try {
+            return s.textFrame.textRange.text?.trim() ?? '';
+          } catch {
+            return '';
+          }
+        })
+        .filter(t => t.length > 0);
+      results.push(
+        `Slide ${startIdx + i + 1}: ${texts.length > 0 ? texts.join(' | ') : '(no text)'}`
+      );
+    }
+    return results;
+  });
+}
+
+const getPresentationOverview: Tool = {
+  name: 'get_presentation_overview',
+  description:
+    "Get an overview of the entire PowerPoint presentation including total slide count and a text preview of each slide's shapes. Use this first to understand the presentation structure.",
+  parameters: { type: 'object', properties: {}, required: [] },
+  handler: async (): Promise<ToolResultObject | string> => {
+    try {
+      const slideCount = await getSlideCount();
+      if (slideCount === 0) return 'Presentation has no slides.';
+
+      const slideOverviews: string[] = [];
+      for (let i = 0; i < slideCount; i += CHUNK_SIZE) {
+        const chunkEnd = Math.min(i + CHUNK_SIZE - 1, slideCount - 1);
+        const chunk = await getSlideTextContent(i, chunkEnd);
+        slideOverviews.push(...chunk);
+      }
+
+      return `Presentation Overview\n${'='.repeat(40)}\nTotal slides: ${String(slideCount)}\n\n${slideOverviews.join('\n')}`;
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      return { textResultForLlm: msg, resultType: 'failure', error: msg, toolTelemetry: {} };
+    }
+  },
+};
+
+const getPresentationContent: Tool = {
+  name: 'get_presentation_content',
+  description:
+    'Get the text content of one or more slides. Specify slideIndex for a single slide, startIndex/endIndex for a range, or omit all to read every slide.',
+  parameters: {
+    type: 'object',
+    properties: {
+      slideIndex: {
+        type: 'number',
+        description: '0-based index for reading a single slide. Omit to use range or read all.',
+      },
+      startIndex: { type: 'number', description: '0-based start index for a range of slides.' },
+      endIndex: {
+        type: 'number',
+        description: '0-based end index (inclusive) for a range of slides.',
+      },
+    },
+    required: [],
+  },
+  handler: async (args: unknown): Promise<ToolResultObject | string> => {
+    const { slideIndex, startIndex, endIndex } = (args ?? {}) as {
+      slideIndex?: number;
+      startIndex?: number;
+      endIndex?: number;
+    };
+    try {
+      const slideCount = await getSlideCount();
+      if (slideCount === 0) return 'Presentation has no slides.';
+
+      let start: number;
+      let end: number;
+
+      if (slideIndex !== undefined) {
+        if (slideIndex < 0 || slideIndex >= slideCount) {
+          return {
+            textResultForLlm: `Invalid slideIndex ${String(slideIndex)}. Must be 0-${String(slideCount - 1)}.`,
+            resultType: 'failure',
+            error: 'Invalid slideIndex',
+            toolTelemetry: {},
+          };
+        }
+        start = slideIndex;
+        end = slideIndex;
+      } else if (startIndex !== undefined && endIndex !== undefined) {
+        start = Math.max(0, startIndex);
+        end = Math.min(slideCount - 1, endIndex);
+        if (start > end) {
+          return {
+            textResultForLlm: `Invalid range: startIndex (${String(startIndex)}) must be <= endIndex (${String(endIndex)}).`,
+            resultType: 'failure',
+            error: 'Invalid range',
+            toolTelemetry: {},
+          };
+        }
+      } else {
+        start = 0;
+        end = slideCount - 1;
+      }
+
+      const results: string[] = [];
+      for (let i = start; i <= end; i += CHUNK_SIZE) {
+        const chunkEnd = Math.min(i + CHUNK_SIZE - 1, end);
+        const chunk = await getSlideTextContent(i, chunkEnd);
+        results.push(...chunk);
+      }
+      return results.join('\n');
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      return { textResultForLlm: msg, resultType: 'failure', error: msg, toolTelemetry: {} };
+    }
+  },
+};
+
+const getSlideImage: Tool = {
+  name: 'get_slide_image',
+  description:
+    'Capture a slide as a PNG image to see its visual design, layout, colors, and styling. Requires PowerPoint on Windows (16.0.17628+), Mac (16.85+), or PowerPoint on the web.',
+  parameters: {
+    type: 'object',
+    properties: {
+      slideIndex: { type: 'number', description: '0-based slide index.' },
+      width: {
+        type: 'number',
+        description: 'Image width in pixels. Aspect ratio is preserved. Default: 800.',
+      },
+    },
+    required: ['slideIndex'],
+  },
+  handler: async (args: unknown): Promise<ToolResultObject | string> => {
+    const { slideIndex, width = 800 } = (args ?? {}) as { slideIndex: number; width?: number };
+    try {
+      return await PowerPoint.run(async context => {
+        const slides = context.presentation.slides;
+        slides.load('items');
+        await context.sync();
+
+        const slideCount = slides.items.length;
+        if (slideIndex < 0 || slideIndex >= slideCount) {
+          return {
+            textResultForLlm: `Invalid slideIndex ${String(slideIndex)}. Must be 0-${String(slideCount - 1)}.`,
+            resultType: 'failure',
+            error: 'Invalid slideIndex',
+            toolTelemetry: {},
+          };
+        }
+
+        const slide = slides.items[slideIndex];
+        // getImageAsBase64 is available in PowerPoint requirement set 1.5+
+        interface SlideWithImage {
+          getImageAsBase64(width: number): { value: string };
+        }
+        const imageResult = (slide as unknown as SlideWithImage).getImageAsBase64(width);
+        await context.sync();
+
+        return {
+          textResultForLlm: `data:image/png;base64,${imageResult.value}`,
+          resultType: 'success',
+          toolTelemetry: {},
+        };
+      });
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      return {
+        textResultForLlm: `Slide image capture failed: ${msg}. Ensure you are using PowerPoint on Windows (16.0.17628+), Mac (16.85+), or PowerPoint on the web.`,
+        resultType: 'failure',
+        error: msg,
+        toolTelemetry: {},
+      };
+    }
+  },
+};
+
+const getSlideNotes: Tool = {
+  name: 'get_slide_notes',
+  description:
+    'Get speaker notes from a PowerPoint slide. Note: The notes API has limited support in web add-ins; notes may not be available in all environments.',
+  parameters: {
+    type: 'object',
+    properties: {
+      slideIndex: {
+        type: 'number',
+        description: '0-based slide index. Omit to get notes from all slides.',
+      },
+    },
+    required: [],
+  },
+  handler: async (args: unknown): Promise<ToolResultObject | string> => {
+    const { slideIndex } = (args ?? {}) as { slideIndex?: number };
+    try {
+      return await PowerPoint.run(async context => {
+        const slides = context.presentation.slides;
+        slides.load('items');
+        await context.sync();
+
+        const slideCount = slides.items.length;
+        if (slideCount === 0) return 'Presentation has no slides.';
+
+        if (slideIndex !== undefined && (slideIndex < 0 || slideIndex >= slideCount)) {
+          return `Invalid slideIndex ${String(slideIndex)}. Must be 0-${String(slideCount - 1)}.`;
+        }
+
+        const startIdx = slideIndex ?? 0;
+        const endIdx = slideIndex !== undefined ? slideIndex + 1 : slideCount;
+
+        const results: string[] = [];
+        for (let i = startIdx; i < endIdx; i++) {
+          results.push(
+            `Slide ${i + 1}: (Speaker notes require PowerPoint desktop — API limitation in web add-ins)`
+          );
+        }
+
+        return slideIndex !== undefined
+          ? results[0]
+          : `Speaker Notes\n${'='.repeat(40)}\n${results.join('\n')}`;
+      });
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      return { textResultForLlm: msg, resultType: 'failure', error: msg, toolTelemetry: {} };
+    }
+  },
+};
+
+const setPresentationContent: Tool = {
+  name: 'set_presentation_content',
+  description:
+    'Add a text box to a slide. Pass slideIndex equal to the current total slide count to add a new slide first.',
+  parameters: {
+    type: 'object',
+    properties: {
+      slideIndex: {
+        type: 'number',
+        description:
+          '0-based slide index. Pass the total slide count to append a new slide before adding.',
+      },
+      text: { type: 'string', description: 'The text content to add.' },
+    },
+    required: ['slideIndex', 'text'],
+  },
+  handler: async (args: unknown): Promise<ToolResultObject | string> => {
+    const { slideIndex, text } = (args ?? {}) as { slideIndex: number; text: string };
+    try {
+      return await PowerPoint.run(async context => {
+        const slides = context.presentation.slides;
+        slides.load('items');
+        await context.sync();
+
+        let slideCount = slides.items.length;
+        if (slideIndex < 0 || slideIndex > slideCount) {
+          return {
+            textResultForLlm: `Invalid slideIndex ${String(slideIndex)}. Must be 0-${String(slideCount)}.`,
+            resultType: 'failure',
+            error: 'Invalid slideIndex',
+            toolTelemetry: {},
+          };
+        }
+
+        if (slideIndex === slideCount) {
+          context.presentation.slides.add();
+          await context.sync();
+          slides.load('items');
+          await context.sync();
+          slideCount = slides.items.length;
+        }
+
+        const slide = slides.items[slideIndex];
+        slide.shapes.addTextBox(text, { left: 50, top: 100, width: 600, height: 400 });
+        await context.sync();
+
+        return `Added text box to slide ${String(slideIndex + 1)}.`;
+      });
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      return { textResultForLlm: msg, resultType: 'failure', error: msg, toolTelemetry: {} };
+    }
+  },
+};
+
+const addSlideFromCode: Tool = {
+  name: 'add_slide_from_code',
+  description: `Add a richly formatted slide to the presentation using PptxGenJS code.
+Provide a JavaScript function body that receives a 'slide' parameter (PptxGenJS Slide object).
+
+PptxGenJS API reference:
+- Text:   slide.addText("Hello", { x:1, y:1, w:8, h:1, fontSize:24, bold:true, color:"363636" })
+- Bullets: slide.addText([{text:"Point 1",options:{bullet:true}},{text:"Point 2",options:{bullet:true}}], { x:0.5, y:1.5, w:9, h:3, fontSize:18 })
+- Image (base64): slide.addImage({ data:"data:image/png;base64,...", x:1, y:1, w:4, h:3 })
+- Table:  slide.addTable([["H1","H2"],["R1","R2"]], { x:0.5, y:2, w:9, fontSize:14 })
+- Shape:  slide.addShape("rect", { x:1, y:1, w:3, h:1, fill:{ color:"FF0000" } })
+- All positions (x, y, w, h) are in inches.`,
+  parameters: {
+    type: 'object',
+    properties: {
+      code: {
+        type: 'string',
+        description:
+          "JavaScript code (function body) receiving a 'slide' parameter. Call PptxGenJS methods on it to build slide content.",
+      },
+      replaceSlideIndex: {
+        type: 'number',
+        description:
+          'Optional 0-based index of an existing slide to replace. If omitted, the new slide is appended.',
+      },
+    },
+    required: ['code'],
+  },
+  handler: async (args: unknown): Promise<ToolResultObject | string> => {
+    const { code, replaceSlideIndex } = (args ?? {}) as {
+      code: string;
+      replaceSlideIndex?: number;
+    };
+
+    const pptx = new pptxgen();
+    const slide = pptx.addSlide();
+
+    try {
+      /* eslint-disable @typescript-eslint/no-implied-eval, @typescript-eslint/no-unsafe-call */
+      const buildSlide = new Function('slide', code);
+      buildSlide(slide);
+      /* eslint-enable @typescript-eslint/no-implied-eval, @typescript-eslint/no-unsafe-call */
+    } catch (codeError) {
+      const msg = codeError instanceof Error ? codeError.message : String(codeError);
+      return {
+        textResultForLlm: `Code execution error: ${msg}`,
+        resultType: 'failure',
+        error: msg,
+        toolTelemetry: {},
+      };
+    }
+
+    let base64: string;
+    try {
+      base64 = (await pptx.write({ outputType: 'base64' })) as string;
+    } catch (writeError) {
+      const msg = writeError instanceof Error ? writeError.message : String(writeError);
+      return {
+        textResultForLlm: `Failed to generate slide: ${msg}`,
+        resultType: 'failure',
+        error: msg,
+        toolTelemetry: {},
+      };
+    }
+
+    try {
+      await PowerPoint.run(async context => {
+        const slides = context.presentation.slides;
+        slides.load('items');
+        await context.sync();
+
+        const slideCount = slides.items.length;
+
+        const insertOptions: PowerPoint.InsertSlideOptions = {
+          formatting: PowerPoint.InsertSlideFormatting.useDestinationTheme,
+        };
+
+        if (replaceSlideIndex !== undefined) {
+          if (replaceSlideIndex < 0 || replaceSlideIndex >= slideCount) {
+            throw new Error(
+              `Invalid replaceSlideIndex ${String(replaceSlideIndex)}. Must be 0-${String(slideCount - 1)}.`
+            );
+          }
+          if (replaceSlideIndex > 0) {
+            const prevSlide = slides.items[replaceSlideIndex - 1];
+            prevSlide.load('id');
+            await context.sync();
+            insertOptions.targetSlideId = prevSlide.id;
+          }
+        } else if (slideCount > 0) {
+          const lastSlide = slides.items[slideCount - 1];
+          lastSlide.load('id');
+          await context.sync();
+          insertOptions.targetSlideId = lastSlide.id;
+        }
+
+        context.presentation.insertSlidesFromBase64(base64, insertOptions);
+        await context.sync();
+
+        if (replaceSlideIndex !== undefined) {
+          // After insert the old slide has shifted by 1
+          slides.load('items');
+          await context.sync();
+          const oldSlide = slides.items[replaceSlideIndex + 1];
+          oldSlide.delete();
+          await context.sync();
+        }
+      });
+
+      return replaceSlideIndex !== undefined
+        ? `Successfully replaced slide ${String(replaceSlideIndex + 1)}.`
+        : 'Successfully added new slide to the presentation.';
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      return { textResultForLlm: msg, resultType: 'failure', error: msg, toolTelemetry: {} };
+    }
+  },
+};
+
+const clearSlide: Tool = {
+  name: 'clear_slide',
+  description: 'Remove all shapes from a specific slide, leaving it blank.',
+  parameters: {
+    type: 'object',
+    properties: {
+      slideIndex: { type: 'number', description: '0-based slide index.' },
+    },
+    required: ['slideIndex'],
+  },
+  handler: async (args: unknown): Promise<ToolResultObject | string> => {
+    const { slideIndex } = (args ?? {}) as { slideIndex: number };
+    try {
+      return await PowerPoint.run(async context => {
+        const slides = context.presentation.slides;
+        slides.load('items');
+        await context.sync();
+
+        const slideCount = slides.items.length;
+        if (slideIndex < 0 || slideIndex >= slideCount) {
+          return {
+            textResultForLlm: `Invalid slideIndex ${String(slideIndex)}. Must be 0-${String(slideCount - 1)}.`,
+            resultType: 'failure',
+            error: 'Invalid slideIndex',
+            toolTelemetry: {},
+          };
+        }
+
+        const slide = slides.items[slideIndex];
+        const shapes = slide.shapes;
+        shapes.load('items');
+        await context.sync();
+
+        for (const shape of shapes.items) {
+          shape.delete();
+        }
+        await context.sync();
+
+        return `Cleared all shapes from slide ${String(slideIndex + 1)}.`;
+      });
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      return { textResultForLlm: msg, resultType: 'failure', error: msg, toolTelemetry: {} };
+    }
+  },
+};
+
+const updateSlideShape: Tool = {
+  name: 'update_slide_shape',
+  description: 'Update the text content of an existing shape on a PowerPoint slide.',
+  parameters: {
+    type: 'object',
+    properties: {
+      slideIndex: { type: 'number', description: '0-based slide index.' },
+      shapeIndex: { type: 'number', description: '0-based shape index within the slide.' },
+      text: { type: 'string', description: 'The new text content for the shape.' },
+    },
+    required: ['slideIndex', 'shapeIndex', 'text'],
+  },
+  handler: async (args: unknown): Promise<ToolResultObject | string> => {
+    const { slideIndex, shapeIndex, text } = (args ?? {}) as {
+      slideIndex: number;
+      shapeIndex: number;
+      text: string;
+    };
+    try {
+      return await PowerPoint.run(async context => {
+        const slides = context.presentation.slides;
+        slides.load('items');
+        await context.sync();
+
+        const slideCount = slides.items.length;
+        if (slideIndex < 0 || slideIndex >= slideCount) {
+          return {
+            textResultForLlm: `Invalid slideIndex ${String(slideIndex)}. Must be 0-${String(slideCount - 1)}.`,
+            resultType: 'failure',
+            error: 'Invalid slideIndex',
+            toolTelemetry: {},
+          };
+        }
+
+        const slide = slides.items[slideIndex];
+        const shapes = slide.shapes;
+        shapes.load('items');
+        await context.sync();
+
+        const shapeCount = shapes.items.length;
+        if (shapeIndex < 0 || shapeIndex >= shapeCount) {
+          return {
+            textResultForLlm: `Invalid shapeIndex ${String(shapeIndex)}. Slide ${String(slideIndex + 1)} has ${String(shapeCount)} shape(s).`,
+            resultType: 'failure',
+            error: 'Invalid shapeIndex',
+            toolTelemetry: {},
+          };
+        }
+
+        const shape = shapes.items[shapeIndex];
+        shape.textFrame.textRange.load('text');
+        await context.sync();
+
+        shape.textFrame.textRange.text = text;
+        await context.sync();
+
+        return `Updated shape ${String(shapeIndex + 1)} on slide ${String(slideIndex + 1)}.`;
+      });
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      return { textResultForLlm: msg, resultType: 'failure', error: msg, toolTelemetry: {} };
+    }
+  },
+};
+
+const setSlideNotes: Tool = {
+  name: 'set_slide_notes',
+  description:
+    'Add or update speaker notes for a slide. Due to API limitations, this provides guidance rather than directly modifying notes in all environments.',
+  parameters: {
+    type: 'object',
+    properties: {
+      slideIndex: { type: 'number', description: '0-based slide index.' },
+      notes: { type: 'string', description: 'The speaker notes text.' },
+    },
+    required: ['slideIndex', 'notes'],
+  },
+  handler: async (args: unknown): Promise<ToolResultObject | string> => {
+    const { slideIndex, notes } = (args ?? {}) as { slideIndex: number; notes: string };
+    try {
+      return await PowerPoint.run(async context => {
+        const slides = context.presentation.slides;
+        slides.load('items');
+        await context.sync();
+
+        const slideCount = slides.items.length;
+        if (slideIndex < 0 || slideIndex >= slideCount) {
+          return `Invalid slideIndex ${String(slideIndex)}. Must be 0-${String(slideCount - 1)}.`;
+        }
+
+        const preview = notes.length > 100 ? `${notes.substring(0, 100)}...` : notes;
+        return `Note: Direct speaker notes editing has limited API support in web add-ins. For slide ${String(slideIndex + 1)}, please use the Notes pane in PowerPoint to add: "${preview}"`;
+      });
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      return { textResultForLlm: msg, resultType: 'failure', error: msg, toolTelemetry: {} };
+    }
+  },
+};
+
+const duplicateSlide: Tool = {
+  name: 'duplicate_slide',
+  description:
+    'Duplicate an existing slide by copying its text content into a new slide. Note: Only text shapes are copied; complex graphics may not be preserved.',
+  parameters: {
+    type: 'object',
+    properties: {
+      sourceIndex: { type: 'number', description: '0-based index of the slide to duplicate.' },
+    },
+    required: ['sourceIndex'],
+  },
+  handler: async (args: unknown): Promise<ToolResultObject | string> => {
+    const { sourceIndex } = (args ?? {}) as { sourceIndex: number };
+    try {
+      return await PowerPoint.run(async context => {
+        const slides = context.presentation.slides;
+        slides.load('items');
+        await context.sync();
+
+        const slideCount = slides.items.length;
+        if (slideCount === 0) return 'Presentation has no slides.';
+        if (sourceIndex < 0 || sourceIndex >= slideCount) {
+          return `Invalid sourceIndex ${String(sourceIndex)}. Must be 0-${String(slideCount - 1)}.`;
+        }
+
+        // Collect shapes from source slide
+        const sourceSlide = slides.items[sourceIndex];
+        sourceSlide.shapes.load('items');
+        await context.sync();
+
+        for (const shape of sourceSlide.shapes.items) {
+          try {
+            shape.textFrame.textRange.load('text');
+          } catch {
+            // not all shapes have a textFrame
+          }
+        }
+        await context.sync();
+
+        // Add a new blank slide and copy text shapes
+        slides.add();
+        await context.sync();
+        slides.load('items');
+        await context.sync();
+        const newSlide = slides.items[slides.items.length - 1];
+
+        for (const shape of sourceSlide.shapes.items) {
+          try {
+            const text = shape.textFrame.textRange.text ?? '';
+            if (text) {
+              newSlide.shapes.addTextBox(text, { left: 50, top: 100, width: 600, height: 100 });
+            }
+          } catch {
+            // skip non-text shapes
+          }
+        }
+        await context.sync();
+
+        return `Duplicated slide ${String(sourceIndex + 1)} (text content only).`;
+      });
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      return { textResultForLlm: msg, resultType: 'failure', error: msg, toolTelemetry: {} };
+    }
+  },
+};
+
+export const powerPointTools: Tool[] = [
+  getPresentationOverview,
+  getPresentationContent,
+  getSlideImage,
+  getSlideNotes,
+  setPresentationContent,
+  addSlideFromCode,
+  clearSlide,
+  updateSlideShape,
+  setSlideNotes,
+  duplicateSlide,
+];

--- a/src/tools/word/index.ts
+++ b/src/tools/word/index.ts
@@ -1,0 +1,532 @@
+import type { Tool, ToolResultObject } from '@github/copilot-sdk';
+
+const getDocumentOverview: Tool = {
+  name: 'get_document_overview',
+  description:
+    'Get a structural overview of the Word document including heading hierarchy, paragraph count, tables, and content controls. Use this first to understand the document structure.',
+  parameters: { type: 'object', properties: {}, required: [] },
+  handler: async (): Promise<ToolResultObject | string> => {
+    try {
+      return await Word.run(async context => {
+        const body = context.document.body;
+        body.load('text');
+
+        const paragraphs = body.paragraphs;
+        paragraphs.load('items');
+        await context.sync();
+
+        for (const para of paragraphs.items) {
+          para.load(['text', 'style', 'isListItem']);
+        }
+        await context.sync();
+
+        const headings: string[] = [];
+        let paragraphCount = 0;
+        let tableCount = 0;
+
+        for (const para of paragraphs.items) {
+          paragraphCount++;
+          const style = para.style ?? '';
+          if (style.startsWith('Heading')) {
+            const level = style.replace('Heading ', 'H');
+            headings.push(`${level}: ${para.text.trim()}`);
+          }
+        }
+
+        const tables = body.tables;
+        tables.load('items');
+        await context.sync();
+        tableCount = tables.items.length;
+
+        const summary = [
+          `Document Overview`,
+          `${'='.repeat(40)}`,
+          `Paragraphs: ${String(paragraphCount)}`,
+          `Tables: ${String(tableCount)}`,
+          '',
+          headings.length > 0 ? `Headings:\n${headings.join('\n')}` : '(no headings found)',
+        ].join('\n');
+
+        return summary;
+      });
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      return { textResultForLlm: msg, resultType: 'failure', error: msg, toolTelemetry: {} };
+    }
+  },
+};
+
+const getDocumentContent: Tool = {
+  name: 'get_document_content',
+  description:
+    'Get the full HTML content of the Word document body. Returns rich formatted content that preserves structure such as headings, lists, and tables.',
+  parameters: { type: 'object', properties: {}, required: [] },
+  handler: async (): Promise<ToolResultObject | string> => {
+    try {
+      return await Word.run(async context => {
+        const body = context.document.body;
+        const htmlResult = body.getHtml();
+        await context.sync();
+        return htmlResult.value;
+      });
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      return { textResultForLlm: msg, resultType: 'failure', error: msg, toolTelemetry: {} };
+    }
+  },
+};
+
+const getDocumentSection: Tool = {
+  name: 'get_document_section',
+  description:
+    'Get the HTML content of a specific section identified by a heading. Finds the heading by partial text match and returns the content until the next heading of the same or higher level.',
+  parameters: {
+    type: 'object',
+    properties: {
+      headingText: {
+        type: 'string',
+        description: 'Partial or full text of the heading that starts the section.',
+      },
+    },
+    required: ['headingText'],
+  },
+  handler: async (args: unknown): Promise<ToolResultObject | string> => {
+    const { headingText } = (args ?? {}) as { headingText: string };
+    try {
+      return await Word.run(async context => {
+        const body = context.document.body;
+        const paragraphs = body.paragraphs;
+        paragraphs.load('items');
+        await context.sync();
+
+        for (const para of paragraphs.items) {
+          para.load(['text', 'style']);
+        }
+        await context.sync();
+
+        const headingPara = paragraphs.items.find(
+          p =>
+            p.style?.startsWith('Heading') &&
+            p.text.toLowerCase().includes(headingText.toLowerCase())
+        );
+
+        if (!headingPara) {
+          return `No heading found containing "${headingText}".`;
+        }
+
+        const headingLevel = parseInt(headingPara.style.replace('Heading ', ''), 10) || 1;
+        const range = headingPara.getRange();
+
+        // Expand range to include content until next heading of same or higher level
+        const allParas = paragraphs.items;
+        const startIdx = allParas.indexOf(headingPara);
+
+        let endPara: Word.Paragraph | undefined;
+        for (let i = startIdx + 1; i < allParas.length; i++) {
+          const p = allParas[i];
+          if (p.style?.startsWith('Heading')) {
+            const level = parseInt(p.style.replace('Heading ', ''), 10) || 1;
+            if (level <= headingLevel) {
+              endPara = p;
+              break;
+            }
+          }
+        }
+
+        let sectionRange: Word.Range;
+        if (endPara) {
+          const endRange = endPara.getRange(Word.RangeLocation.start);
+          sectionRange = range.expandTo(endRange);
+        } else {
+          const bodyEnd = body.getRange(Word.RangeLocation.end);
+          sectionRange = range.expandTo(bodyEnd);
+        }
+
+        const htmlResult = sectionRange.getHtml();
+        await context.sync();
+        return htmlResult.value;
+      });
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      return { textResultForLlm: msg, resultType: 'failure', error: msg, toolTelemetry: {} };
+    }
+  },
+};
+
+const setDocumentContent: Tool = {
+  name: 'set_document_content',
+  description:
+    'Replace the entire document body with new HTML content. WARNING: This clears all existing content.',
+  parameters: {
+    type: 'object',
+    properties: {
+      html: {
+        type: 'string',
+        description: 'HTML content to set as the full document body.',
+      },
+    },
+    required: ['html'],
+  },
+  handler: async (args: unknown): Promise<ToolResultObject | string> => {
+    const { html } = (args ?? {}) as { html: string };
+    try {
+      return await Word.run(async context => {
+        const body = context.document.body;
+        body.clear();
+        body.insertHtml(html, Word.InsertLocation.start);
+        await context.sync();
+        return 'Document content replaced successfully.';
+      });
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      return { textResultForLlm: msg, resultType: 'failure', error: msg, toolTelemetry: {} };
+    }
+  },
+};
+
+const getSelection: Tool = {
+  name: 'get_selection',
+  description:
+    'Get the currently selected content in the Word document as OOXML. Useful for inspecting the structure of the selection.',
+  parameters: { type: 'object', properties: {}, required: [] },
+  handler: async (): Promise<ToolResultObject | string> => {
+    try {
+      return await Word.run(async context => {
+        const selection = context.document.getSelection();
+        const ooxmlResult = selection.getOoxml();
+        await context.sync();
+
+        const ooxml = ooxmlResult.value;
+        // Extract the <w:document> element for a cleaner view
+        const docMatch = /<w:document[^>]*>[\s\S]*<\/w:document>/i.exec(ooxml);
+        return docMatch ? docMatch[0] : ooxml;
+      });
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      return { textResultForLlm: msg, resultType: 'failure', error: msg, toolTelemetry: {} };
+    }
+  },
+};
+
+const getSelectionText: Tool = {
+  name: 'get_selection_text',
+  description: 'Get the plain text of the currently selected content in the Word document.',
+  parameters: { type: 'object', properties: {}, required: [] },
+  handler: async (): Promise<ToolResultObject | string> => {
+    try {
+      return await Word.run(async context => {
+        const selection = context.document.getSelection();
+        selection.load('text');
+        await context.sync();
+        return selection.text.length > 0 ? selection.text : '(no text selected)';
+      });
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      return { textResultForLlm: msg, resultType: 'failure', error: msg, toolTelemetry: {} };
+    }
+  },
+};
+
+const insertContentAtSelection: Tool = {
+  name: 'insert_content_at_selection',
+  description: 'Insert HTML content at or relative to the current selection in the Word document.',
+  parameters: {
+    type: 'object',
+    properties: {
+      html: { type: 'string', description: 'HTML content to insert.' },
+      location: {
+        type: 'string',
+        enum: ['Replace', 'Before', 'After', 'Start', 'End'],
+        description:
+          'Where to insert relative to the selection. Replace overwrites the selection. Default: Replace.',
+      },
+    },
+    required: ['html'],
+  },
+  handler: async (args: unknown): Promise<ToolResultObject | string> => {
+    const { html, location = 'Replace' } = (args ?? {}) as {
+      html: string;
+      location?: string;
+    };
+
+    const locationMap: Record<string, Word.InsertLocation> = {
+      Replace: Word.InsertLocation.replace,
+      Before: Word.InsertLocation.before,
+      After: Word.InsertLocation.after,
+      Start: Word.InsertLocation.start,
+      End: Word.InsertLocation.end,
+    };
+
+    const insertLocation = locationMap[location] ?? Word.InsertLocation.replace;
+
+    try {
+      return await Word.run(async context => {
+        const selection = context.document.getSelection();
+        selection.insertHtml(html, insertLocation);
+        await context.sync();
+        return `Content inserted at selection (location: ${location}).`;
+      });
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      return { textResultForLlm: msg, resultType: 'failure', error: msg, toolTelemetry: {} };
+    }
+  },
+};
+
+const findAndReplace: Tool = {
+  name: 'find_and_replace',
+  description: 'Find text in the Word document and replace all occurrences with new text.',
+  parameters: {
+    type: 'object',
+    properties: {
+      find: { type: 'string', description: 'Text to search for.' },
+      replace: { type: 'string', description: 'Replacement text.' },
+      matchCase: {
+        type: 'boolean',
+        description: 'Whether the search is case-sensitive. Default: false.',
+      },
+      matchWholeWord: {
+        type: 'boolean',
+        description: 'Whether to match whole words only. Default: false.',
+      },
+    },
+    required: ['find', 'replace'],
+  },
+  handler: async (args: unknown): Promise<ToolResultObject | string> => {
+    const {
+      find,
+      replace,
+      matchCase = false,
+      matchWholeWord = false,
+    } = (args ?? {}) as {
+      find: string;
+      replace: string;
+      matchCase?: boolean;
+      matchWholeWord?: boolean;
+    };
+    try {
+      return await Word.run(async context => {
+        const body = context.document.body;
+        const results = body.search(find, { matchCase, matchWholeWord });
+        results.load('items');
+        await context.sync();
+
+        const count = results.items.length;
+        if (count === 0) {
+          return `No occurrences of "${find}" found.`;
+        }
+
+        for (const result of results.items) {
+          result.insertText(replace, Word.InsertLocation.replace);
+        }
+        await context.sync();
+
+        return `Replaced ${String(count)} occurrence(s) of "${find}" with "${replace}".`;
+      });
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      return { textResultForLlm: msg, resultType: 'failure', error: msg, toolTelemetry: {} };
+    }
+  },
+};
+
+const insertTable: Tool = {
+  name: 'insert_table',
+  description:
+    'Insert a table at the current selection in the Word document. Supports grid, striped, and plain styles.',
+  parameters: {
+    type: 'object',
+    properties: {
+      rows: { type: 'number', description: 'Number of rows.' },
+      columns: { type: 'number', description: 'Number of columns.' },
+      data: {
+        type: 'array',
+        items: { type: 'array', items: { type: 'string' } },
+        description: 'Optional 2D array of cell values (row-major). Omit for an empty table.',
+      },
+      style: {
+        type: 'string',
+        enum: ['grid', 'striped', 'plain'],
+        description:
+          'Visual style. grid adds borders, striped alternates row colors, plain has no formatting. Default: grid.',
+      },
+      hasHeaderRow: {
+        type: 'boolean',
+        description: 'Whether the first row is a header row with distinct styling. Default: true.',
+      },
+    },
+    required: ['rows', 'columns'],
+  },
+  handler: async (args: unknown): Promise<ToolResultObject | string> => {
+    const {
+      rows,
+      columns,
+      data,
+      style = 'grid',
+      hasHeaderRow = true,
+    } = (args ?? {}) as {
+      rows: number;
+      columns: number;
+      data?: string[][];
+      style?: 'grid' | 'striped' | 'plain';
+      hasHeaderRow?: boolean;
+    };
+
+    try {
+      return await Word.run(async context => {
+        const selection = context.document.getSelection();
+
+        // Build flat cell data array expected by insertTable
+        const cellValues: string[][] = [];
+        for (let r = 0; r < rows; r++) {
+          const row: string[] = [];
+          for (let c = 0; c < columns; c++) {
+            row.push(data?.[r]?.[c] ?? '');
+          }
+          cellValues.push(row);
+        }
+
+        const table = selection.insertTable(rows, columns, Word.InsertLocation.after, cellValues);
+        await context.sync();
+
+        table.load('rows');
+        await context.sync();
+
+        if (style === 'grid') {
+          table.style = 'Table Grid';
+        }
+
+        if (hasHeaderRow && rows > 0) {
+          const headerRow = table.rows.items[0];
+          headerRow.load('cells');
+          await context.sync();
+
+          for (const cell of headerRow.cells.items) {
+            cell.shadingColor = '#4472C4';
+            const paras = cell.body.paragraphs;
+            paras.load('items');
+            await context.sync();
+            for (const para of paras.items) {
+              para.font.bold = true;
+              para.font.color = '#FFFFFF';
+            }
+          }
+        }
+
+        if (style === 'striped') {
+          for (let r = hasHeaderRow ? 1 : 0; r < table.rows.items.length; r++) {
+            if (r % 2 === 0) continue;
+            const row = table.rows.items[r];
+            row.load('cells');
+            await context.sync();
+            for (const cell of row.cells.items) {
+              cell.shadingColor = '#E8E8E8';
+            }
+          }
+        }
+
+        await context.sync();
+        return `Inserted a ${String(rows)}×${String(columns)} table with "${style}" style.`;
+      });
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      return { textResultForLlm: msg, resultType: 'failure', error: msg, toolTelemetry: {} };
+    }
+  },
+};
+
+const applyStyleToSelection: Tool = {
+  name: 'apply_style_to_selection',
+  description: 'Apply font formatting to the currently selected text in the Word document.',
+  parameters: {
+    type: 'object',
+    properties: {
+      bold: { type: 'boolean', description: 'Make text bold.' },
+      italic: { type: 'boolean', description: 'Make text italic.' },
+      underline: { type: 'boolean', description: 'Underline text. true = single underline.' },
+      strikeThrough: { type: 'boolean', description: 'Apply strikethrough.' },
+      fontSize: { type: 'number', description: 'Font size in points.' },
+      fontName: { type: 'string', description: 'Font family name (e.g. "Calibri", "Arial").' },
+      fontColor: {
+        type: 'string',
+        description: 'Font color as hex (e.g. "#FF0000") or named color.',
+      },
+      highlightColor: {
+        type: 'string',
+        description:
+          'Highlight color. Allowed values: Yellow, Cyan, Magenta, Blue, Red, DarkBlue, DarkCyan, DarkMagenta, DarkRed, DarkYellow, DarkGray, LightGray, Black, White, None.',
+      },
+    },
+    required: [],
+  },
+  handler: async (args: unknown): Promise<ToolResultObject | string> => {
+    const {
+      bold,
+      italic,
+      underline,
+      strikeThrough,
+      fontSize,
+      fontName,
+      fontColor,
+      highlightColor,
+    } = (args ?? {}) as {
+      bold?: boolean;
+      italic?: boolean;
+      underline?: boolean;
+      strikeThrough?: boolean;
+      fontSize?: number;
+      fontName?: string;
+      fontColor?: string;
+      highlightColor?: string;
+    };
+
+    try {
+      return await Word.run(async context => {
+        const selection = context.document.getSelection();
+        const font = selection.font;
+
+        if (bold !== undefined) font.bold = bold;
+        if (italic !== undefined) font.italic = italic;
+        if (underline !== undefined)
+          font.underline = underline ? Word.UnderlineType.single : Word.UnderlineType.none;
+        if (strikeThrough !== undefined) font.strikeThrough = strikeThrough;
+        if (fontSize !== undefined) font.size = fontSize;
+        if (fontName !== undefined) font.name = fontName;
+        if (fontColor !== undefined) font.color = fontColor;
+        if (highlightColor !== undefined) font.highlightColor = highlightColor;
+
+        await context.sync();
+
+        const applied: string[] = [];
+        if (bold !== undefined) applied.push(`bold=${String(bold)}`);
+        if (italic !== undefined) applied.push(`italic=${String(italic)}`);
+        if (underline !== undefined) applied.push(`underline=${String(underline)}`);
+        if (strikeThrough !== undefined) applied.push(`strikeThrough=${String(strikeThrough)}`);
+        if (fontSize !== undefined) applied.push(`fontSize=${String(fontSize)}`);
+        if (fontName !== undefined) applied.push(`fontName="${fontName}"`);
+        if (fontColor !== undefined) applied.push(`color="${fontColor}"`);
+        if (highlightColor !== undefined) applied.push(`highlight="${highlightColor}"`);
+
+        return applied.length > 0
+          ? `Applied: ${applied.join(', ')}.`
+          : 'No style properties specified.';
+      });
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      return { textResultForLlm: msg, resultType: 'failure', error: msg, toolTelemetry: {} };
+    }
+  },
+};
+
+export const wordTools: Tool[] = [
+  getDocumentOverview,
+  getDocumentContent,
+  getDocumentSection,
+  setDocumentContent,
+  getSelection,
+  getSelectionText,
+  insertContentAtSelection,
+  findAndReplace,
+  insertTable,
+  applyStyleToSelection,
+];

--- a/src/types/agent.ts
+++ b/src/types/agent.ts
@@ -1,4 +1,4 @@
-export type AgentHost = 'excel' | 'powerpoint';
+export type AgentHost = 'excel' | 'powerpoint' | 'word';
 
 /** Parsed metadata from an agent's YAML frontmatter. */
 export interface AgentMetadata {

--- a/tests/unit/agentService.test.ts
+++ b/tests/unit/agentService.test.ts
@@ -62,8 +62,8 @@ Body content.`;
 name: InvalidHosts
 description: Agent with invalid host entries
 version: 1.0.0
-hosts: [excel, word, powerpoint]
-defaultForHosts: [word, excel]
+hosts: [excel, outlook, powerpoint]
+defaultForHosts: [outlook, excel]
 ---
 
 Body content.`;
@@ -155,8 +155,11 @@ describe('getAgents', () => {
     expect(excel!.metadata.hosts).toContain('excel');
   });
 
-  it('returns no agents for PowerPoint until one is added', () => {
-    expect(getAgents('powerpoint')).toEqual([]);
+  it('returns the PowerPoint agent', () => {
+    const agents = getAgents('powerpoint');
+    const ppt = agents.find(a => a.metadata.name === 'PowerPoint');
+    expect(ppt).toBeDefined();
+    expect(ppt!.metadata.hosts).toContain('powerpoint');
   });
 });
 
@@ -198,7 +201,7 @@ describe('default and active resolution', () => {
   });
 
   it('returns undefined default for host with no configured agents', () => {
-    expect(getDefaultAgent('powerpoint')).toBeUndefined();
+    expect(getDefaultAgent('unknown')).toBeUndefined();
   });
 
   it('falls back to host default when active agent does not match host', () => {


### PR DESCRIPTION
Adds 10 PowerPoint tools and 10 Word tools. PowerPoint: get_presentation_overview, get_presentation_content, get_slide_image, get_slide_notes, set_presentation_content, add_slide_from_code, clear_slide, update_slide_shape, set_slide_notes, duplicate_slide. Word: get_document_overview, get_document_content, get_document_section, set_document_content, get_selection, get_selection_text, insert_content_at_selection, find_and_replace, insert_table, apply_style_to_selection. Infrastructure: OfficeHostApp/AgentHost extended with word, agentService loads all 3 bundled agents, manifests updated for Presentation + Document hosts. 275 tests pass.