### PR TITLE
fix(ui): show tool names in thinking indicator

### DIFF
--- a/src/hooks/useOfficeChat.ts
+++ b/src/hooks/useOfficeChat.ts
@@ -9,6 +9,7 @@ import { resolveActiveAgent } from '@/services/agents';
 import { resolveActiveMcpServers, toSdkMcpServers } from '@/services/mcp';
 import { useSettingsStore } from '@/stores';
 import { buildSystemPrompt } from '@/services/ai/systemPrompt';
+import { humanizeToolName } from '@/utils/humanizeToolName';
 import { inferProvider } from '@/types';
 import type { OfficeHostApp } from '@/services/office/host';
 import { generateId } from '@/utils/id';
@@ -255,6 +256,7 @@ export function useOfficeChat(host: OfficeHostApp) {
             }
             continue;
           }
+          setThinkingText(`${humanizeToolName(toolName)}…`);
           toolParts.set(toolCallId, {
             type: 'tool-call',
             toolCallId,


### PR DESCRIPTION
The thinking indicator relied solely on eport_intent events from the Copilot SDK, which don't always fire. Users saw static 'Thinking…' text even while tools were actively executing.

Now when a tool starts executing, the indicator shows a humanized tool name (e.g. 'Get range values…') via humanizeToolName(), giving immediate feedback. eport_intent text still overrides when available.