### PR TITLE
fix: make skill proxy robust (module-relative path, randomUUID, host-scoped bundled skills)

### DIFF
--- a/src/hooks/useOfficeChat.ts
+++ b/src/hooks/useOfficeChat.ts
@@ -176,6 +176,7 @@ export function useOfficeChat(host: OfficeHostApp) {
           tools: getToolsForHost(host),
           mcpServers,
           availableTools,
+          host,
           skills,
           disabledSkills,
           customAgents,

--- a/src/lib/websocket-client.ts
+++ b/src/lib/websocket-client.ts
@@ -46,6 +46,8 @@ export interface CustomAgentPayload {
 /** Extended session config for browser → proxy communication. */
 export interface BrowserSessionConfig extends Omit<SessionConfig, 'tools'> {
   tools?: Tool[];
+  /** Office host identifier (e.g. 'excel', 'powerpoint'). Used by proxy for per-host skill loading. */
+  host?: string;
   /** Imported skill files for the proxy to write to disk and pass as skillDirectories. */
   skills?: SkillPayload[];
   /** Skill names to disable (SDK disabledSkills). */
@@ -205,6 +207,7 @@ export class WebSocketCopilotClient {
       })),
       mcpServers: config.mcpServers,
       availableTools: config.availableTools,
+      host: config.host,
       skills: config.skills,
       disabledSkills: config.disabledSkills,
       customAgents: config.customAgents,


### PR DESCRIPTION
Code review fixes for #38.

## Bugs fixed

**BUNDLED_SKILLS_ROOT was CWD-relative**
resolve('src/skills') uses process.cwd(), which breaks if the server is started from a directory other than the project root. Fixed with import.meta.url + dirname(fileURLToPath(...)).

**Race condition in temp directory naming**
oca-skills-Date.now() -- two concurrent session.create calls in the same millisecond share a directory. When either session destroys (deleting the dir), the other loses its skills. Fixed with crypto.randomUUID().

**slugify() could return an empty string**
A skill name of all special characters produced "" after stripping, causing writeFile to land directly in the temp root. Every additional skill overwrote the same SKILL.md. Fixed with a fallback to 'skill'.

**All bundled skills were loaded for every Office host**
skillDirectories always included the entire src/skills/ root, so a PowerPoint session also loaded the Excel skill. host is now forwarded from the browser via BrowserSessionConfig.host; the proxy resolves the host-specific subdirectory with an existsSync guard so missing dirs are silently skipped.

## Not fixed in this PR (documented)

- hosts attribute in SKILL.md: the Copilot extension flags this as unsupported. The field is needed for browser-side SkillPicker filtering. A follow-up could move it under the SDK metadata: key.
- skillToMarkdown in zipExportService: pre-existing placement issue, belongs in skillService.ts.

## Testing
422/422 tests pass (34 files)