### PR TITLE
feat: use native SDK skillDirectories and customAgents instead of system prompt injection

### DIFF
--- a/src/lib/websocket-client.ts
+++ b/src/lib/websocket-client.ts
@@ -28,6 +28,32 @@ interface ToolCallResponsePayload {
   result: ToolResultObject;
 }
 
+/** Skill data sent from browser to proxy for writing to disk. */
+export interface SkillPayload {
+  name: string;
+  content: string;
+}
+
+/** Custom agent config sent from browser to proxy. */
+export interface CustomAgentPayload {
+  name: string;
+  displayName?: string;
+  description?: string;
+  prompt: string;
+  tools?: string[] | null;
+}
+
+/** Extended session config for browser → proxy communication. */
+export interface BrowserSessionConfig extends Omit<SessionConfig, 'tools'> {
+  tools?: Tool[];
+  /** Imported skill files for the proxy to write to disk and pass as skillDirectories. */
+  skills?: SkillPayload[];
+  /** Skill names to disable (SDK disabledSkills). */
+  disabledSkills?: string[];
+  /** Custom agent configs passed natively to the SDK. */
+  customAgents?: CustomAgentPayload[];
+}
+
 /**
  * Browser-compatible Copilot session over WebSocket.
  */
@@ -163,7 +189,7 @@ export class WebSocketCopilotClient {
     });
   }
 
-  async createSession(config: SessionConfig = {}): Promise<BrowserCopilotSession> {
+  async createSession(config: BrowserSessionConfig = {}): Promise<BrowserCopilotSession> {
     if (!this.connection) {
       throw new Error('Client not connected. Call start() first.');
     }
@@ -179,6 +205,9 @@ export class WebSocketCopilotClient {
       })),
       mcpServers: config.mcpServers,
       availableTools: config.availableTools,
+      skills: config.skills,
+      disabledSkills: config.disabledSkills,
+      customAgents: config.customAgents,
     });
 
     const sessionId = response.sessionId;


### PR DESCRIPTION
## Problem

Skills and agents were injected into the AI context by manually concatenating their content into the system prompt string. The Copilot SDK's native \skillDirectories\, \disabledSkills\, and \customAgents\ parameters were never used.

This meant:
- **Multi-file skills** (e.g. \src/skills/excel/\ with \SKILL.md\ + \eferences/\) couldn't be properly handled — the SDK can traverse skill directories and resolve references
- **Skill enable/disable** had to be managed manually instead of using the SDK's built-in \disabledSkills\ mechanism
- **Agent instructions** were part of the system prompt instead of being a proper custom agent config

## Solution

### Skills
- **Bundled skills** (on disk at \src/skills/\): proxy passes the directory path directly via \skillDirectories\ — the SDK discovers \SKILL.md\ files and their references
- **Imported skills**: browser serializes content → proxy writes to temp directory → added to \skillDirectories\
- **Disabled skills**: computed from \ctiveSkillNames\ and passed as \disabledSkills\ string array
- Temp directories are cleaned up on session destroy and WebSocket disconnect

### Agents
- Resolved agent (name, description, instructions) is passed as \customAgents\ config to the SDK
- Tool scoping (\vailableTools\) remains at session level

### System Prompt
- Now contains only \BASE_PROMPT + APP_PROMPT\ — no more manual concatenation of agent instructions or skill context

## Changes

| File | What changed |
|------|-------------|
| \src/lib/websocket-client.ts\ | Added \SkillPayload\, \CustomAgentPayload\, \BrowserSessionConfig\ interfaces; \createSession\ serializes new fields |
| \src/hooks/useOfficeChat.ts\ | Builds skill/agent payloads; system prompt = base+app only |
| \src/copilotProxy.mjs\ | Writes imported skills to temp dir; passes \skillDirectories\, \disabledSkills\, \customAgents\ to SDK |
| \	ests/integration/use-office-chat.test.tsx\ | 4 new tests for native SDK skills and agents |

## Testing
- 420/420 integration tests pass
- 4 new tests verify: custom agents passed correctly, system message excludes agent instructions, imported skills serialized, disabled skills computed