### PR TITLE
fix: strengthen test assertions across integration suite

### DIFF
--- a/tests/integration/chat-error-boundary.test.tsx
+++ b/tests/integration/chat-error-boundary.test.tsx
@@ -83,6 +83,12 @@ describe('ChatErrorBoundary', () => {
     );
 
     expect(console.error).toHaveBeenCalled();
+    // Verify the error object was passed to console.error
+    const calls = (console.error as ReturnType<typeof vi.fn>).mock.calls;
+    const hasSimulatedCrash = calls.some(args =>
+      args.some(arg => arg instanceof Error && arg.message === 'Simulated render crash')
+    );
+    expect(hasSimulatedCrash).toBe(true);
   });
 
   it('"Try again" button resets the error boundary', async () => {

--- a/tests/integration/chat-panel.test.tsx
+++ b/tests/integration/chat-panel.test.tsx
@@ -33,6 +33,8 @@ describe('ChatPanel — integration', () => {
     expect(screen.getByTestId('thread')).toBeInTheDocument();
     // AgentPicker renders agent name (default agent "Excel")
     expect(screen.getByText('Excel')).toBeInTheDocument();
+    // ModelPicker renders with its aria-label and default model display
+    expect(screen.getByLabelText('Select model')).toBeInTheDocument();
   });
 
   it('renders toolbar border between thread and pickers', () => {

--- a/tests/integration/excel-tools.test.ts
+++ b/tests/integration/excel-tools.test.ts
@@ -37,7 +37,7 @@ const ALL_TOOL_NAMES = [
 
 describe('Integration: Excel tool configs — structural', () => {
   it('excelTools array is non-empty and every tool has parameters and handler', () => {
-    expect(excelTools.length).toBeGreaterThan(0);
+    expect(excelTools).toHaveLength(ALL_TOOL_NAMES.length);
     for (const t of excelTools) {
       expect(t).toBeDefined();
       expect(t.parameters).toBeDefined();

--- a/tests/integration/host-tools-limit.test.ts
+++ b/tests/integration/host-tools-limit.test.ts
@@ -4,6 +4,19 @@ import { getToolsForHost, MAX_TOOLS_PER_REQUEST } from '@/tools';
 describe('host tools limit', () => {
   it('getToolsForHost("excel") returns at most MAX_TOOLS_PER_REQUEST tools', () => {
     const tools = getToolsForHost('excel');
+    expect(tools.length).toBeGreaterThan(0);
+    expect(tools.length).toBeLessThanOrEqual(MAX_TOOLS_PER_REQUEST);
+  });
+
+  it('getToolsForHost("powerpoint") returns at most MAX_TOOLS_PER_REQUEST tools', () => {
+    const tools = getToolsForHost('powerpoint');
+    expect(tools.length).toBeGreaterThan(0);
+    expect(tools.length).toBeLessThanOrEqual(MAX_TOOLS_PER_REQUEST);
+  });
+
+  it('getToolsForHost("word") returns at most MAX_TOOLS_PER_REQUEST tools', () => {
+    const tools = getToolsForHost('word');
+    expect(tools.length).toBeGreaterThan(0);
     expect(tools.length).toBeLessThanOrEqual(MAX_TOOLS_PER_REQUEST);
   });
 

--- a/tests/integration/management-tools.test.ts
+++ b/tests/integration/management-tools.test.ts
@@ -168,8 +168,7 @@ describe('manage_skills handler', () => {
     }) as { toggled: boolean; name: string; active: boolean };
     expect(toggled.toggled).toBe(true);
     expect(toggled.name).toBe('ToggleSkill');
-    // active state depends on store logic — just verify the field exists
-    expect(typeof toggled.active).toBe('boolean');
+    expect(toggled.active).toBe(false);
   });
 
   it('toggle requires name', () => {
@@ -355,7 +354,7 @@ describe('manage_mcp_servers handler', () => {
       name: 'toggle-server',
     }) as { toggled: boolean; name: string; active: boolean };
     expect(toggled.toggled).toBe(true);
-    expect(typeof toggled.active).toBe('boolean');
+    expect(toggled.active).toBe(false);
   });
 
   it('toggle requires name', () => {

--- a/tests/integration/mcp-service.test.ts
+++ b/tests/integration/mcp-service.test.ts
@@ -86,7 +86,7 @@ describe('parseMcpJsonFile', () => {
 
   it('throws when no mcpServers/servers key exists', async () => {
     const file = makeFile({ foo: 'bar' });
-    await expect(parseMcpJsonFile(file)).rejects.toThrow();
+    await expect(parseMcpJsonFile(file)).rejects.toThrow(/mcpServers|servers/);
   });
 
   it('throws when all entries are skipped (no valid HTTP/SSE servers)', async () => {

--- a/tests/integration/settings-store.test.ts
+++ b/tests/integration/settings-store.test.ts
@@ -210,7 +210,7 @@ describe('settingsStore — MCP servers', () => {
     useSettingsStore.getState().importMcpServers([server1]);
     const names = useSettingsStore.getState().importedMcpServers.map(s => s.name);
     expect(names[0]).toBe('srv1');
-    expect(names[1]).not.toBe('srv1');
+    expect(names[1]).toBe('srv1 (imported)');
   });
 
   it('removes a MCP server by name', () => {

--- a/tests/integration/use-tool-invocations-patch.test.tsx
+++ b/tests/integration/use-tool-invocations-patch.test.tsx
@@ -115,6 +115,10 @@ describe('useToolInvocations patch', () => {
         rerender(<HookDriver stateRef={stateRef} />);
       });
     }).not.toThrow();
+
+    // Positive assertion: component still renders with the updated tool call
+    expect(stateRef.current.messages[0].content[0].argsText).toBe(completeArgsText);
+    expect(stateRef.current.messages[0].content[0].toolCallId).toBe('tc-1');
   });
 
   it('still works for normal append-only streaming (no key reorder)', () => {
@@ -147,6 +151,9 @@ describe('useToolInvocations patch', () => {
         rerender(<HookDriver stateRef={stateRef} />);
       });
     }).not.toThrow();
+
+    // Positive assertion: tool call state reflects the appended argsText
+    expect(stateRef.current.messages[0].content[0].argsText).toBe('{"address":"A1","value":"hello"}');
   });
 
   it('does not throw for non-appendable argsText (handled via replacement stream)', () => {
@@ -179,5 +186,8 @@ describe('useToolInvocations patch', () => {
         rerender(<HookDriver stateRef={stateRef} />);
       });
     }).not.toThrow();
+
+    // Positive assertion: tool call state reflects the replacement argsText
+    expect(stateRef.current.messages[0].content[0].argsText).toBe('CORRUPTED_GARBAGE');
   });
 });

--- a/tests/integration/zip-export-service.test.ts
+++ b/tests/integration/zip-export-service.test.ts
@@ -135,6 +135,7 @@ describe('buildAgentsZip', () => {
     const blob = await buildAgentsZip([testAgent]);
     const zip = await JSZip.loadAsync(await blob.arrayBuffer());
     const paths = Object.keys(zip.files).filter(p => !zip.files[p].dir);
+    expect(paths.length).toBeGreaterThan(0);
     expect(paths.every(p => p.startsWith('agents/'))).toBe(true);
     expect(paths[0]).toMatch(/\.md$/);
   });
@@ -157,6 +158,7 @@ describe('buildSkillsZip', () => {
     const blob = await buildSkillsZip([testSkill]);
     const zip = await JSZip.loadAsync(await blob.arrayBuffer());
     const paths = Object.keys(zip.files).filter(p => !zip.files[p].dir);
+    expect(paths.length).toBeGreaterThan(0);
     expect(paths.every(p => p.startsWith('skills/'))).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

Comprehensive audit of all 46 test files (36 integration + 3 E2E runners + 7 Playwright UI specs) revealed weak or misleading assertions. This PR fixes P0 and P1 gaps in 10 integration test files.

### P0 — Silent pass / misleading assertions
- **use-office-chat.test.tsx**: Replaced 4 guarded \if (textPart?.type === 'text')\ blocks with unconditional \xpect(textPart).toBeDefined()\ + direct value assertions — these would silently skip assertions if the condition was false
- **use-tool-invocations-patch.test.tsx**: Added positive assertions after all 3 \.not.toThrow()\ blocks — previously had zero positive assertions, only negative guards
- **chat-panel.test.tsx**: Added ModelPicker assertion (\getByLabelText('Select model')\) — test title claimed to verify ModelPicker but never did
- **zip-export-service.test.ts**: Added \length > 0\ guard before \.every()\ calls — \.every()\ on empty array is vacuously true

### P1 — Wrong assertion type
- **excel-tools.test.ts**: \	oBeGreaterThan(0)\ → \	oHaveLength(ALL_TOOL_NAMES.length)\ (exact count: 10)
- **host-tools-limit.test.ts**: Added \	oBeGreaterThan(0)\ lower bound + \powerpoint\/\word\ host tests
- **management-tools.test.ts**: \	ypeof toggled.active === 'boolean'\ → \xpect(toggled.active).toBe(false)\ for skill and MCP toggle
- **settings-store.test.ts**: \
ot.toBe('srv1')\ → \	oBe('srv1 (imported)')\ (exact expected value)
- **chat-error-boundary.test.tsx**: Added verification that \console.error\ receives the actual \Error\ object
- **mcp-service.test.ts**: Bare \.toThrow()\ → \.toThrow(/mcpServers|servers/)\ with message pattern

### Also
- Updated \copilot-instructions.md\ with zero-failures policy and corrected thinking indicator docs

### Test Results
- **36 test files passed, 433 tests passed, 0 failures**