### PR TITLE
fix: move thinking indicator into sticky footer for visibility

### DIFF
--- a/src/components/assistant-ui/thread.tsx
+++ b/src/components/assistant-ui/thread.tsx
@@ -40,10 +40,9 @@ export const Thread: FC = () => {
           }}
         />
 
-        <ThinkingIndicator />
-
         <ThreadPrimitive.ViewportFooter className="aui-thread-viewport-footer sticky bottom-0 mt-auto flex w-full flex-col gap-3 overflow-visible rounded-t-2xl bg-background pb-3">
           <ThreadScrollToBottom />
+          <ThinkingIndicator />
           <Composer />
         </ThreadPrimitive.ViewportFooter>
       </ThreadPrimitive.Viewport>


### PR DESCRIPTION
## Problem

The ThinkingIndicator rendered inside the scroll area (after \ThreadPrimitive.Messages\), which caused two issues:

1. **Indicator invisible** — when messages filled the viewport, the indicator appeared below the fold and auto-scroll didn't reliably bring it into view
2. **Scroll-to-bottom button appeared incorrectly** — the indicator added height to the scroll area, making the viewport think there was content to scroll to

## Fix

Moved \<ThinkingIndicator />\ from the scroll area into \<ThreadPrimitive.ViewportFooter>\ (the sticky footer), placed between \<ThreadScrollToBottom />\ and \<Composer />\. This matches ChatGPT/Copilot behavior where the thinking state is always visible above the input box.

## Testing

- 416/416 integration tests pass