### PR TITLE
fix: 15 UX bugs + comprehensive test coverage (693 integration + 234 E2E)

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -12,6 +12,7 @@ All changes must go through a pull request on a feature branch:
 4. Ask the user to review and merge the PR on GitHub
 
 **Never run:**
+
 - `git push origin main`
 - `git merge <branch> ` while on `main`
 - `git commit --no-verify` to bypass hooks and then push to `main`
@@ -148,26 +149,26 @@ The task pane is split into three areas:
 
 ### Test Tiers
 
-| Tier            | Runner     | Directory            | Count | What it tests                                                                        |
-| --------------- | ---------- | -------------------- | ----- | ------------------------------------------------------------------------------------ |
-| **Integration** | Vitest     | `tests/integration/` | 36    | Component wiring; tool schemas; stores; hooks; live Copilot WebSocket |
-| **UI**          | Playwright | `tests-ui/`          |       | Browser task pane flows (real Copilot API, NO mocking)                                |
-| **E2E (Excel)**   | Mocha      | `tests-e2e/`           | ~187  | Excel commands inside real Excel Desktop                                             |
-| **E2E (PPT)**     | Mocha      | `tests-e2e-ppt/`       | ~13   | PowerPoint commands inside real PowerPoint Desktop                                   |
-| **E2E (Word)**    | Mocha      | `tests-e2e-word/`      | ~12   | Word commands inside real Word Desktop                                               |
-| **E2E (Outlook)** | Mocha      | `tests-e2e-outlook/`   | ~9    | Outlook commands (requires Exchange sideloading approval)                            |
-| ~~Unit~~          | ~~Vitest~~ | ~~`tests/unit/`~~      |       | ~~DO NOT ADD NEW UNIT TESTS~~                                                        |
+| Tier              | Runner     | Directory            | Count | What it tests                                                         |
+| ----------------- | ---------- | -------------------- | ----- | --------------------------------------------------------------------- |
+| **Integration**   | Vitest     | `tests/integration/` | 36    | Component wiring; tool schemas; stores; hooks; live Copilot WebSocket |
+| **UI**            | Playwright | `tests-ui/`          |       | Browser task pane flows (real Copilot API, NO mocking)                |
+| **E2E (Excel)**   | Mocha      | `tests-e2e/`         | ~187  | Excel commands inside real Excel Desktop                              |
+| **E2E (PPT)**     | Mocha      | `tests-e2e-ppt/`     | ~13   | PowerPoint commands inside real PowerPoint Desktop                    |
+| **E2E (Word)**    | Mocha      | `tests-e2e-word/`    | ~12   | Word commands inside real Word Desktop                                |
+| **E2E (Outlook)** | Mocha      | `tests-e2e-outlook/` | ~9    | Outlook commands (requires Exchange sideloading approval)             |
+| ~~Unit~~          | ~~Vitest~~ | ~~`tests/unit/`~~    |       | ~~DO NOT ADD NEW UNIT TESTS~~                                         |
 
 ### Required Test Execution After Any Code Change
 
 **ALWAYS run integration and E2E tests after making code changes — these are the only tests that matter:**
 
 2. `npm run test:integration` — integration tests via `--project integration` (**ALL must pass — 0 failures is the only acceptable result**)
-2. `npm run test:e2e` — E2E tests inside real Excel Desktop (requires `npm run start:desktop` first; **must pass before marking work complete**)
-3. `npm run test:e2e:ppt` — E2E tests inside real PowerPoint Desktop (requires PPT open; **must pass before marking PPT work complete**)
-4. `npm run test:e2e:word` — E2E tests inside real Word Desktop (requires Word open; **must pass before marking Word work complete**)
-5. `npm run test:e2e:outlook` — E2E tests inside real Outlook Desktop (requires Exchange sideloading approval; blocked on tenants with policy restrictions — flag as blocker if unavailable)
-6. `npm run test:ui` — Playwright UI tests when task pane flows are changed
+3. `npm run test:e2e` — E2E tests inside real Excel Desktop (requires `npm run start:desktop` first; **must pass before marking work complete**)
+4. `npm run test:e2e:ppt` — E2E tests inside real PowerPoint Desktop (requires PPT open; **must pass before marking PPT work complete**)
+5. `npm run test:e2e:word` — E2E tests inside real Word Desktop (requires Word open; **must pass before marking Word work complete**)
+6. `npm run test:e2e:outlook` — E2E tests inside real Outlook Desktop (requires Exchange sideloading approval; blocked on tenants with policy restrictions — flag as blocker if unavailable)
+7. `npm run test:ui` — Playwright UI tests when task pane flows are changed
 
 **Never consider work done until integration and E2E tests pass for the affected host(s).** If live Copilot WebSocket tests fail because the dev server is not running, start `npm run dev` as a background process and re-run — do not skip or report as blocked. If E2E tests cannot be run (Office app not open), explicitly flag this as a blocker to the user — do not silently skip them.
 
@@ -179,6 +180,7 @@ The task pane is split into three areas:
 > Run `npm run dev` as a background process, wait for `https://localhost:3000` to be ready, then re-run the failing tests. Only after the server is up and the tests still fail should you escalate to the user.
 >
 > Dev server start sequence:
+>
 > 1. Start `npm run dev` in the background (it binds to `https://localhost:3000`)
 > 2. Poll or wait ~10 s for `Copilot Office Add-in server running on https://localhost:3000`
 > 3. Re-run the affected tests
@@ -190,45 +192,46 @@ The task pane is split into three areas:
 
 > `tests/unit/` is **empty** — all logic has been migrated to `tests/integration/`. There are no unit tests in this codebase.
 
-### Current Integration Test Files (35)
+### Current Integration Test Files (40)
 
-| File                                    | Category                            | Requires server? |
-| --------------------------------------- | ----------------------------------- | ---------------- |
-| `agent-manager-dialog.test.tsx`         | Component wiring                    | No               |
-| `agent-picker.test.tsx`                 | Component wiring                    | No               |
-| `agent-service.test.ts`                 | Agent service + frontmatter parsing | No               |
-| `app-error-boundary.test.tsx`           | Component wiring                    | No               |
-| `app-session-error.test.tsx`            | Component wiring                    | No               |
-| `app-state.test.tsx`                    | Component wiring                    | No               |
-| `chat-error-boundary.test.tsx`          | Component wiring                    | No               |
-| `chat-header-settings-flow.test.tsx`    | Component wiring                    | No               |
-| `chat-panel.test.tsx`                   | Component wiring                    | No               |
-| `chat-store.test.ts`                    | Chat message store                  | No               |
-| `copilot-custom-agent.integration.test.ts` | Live Copilot custom agent + skills | Yes (fails without server) |
-| `copilot-websocket.integration.test.ts` | Live Copilot WebSocket E2E          | Yes (fails without server) |
-| `excel-tools.test.ts`                   | Tool schema + factory (Excel)       | No               |
-| `host-tools-limit.test.ts`              | Host tool count limits              | No               |
-| `humanize-tool-name.test.ts`            | Tool-name → human-readable labels   | No               |
-| `id.test.ts`                            | `generateId` utility                | No               |
-| `management-tools.test.ts`              | Management tool schemas + handlers  | No               |
-| `manifest.test.ts`                      | Office manifest / host assumptions  | No               |
-| `mcp-manager-dialog.test.tsx`           | Component wiring                    | No               |
-| `mcp-service.test.ts`                   | MCP server config parsing           | No               |
-| `model-manager.test.tsx`                | Component wiring                    | No               |
-| `model-picker-interactions.test.tsx`    | Component wiring                    | No               |
-| `office-storage.test.ts`                | `officeStorage` with OfficeRuntime  | No               |
-| `powerpoint-tools.test.ts`              | Tool schema + factory (PPT)         | No               |
-| `settings-dialog.test.tsx`              | Component wiring                    | No               |
-| `settings-store.test.ts`                | Zustand store (model/agent/skills)  | No               |
-| `skill-manager-dialog.test.tsx`         | Component wiring                    | No               |
-| `skill-picker.test.tsx`                 | Component wiring                    | No               |
-| `skill-service.test.ts`                 | Skill service + context building    | No               |
-| `stale-state.test.tsx`                  | Store hydration                     | No               |
-| `use-office-chat.test.tsx`              | useOfficeChat hook                  | No               |
-| `use-tool-invocations-patch.test.tsx`   | Tool invocation argument streaming  | No               |
-| `word-tools.test.ts`                    | Tool schema + factory (Word)        | No               |
-| `zip-export-service.test.ts`            | ZIP export service                  | No               |
-| `zip-import-service.test.ts`            | ZIP import service                  | No               |
+| File                                       | Category                            | Requires server?           |
+| ------------------------------------------ | ----------------------------------- | -------------------------- |
+| `agent-manager-dialog.test.tsx`            | Component wiring                    | No                         |
+| `agent-picker.test.tsx`                    | Component wiring                    | No                         |
+| `agent-service.test.ts`                    | Agent service + frontmatter parsing | No                         |
+| `app-error-boundary.test.tsx`              | Component wiring                    | No                         |
+| `app-session-error.test.tsx`               | Component wiring                    | No                         |
+| `app-state.test.tsx`                       | Component wiring                    | No                         |
+| `chat-error-boundary.test.tsx`             | Component wiring                    | No                         |
+| `chat-header-settings-flow.test.tsx`       | Component wiring                    | No                         |
+| `chat-panel.test.tsx`                      | Component wiring                    | No                         |
+| `chat-store.test.ts`                       | Chat message store                  | No                         |
+| `copilot-custom-agent.integration.test.ts` | Live Copilot custom agent + skills  | Yes (fails without server) |
+| `copilot-websocket.integration.test.ts`    | Live Copilot WebSocket E2E          | Yes (fails without server) |
+| `excel-tools.test.ts`                      | Tool schema + factory (Excel)       | No                         |
+| `host-tools-limit.test.ts`                 | Host tool count limits              | No                         |
+| `humanize-tool-name.test.ts`               | Tool-name → human-readable labels   | No                         |
+| `id.test.ts`                               | `generateId` utility                | No                         |
+| `management-tools.test.ts`                 | Management tool schemas + handlers  | No                         |
+| `manifest.test.ts`                         | Office manifest / host assumptions  | No                         |
+| `mcp-manager-dialog.test.tsx`              | Component wiring                    | No                         |
+| `mcp-service.test.ts`                      | MCP server config parsing           | No                         |
+| `model-manager.test.tsx`                   | Component wiring                    | No                         |
+| `model-picker-interactions.test.tsx`       | Component wiring                    | No                         |
+| `office-storage.test.ts`                   | `officeStorage` with OfficeRuntime  | No                         |
+| `powerpoint-tools.test.ts`                 | Tool schema + factory (PPT)         | No                         |
+| `settings-dialog.test.tsx`                 | Component wiring                    | No                         |
+| `settings-store.test.ts`                   | Zustand store (model/agent/skills)  | No                         |
+| `skill-manager-dialog.test.tsx`            | Component wiring                    | No                         |
+| `skill-picker.test.tsx`                    | Component wiring                    | No                         |
+| `skill-service.test.ts`                    | Skill service + context building    | No                         |
+| `stale-state.test.tsx`                     | Store hydration                     | No                         |
+| `thread-message-rendering.test.tsx`        | Component wiring                    | No                         |
+| `use-office-chat.test.tsx`                 | useOfficeChat hook                  | No                         |
+| `use-tool-invocations-patch.test.tsx`      | Tool invocation argument streaming  | No                         |
+| `word-tools.test.ts`                       | Tool schema + factory (Word)        | No                         |
+| `zip-export-service.test.ts`               | ZIP export service                  | No                         |
+| `zip-import-service.test.ts`               | ZIP import service                  | No                         |
 
 ### Integration Test Categories
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "office-coding-agent",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "office-coding-agent",
-      "version": "0.2.1",
+      "version": "0.3.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -20,6 +20,7 @@
         "@radix-ui/react-slot": "^1.2.4",
         "@radix-ui/react-tooltip": "^1.2.8",
         "@types/office-runtime": "^1.0.35",
+        "@vscode/codicons": "^0.0.44",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "cors": "^2.8.6",
@@ -8536,6 +8537,12 @@
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
+    },
+    "node_modules/@vscode/codicons": {
+      "version": "0.0.44",
+      "resolved": "https://registry.npmjs.org/@vscode/codicons/-/codicons-0.0.44.tgz",
+      "integrity": "sha512-F7qPRumUK3EHjNdopfICLGRf3iNPoZQt+McTHAn4AlOWPB3W2kL4H0S7uqEqbyZ6rCxaeDjpAn3MCUnwTu/VJQ==",
+      "license": "CC-BY-4.0"
     },
     "node_modules/@xmldom/xmldom": {
       "version": "0.8.11",

--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "@radix-ui/react-slot": "^1.2.4",
     "@radix-ui/react-tooltip": "^1.2.8",
     "@types/office-runtime": "^1.0.35",
+    "@vscode/codicons": "^0.0.44",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cors": "^2.8.6",

--- a/src/components/AgentPicker.tsx
+++ b/src/components/AgentPicker.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import * as Popover from '@radix-ui/react-popover';
-import { Bot, Check, ChevronDown } from 'lucide-react';
+import { Check } from 'lucide-react';
+import { Codicon } from '@/components/Codicon';
 import { cn } from '@/lib/utils';
 import { useSettingsStore } from '@/stores';
 import {
@@ -21,7 +22,10 @@ export const AgentPicker: React.FC<AgentPickerProps> = ({ onOpenPanel }) => {
   const setActiveAgent = useSettingsStore(s => s.setActiveAgent);
 
   const host = detectOfficeHost();
-  const targetHost = host === 'excel' || host === 'powerpoint' ? host : undefined;
+  const targetHost =
+    host === 'excel' || host === 'powerpoint' || host === 'word' || host === 'outlook'
+      ? host
+      : undefined;
   const allAgents = getAgents(host);
   const bundledAgents = targetHost
     ? getBundledAgents().filter(agent => agent.metadata.hosts.includes(targetHost))
@@ -35,8 +39,10 @@ export const AgentPicker: React.FC<AgentPickerProps> = ({ onOpenPanel }) => {
   const activeAgent = resolveActiveAgent(activeAgentId, host);
   const displayName = activeAgent?.metadata.name ?? allAgents[0].metadata.name;
 
+  const resolvedName = activeAgent?.metadata.name ?? null;
+
   const renderAgentOption = (agentName: string, agentDescription: string) => {
-    const isActive = agentName === activeAgentId;
+    const isActive = agentName === resolvedName;
 
     return (
       <button
@@ -66,13 +72,11 @@ export const AgentPicker: React.FC<AgentPickerProps> = ({ onOpenPanel }) => {
       <Popover.Root open={open} onOpenChange={setOpen}>
         <Popover.Trigger asChild>
           <button
-            className="inline-flex items-center gap-1.5 rounded-full border border-border/60 py-0.5 pl-1.5 pr-2 text-xs text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground"
+            className="relative inline-flex h-7 w-7 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground"
             aria-label="Select agent"
-            title="Select agent"
+            title={`Agent: ${displayName}`}
           >
-            <Bot className="size-3 shrink-0" />
-            <span className="max-w-[80px] truncate">{displayName}</span>
-            <ChevronDown className="size-3 shrink-0 opacity-50" />
+            <Codicon name="robot" className="text-base" />
           </button>
         </Popover.Trigger>
 

--- a/src/components/ChatHeader.tsx
+++ b/src/components/ChatHeader.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
-import { RotateCcw, Shield } from 'lucide-react';
 import { SessionHistoryPicker } from './SessionHistoryPicker';
+import { SkillPicker } from './SkillPicker';
+import { Codicon } from '@/components/Codicon';
 import type { SessionHistoryItem } from '@/stores/sessionHistoryStore';
 import type { OfficeHostApp } from '@/services/office/host';
 
@@ -36,13 +37,14 @@ export const ChatHeader: React.FC<ChatHeaderProps> = ({
       </div>
 
       <div className="flex items-center gap-0.5">
+        <SkillPicker onOpenPanel={onOpenPanel} />
         <button
           onClick={() => onOpenPanel?.('permissions')}
           className="inline-flex h-8 w-8 items-center justify-center rounded-md text-muted-foreground hover:bg-accent hover:text-accent-foreground transition-colors"
           aria-label="Permissions"
           title="Permissions"
         >
-          <Shield className="size-4" />
+          <Codicon name="shield" className="text-base" />
         </button>
         <button
           onClick={onClearMessages}
@@ -50,7 +52,7 @@ export const ChatHeader: React.FC<ChatHeaderProps> = ({
           aria-label="New conversation"
           title="New conversation"
         >
-          <RotateCcw className="size-4" />
+          <Codicon name="comment-add" className="text-base" />
         </button>
       </div>
     </div>

--- a/src/components/ChatPanel.tsx
+++ b/src/components/ChatPanel.tsx
@@ -1,40 +1,23 @@
 import React from 'react';
-import { Server } from 'lucide-react';
+import { Codicon } from '@/components/Codicon';
 import { Thread } from '@/components/assistant-ui/thread';
 import { AgentPicker } from './AgentPicker';
 import { ModelPicker } from './ModelPicker';
-import { SkillPicker } from './SkillPicker';
-import { useSettingsStore } from '@/stores';
-import { BUNDLED_MCP_SERVERS } from '@/types';
 
 interface ChatPanelProps {
   onOpenPanel?: (panel: string) => void;
 }
 
-/** VS Code-style "Tools N" pill — shows active MCP server count, opens MCP panel. */
+/** VS Code-style icon-only tools button. */
 const McpPill: React.FC<{ onOpenPanel?: (panel: string) => void }> = ({ onOpenPanel }) => {
-  const activeMcpServerNames = useSettingsStore(s => s.activeMcpServerNames);
-  const importedMcpServers = useSettingsStore(s => s.importedMcpServers);
-
-  const allServers = [...BUNDLED_MCP_SERVERS, ...importedMcpServers];
-  const activeCount = allServers.filter(
-    s => activeMcpServerNames === null || activeMcpServerNames.includes(s.name)
-  ).length;
-
   return (
     <button
       onClick={() => onOpenPanel?.('mcp')}
-      className="inline-flex items-center gap-1.5 rounded-full border border-border/60 py-0.5 pl-1.5 pr-2 text-xs text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground"
+      className="relative inline-flex h-7 w-7 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground"
       aria-label="MCP Tools"
       title="MCP Servers"
     >
-      <Server className="size-3 shrink-0" />
-      <span>Tools</span>
-      {activeCount > 0 && (
-        <span className="min-w-[14px] rounded-full bg-muted px-1 text-center text-[10px] tabular-nums text-muted-foreground">
-          {activeCount}
-        </span>
-      )}
+      <Codicon name="extensions" className="text-base" />
     </button>
   );
 };
@@ -46,11 +29,10 @@ export const ChatPanel: React.FC<ChatPanelProps> = ({ onOpenPanel }) => {
         leftToolbar={
           <>
             <AgentPicker onOpenPanel={onOpenPanel} />
-            <SkillPicker onOpenPanel={onOpenPanel} />
-            <McpPill onOpenPanel={onOpenPanel} />
+            <ModelPicker />
           </>
         }
-        rightToolbar={<ModelPicker />}
+        rightToolbar={<McpPill onOpenPanel={onOpenPanel} />}
       />
     </div>
   );

--- a/src/components/Codicon.tsx
+++ b/src/components/Codicon.tsx
@@ -1,0 +1,22 @@
+/**
+ * Thin wrapper around @vscode/codicons icon font.
+ *
+ * Usage:  <Codicon name="robot" className="text-base" />
+ *
+ * Icon names: https://microsoft.github.io/vscode-codicons/dist/codicon.html
+ */
+import React from 'react';
+import { cn } from '@/lib/utils';
+
+interface CodiconProps {
+  /** Codicon name without the "codicon-" prefix, e.g. "robot", "extensions", "lightbulb-sparkle" */
+  name: string;
+  className?: string;
+  'aria-hidden'?: boolean;
+}
+
+export const Codicon: React.FC<CodiconProps> = ({
+  name,
+  className,
+  'aria-hidden': ariaHidden = true,
+}) => <i className={cn(`codicon codicon-${name}`, className)} aria-hidden={ariaHidden} />;

--- a/src/components/McpManagerDialog.tsx
+++ b/src/components/McpManagerDialog.tsx
@@ -49,6 +49,7 @@ export const McpManagerPanel: React.FC = () => {
   const [expandedTools, setExpandedTools] = useState<Set<string>>(new Set());
   const [logServer, setLogServer] = useState<string | null>(null);
   const inputRef = useRef<HTMLInputElement>(null);
+  const restartTimerRef = useRef<Record<string, ReturnType<typeof setTimeout>>>({});
 
   const importedMcpServers = useSettingsStore(s => s.importedMcpServers);
   const activeMcpServerNames = useSettingsStore(s => s.activeMcpServerNames);
@@ -296,9 +297,13 @@ export const McpManagerPanel: React.FC = () => {
                     {isServerActive(server.name) && (
                       <button
                         onClick={() => {
+                          // Guard against double-click: skip if a restart is already pending
+                          if (restartTimerRef.current[server.name]) return;
                           toggleMcpServer(server.name);
-                          // Brief delay to allow the server to stop before restarting
-                          setTimeout(() => toggleMcpServer(server.name), 150);
+                          restartTimerRef.current[server.name] = setTimeout(() => {
+                            toggleMcpServer(server.name);
+                            delete restartTimerRef.current[server.name];
+                          }, 200);
                         }}
                         className="inline-flex h-6 w-6 items-center justify-center rounded text-muted-foreground hover:bg-accent hover:text-accent-foreground"
                         title="Restart"

--- a/src/components/PermissionManagerDialog.tsx
+++ b/src/components/PermissionManagerDialog.tsx
@@ -39,6 +39,9 @@ export const PermissionManagerPanel: React.FC = () => {
       setBrowsePath(data.path);
       setBrowseParent(data.parent);
       setBrowseDirs(data.dirs ?? []);
+    } catch {
+      // Network error — clear stale directories so the UI doesn't show old data
+      setBrowseDirs([]);
     } finally {
       setBrowseLoading(false);
     }
@@ -50,9 +53,14 @@ export const PermissionManagerPanel: React.FC = () => {
       return;
     }
     void (async () => {
-      const response = await fetch('/api/env');
-      const data = (await response.json()) as { cwd?: string; home?: string };
-      void loadDir(data.cwd ?? data.home);
+      try {
+        const response = await fetch('/api/env');
+        const data = (await response.json()) as { cwd?: string; home?: string };
+        void loadDir(data.cwd ?? data.home);
+      } catch {
+        // Server unavailable — load root or leave empty
+        void loadDir();
+      }
     })();
   }, [workingDirectory]);
 

--- a/src/components/SessionHistoryPicker.tsx
+++ b/src/components/SessionHistoryPicker.tsx
@@ -1,6 +1,7 @@
 import React, { useMemo, useState } from 'react';
 import * as Popover from '@radix-ui/react-popover';
 import { History, ChevronDown, Trash2 } from 'lucide-react';
+import { cn } from '@/lib/utils';
 import type { SessionHistoryItem } from '@/stores/sessionHistoryStore';
 
 interface SessionHistoryPickerProps {
@@ -80,7 +81,10 @@ export const SessionHistoryPicker: React.FC<SessionHistoryPickerProps> = ({
                         onRestoreSession(session.id);
                         setOpen(false);
                       }}
-                      className={isActive ? 'font-medium text-foreground' : 'text-foreground'}
+                      className={cn(
+                        'w-full truncate text-left',
+                        isActive ? 'font-medium text-foreground' : 'text-foreground'
+                      )}
                     >
                       {session.title}
                     </button>

--- a/src/components/SkillPicker.tsx
+++ b/src/components/SkillPicker.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import * as Popover from '@radix-ui/react-popover';
-import { BrainCircuit, Check, Square, ChevronDown } from 'lucide-react';
+import { Check, Square } from 'lucide-react';
+import { Codicon } from '@/components/Codicon';
 import { cn } from '@/lib/utils';
 import { useSettingsStore } from '@/stores';
 import { getBundledSkills, getImportedSkills, getSkills } from '@/services/skills';
@@ -69,18 +70,16 @@ export const SkillPicker: React.FC<SkillPickerProps> = ({ onOpenPanel }) => {
       <Popover.Root open={open} onOpenChange={setOpen}>
         <Popover.Trigger asChild>
           <button
-            className="inline-flex items-center gap-1.5 rounded-full border border-border/60 py-0.5 pl-1.5 pr-2 text-xs text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground"
+            className="relative inline-flex h-8 w-8 items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground"
             aria-label="Agent skills"
             title="Agent skills"
           >
-            <BrainCircuit className="size-3 shrink-0" />
-            <span>Skills</span>
+            <Codicon name="lightbulb-sparkle" className="text-base" />
             {activeCount > 0 && activeSkillNames !== null && (
-              <span className="min-w-[14px] rounded-full bg-muted px-1 text-center text-[10px] tabular-nums text-muted-foreground">
+              <span className="absolute -top-0.5 -right-0.5 flex h-3.5 min-w-[14px] items-center justify-center rounded-full bg-primary px-0.5 text-[9px] font-medium tabular-nums text-primary-foreground">
                 {activeCount}
               </span>
             )}
-            <ChevronDown className="size-3 shrink-0 opacity-50" />
           </button>
         </Popover.Trigger>
 

--- a/src/components/SlidePanel.tsx
+++ b/src/components/SlidePanel.tsx
@@ -81,6 +81,17 @@ export const SlidePanel: React.FC<SlidePanelProps> = ({
     }
   }, []);
 
+  // Sync the `inert` attribute imperatively — React 18 strips unknown HTML attrs
+  useEffect(() => {
+    const el = panelRef.current;
+    if (!el) return;
+    if (!open) {
+      el.setAttribute('inert', '');
+    } else {
+      el.removeAttribute('inert');
+    }
+  }, [open]);
+
   return (
     <div
       ref={panelRef}

--- a/src/components/assistant-ui/markdown-text.tsx
+++ b/src/components/assistant-ui/markdown-text.tsx
@@ -213,13 +213,12 @@ const defaultComponents = memoizeMarkdownComponents({
     <hr className={cn('aui-md-hr my-2 border-muted-foreground/20', className)} {...props} />
   ),
   table: ({ className, ...props }) => (
-    <table
-      className={cn(
-        'aui-md-table my-2 w-full border-separate border-spacing-0 overflow-y-auto',
-        className
-      )}
-      {...props}
-    />
+    <div className="my-2 overflow-x-auto">
+      <table
+        className={cn('aui-md-table w-full border-separate border-spacing-0', className)}
+        {...props}
+      />
+    </div>
   ),
   th: ({ className, ...props }) => (
     <th

--- a/src/components/assistant-ui/thread.tsx
+++ b/src/components/assistant-ui/thread.tsx
@@ -2,13 +2,15 @@ import { MarkdownText } from '@/components/assistant-ui/markdown-text';
 import { ToolFallback } from '@/components/assistant-ui/tool-fallback';
 import { TooltipIconButton } from '@/components/assistant-ui/tooltip-icon-button';
 import {
+  ActionBarPrimitive,
   AuiIf,
   ComposerPrimitive,
   ErrorPrimitive,
   MessagePrimitive,
   ThreadPrimitive,
 } from '@assistant-ui/react';
-import { ArrowDownIcon, ArrowUpIcon, CircleStop, LoaderIcon, SparklesIcon } from 'lucide-react';
+import { ArrowDownIcon, CircleStop, LoaderIcon, SparklesIcon } from 'lucide-react';
+import { Codicon } from '@/components/Codicon';
 import type { FC, ReactNode } from 'react';
 import { useThinkingText } from '@/contexts/ThinkingContext';
 
@@ -32,6 +34,8 @@ export const Thread: FC<{ leftToolbar?: ReactNode; rightToolbar?: ReactNode }> =
             AssistantMessage,
           }}
         />
+
+        <ThreadLevelThinkingIndicator />
 
         <ThreadPrimitive.ViewportFooter className="aui-thread-viewport-footer sticky bottom-0 mt-auto flex w-full flex-col gap-3 overflow-visible rounded-t-2xl bg-background pb-3">
           <ThreadScrollToBottom />
@@ -123,10 +127,10 @@ const Composer: FC<{ leftToolbar?: ReactNode; rightToolbar?: ReactNode }> = ({
             <ComposerPrimitive.Send asChild>
               <TooltipIconButton
                 tooltip="Send"
-                variant="default"
-                className="aui-composer-send size-8 rounded-full p-2 transition-opacity"
+                variant="ghost"
+                className="aui-composer-send h-7 w-7 rounded-md transition-opacity"
               >
-                <ArrowUpIcon />
+                <Codicon name="send" className="text-base" />
               </TooltipIconButton>
             </ComposerPrimitive.Send>
           </AuiIf>
@@ -134,8 +138,8 @@ const Composer: FC<{ leftToolbar?: ReactNode; rightToolbar?: ReactNode }> = ({
             <ComposerPrimitive.Cancel asChild>
               <TooltipIconButton
                 tooltip="Stop"
-                variant="default"
-                className="aui-composer-cancel size-8 rounded-full p-2 transition-opacity"
+                variant="ghost"
+                className="aui-composer-cancel h-7 w-7 rounded-md transition-opacity"
               >
                 <CircleStop className="size-4" />
               </TooltipIconButton>
@@ -157,23 +161,66 @@ const MessageError: FC = () => {
   );
 };
 
-const AssistantThinkingIndicator: FC = () => {
+/**
+ * Thread-level thinking indicator.  Rendered once after ThreadPrimitive.Messages
+ * so it always appears below the last message.  It reads directly from
+ * ThinkingContext — no dependency on the per-message AUI store, which avoids
+ * the timing gap between flushSync renders and the deferred useEffect adapter
+ * sync in useExternalStoreRuntime.
+ */
+const ThreadLevelThinkingIndicator: FC = () => {
   const thinkingText = useThinkingText();
   if (thinkingText === null) return null;
   return (
-    <AuiIf condition={s => s.message.status?.type === 'running'}>
-      <div className="aui-assistant-thinking-indicator fade-in animate-in duration-150 mt-1 flex items-center gap-2 px-1 text-muted-foreground text-sm">
-        <LoaderIcon className="size-3.5 animate-spin" />
-        <span className="animate-pulse">{thinkingText}</span>
-      </div>
-    </AuiIf>
+    <div className="aui-assistant-thinking-indicator fade-in animate-in duration-150 mt-1 flex items-center gap-2 px-4 py-2 text-muted-foreground text-sm">
+      <LoaderIcon className="size-3.5 animate-spin" />
+      <span className="animate-pulse">{thinkingText}</span>
+    </div>
+  );
+};
+
+const AssistantActionBar: FC = () => {
+  return (
+    <ActionBarPrimitive.Root
+      hideWhenRunning
+      autohide="not-last"
+      className="aui-assistant-action-bar flex items-center gap-0.5 mt-1 opacity-0 transition-opacity duration-150 group-hover/message:opacity-100 data-[floating]:absolute data-[floating]:-bottom-2 data-[floating]:right-0"
+    >
+      <ActionBarPrimitive.Copy asChild>
+        <TooltipIconButton
+          tooltip="Copy"
+          variant="ghost"
+          className="h-6 w-6 rounded text-muted-foreground/60 hover:text-muted-foreground"
+        >
+          <Codicon name="copy" className="text-sm" />
+        </TooltipIconButton>
+      </ActionBarPrimitive.Copy>
+      <ActionBarPrimitive.FeedbackPositive asChild>
+        <TooltipIconButton
+          tooltip="Good response"
+          variant="ghost"
+          className="h-6 w-6 rounded text-muted-foreground/60 hover:text-muted-foreground"
+        >
+          <Codicon name="thumbsup" className="text-sm" />
+        </TooltipIconButton>
+      </ActionBarPrimitive.FeedbackPositive>
+      <ActionBarPrimitive.FeedbackNegative asChild>
+        <TooltipIconButton
+          tooltip="Bad response"
+          variant="ghost"
+          className="h-6 w-6 rounded text-muted-foreground/60 hover:text-muted-foreground"
+        >
+          <Codicon name="thumbsdown" className="text-sm" />
+        </TooltipIconButton>
+      </ActionBarPrimitive.FeedbackNegative>
+    </ActionBarPrimitive.Root>
   );
 };
 
 const AssistantMessage: FC = () => {
   return (
     <MessagePrimitive.Root
-      className="aui-assistant-message-root fade-in slide-in-from-bottom-1 relative w-full animate-in py-3 duration-150"
+      className="aui-assistant-message-root group/message fade-in slide-in-from-bottom-1 relative w-full animate-in py-3 duration-150"
       data-role="assistant"
     >
       <div className="aui-assistant-message-content wrap-break-word px-1 text-foreground text-sm leading-relaxed">
@@ -181,9 +228,15 @@ const AssistantMessage: FC = () => {
           components={{
             Text: MarkdownText,
             tools: { Fallback: ToolFallback },
+            // Prevent EmptyPartFallback from rendering MarkdownText outside a valid
+            // part context — this avoids the "MessagePartText can only be used inside
+            // text or reasoning message parts" crash when the message has 0 parts or
+            // ends in a tool-call / source part.
+            Empty: () => null,
           }}
+          unstable_showEmptyOnNonTextEnd={false}
         />
-        <AssistantThinkingIndicator />
+        <AssistantActionBar />
         <MessageError />
       </div>
     </MessagePrimitive.Root>

--- a/src/copilotProxy.mjs
+++ b/src/copilotProxy.mjs
@@ -461,7 +461,11 @@ async function handleConnection(ws) {
           }
           // Emit error status for all MCP servers
           for (const name of mcpServerNames) {
-            sendNotification('mcp.status', { server: name, status: 'error', error: err.message || 'Session creation failed' });
+            sendNotification('mcp.status', {
+              server: name,
+              status: 'error',
+              error: err.message || 'Session creation failed',
+            });
             sendNotification('mcp.log', {
               server: name,
               timestamp: new Date().toISOString(),
@@ -614,7 +618,10 @@ async function handleConnection(ws) {
 
   // ── Cleanup ─────────────────────────────────────────────────────────────
 
+  let _cleaned = false;
   async function cleanup() {
+    if (_cleaned) return;
+    _cleaned = true;
     _activeConnections--;
     for (const unsub of eventUnsubs.values()) {
       unsub();

--- a/src/hooks/useOfficeChat.ts
+++ b/src/hooks/useOfficeChat.ts
@@ -307,6 +307,7 @@ export function useOfficeChat(host: OfficeHostApp) {
     importedMcpServers,
     activeMcpServerNames,
     evaluatePermission,
+    npmSkillPackages,
   ]);
 
   useEffect(() => {
@@ -454,9 +455,10 @@ export function useOfficeChat(host: OfficeHostApp) {
           )
             ? ('deep' as const)
             : ('fast' as const);
+        const currentModelForDoc = useSettingsStore.getState().activeModel;
         await orchestrateDocument(
           client,
-          activeModel,
+          currentModelForDoc,
           userText,
           {
             onPlan: () => {
@@ -539,9 +541,10 @@ export function useOfficeChat(host: OfficeHostApp) {
         const deckMode = /\b(deep|detail|qualit)/i.test(userText)
           ? ('deep' as const)
           : ('fast' as const);
+        const currentModelForDeck = useSettingsStore.getState().activeModel;
         await orchestrateDeck(
           client,
-          activeModel,
+          currentModelForDeck,
           userText,
           {
             onPlan: () => {
@@ -592,7 +595,7 @@ export function useOfficeChat(host: OfficeHostApp) {
     const assistantMsg: ThreadMessageLike = {
       id: assistantId,
       role: 'assistant',
-      content: [{ type: 'text', text: '' }],
+      content: [],
       status: { type: 'running' },
       createdAt: new Date(),
     };
@@ -619,18 +622,26 @@ export function useOfficeChat(host: OfficeHostApp) {
     const updateAssistant = (extra?: Partial<Pick<ThreadMessageLike, 'status'>>) => {
       const content: ThreadMessageLike['content'] = [
         ...Array.from(toolParts.values()),
-        { type: 'text', text: streamText },
+        // Only append a text part when there is actual text — the
+        // external-store adapter's fromThreadMessageLike() silently strips
+        // empty text parts (text.trim().length === 0 → null → filtered).
+        // Sending an empty text part causes a 0-part message or a message
+        // that ends on a tool-call part, which can trigger the
+        // "MessagePartText can only be used inside text or reasoning
+        // message parts" crash in @assistant-ui/react-markdown.
+        ...(streamText ? [{ type: 'text' as const, text: streamText }] : []),
       ];
       setMessages(prev => prev.map(m => (m.id === assistantId ? { ...m, content, ...extra } : m)));
     };
 
+    // Stale-response watchdog: if no event arrives within 30s, warn the user.
+    // Reset on every event; cleared when the stream ends.
+    // Declared outside `try` so the `finally` block can clear it.
+    const STALE_TIMEOUT = 30_000;
+    let staleTimer: ReturnType<typeof setTimeout> | null = null;
+
     try {
       const session = sessionRef.current;
-
-      // Stale-response watchdog: if no event arrives within 30s, warn the user.
-      // Reset on every event; cleared when the stream ends.
-      const STALE_TIMEOUT = 30_000;
-      let staleTimer: ReturnType<typeof setTimeout> | null = null;
       const resetStaleTimer = () => {
         if (staleTimer) clearTimeout(staleTimer);
         staleTimer = setTimeout(() => {
@@ -698,7 +709,6 @@ export function useOfficeChat(host: OfficeHostApp) {
           break;
         }
       }
-      if (staleTimer) clearTimeout(staleTimer);
     } catch (err) {
       const errMsg = err instanceof Error ? err.message : String(err);
       // Auto-reconnect if the Copilot session was lost (e.g. proxy restart, laptop sleep)
@@ -730,6 +740,7 @@ export function useOfficeChat(host: OfficeHostApp) {
         );
       }
     } finally {
+      if (staleTimer) clearTimeout(staleTimer);
       setThinkingText(null);
       setIsRunning(false);
     }
@@ -814,7 +825,9 @@ export function useOfficeChat(host: OfficeHostApp) {
     onNew,
     onCancel: () => {
       cancelRef.current = true;
-      setIsRunning(false);
+      // Do not set isRunning=false here — the streaming loop's `finally` block
+      // handles it after the current iteration actually finishes. Setting it
+      // prematurely causes the UI to show "idle" while events are still processing.
       return Promise.resolve();
     },
     convertMessage: (msg: ThreadMessageLike) => msg,

--- a/src/services/skills/skillService.ts
+++ b/src/services/skills/skillService.ts
@@ -50,7 +50,15 @@ export function parseFrontmatter(raw: string): { metadata: SkillMetadata; conten
       if (currentKey === 'tags') {
         metadata.tags.push(itemValue);
       } else {
-        metadata.hosts.push(itemValue as AgentHost);
+        const lower = itemValue.toLowerCase();
+        if (
+          lower === 'excel' ||
+          lower === 'powerpoint' ||
+          lower === 'word' ||
+          lower === 'outlook'
+        ) {
+          metadata.hosts.push(lower as AgentHost);
+        }
       }
       continue;
     }
@@ -83,7 +91,11 @@ export function parseFrontmatter(raw: string): { metadata: SkillMetadata; conten
       // Could be start of array (tags: / hosts:) — handled by "- " check above
       continue;
     } else if (currentKey === 'hosts') {
-      metadata.hosts = parseInlineArray(value) as AgentHost[];
+      metadata.hosts = parseInlineArray(value)
+        .map(h => h.toLowerCase())
+        .filter(
+          h => h === 'excel' || h === 'powerpoint' || h === 'word' || h === 'outlook'
+        ) as AgentHost[];
     } else {
       setMetadataField(metadata, currentKey, value);
     }

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -223,8 +223,12 @@ export const useSettingsStore = create<SettingsState>()(
         set(state => {
           const current = state.activeMcpServerNames;
           if (current === null) {
-            const allNames = state.importedMcpServers.map(s => s.name);
-            return { activeMcpServerNames: allNames.filter(n => n !== serverName) };
+            const allImported = state.importedMcpServers.map(s => s.name);
+            // If toggling a bundled server (not in imported list), add it to the active list
+            if (!allImported.includes(serverName)) {
+              return { activeMcpServerNames: [...allImported, serverName] };
+            }
+            return { activeMcpServerNames: allImported.filter(n => n !== serverName) };
           }
           const next = current.includes(serverName)
             ? current.filter(n => n !== serverName)

--- a/src/taskpane/index.tsx
+++ b/src/taskpane/index.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { createRoot } from 'react-dom/client';
 import '../styles/globals.css';
+import '@vscode/codicons/dist/codicon.css';
 import { App } from './App';
 
 /* global Office */

--- a/src/utils/toolResultSummary.ts
+++ b/src/utils/toolResultSummary.ts
@@ -6,7 +6,12 @@
 export function toolResultSummary(result: unknown): string {
   if (result === undefined || result === null) return '';
 
-  const str = typeof result === 'string' ? result : JSON.stringify(result);
+  let str: string;
+  try {
+    str = typeof result === 'string' ? result : JSON.stringify(result);
+  } catch {
+    return '';
+  }
   if (!str) return '';
 
   // Try to parse as JSON for structured inspection

--- a/tests-ui/chat/chat-action-bar.spec.ts
+++ b/tests-ui/chat/chat-action-bar.spec.ts
@@ -1,0 +1,167 @@
+/**
+ * Playwright tests for the AssistantMessage action bar.
+ *
+ * Verifies:
+ *  - Copy / thumbsup / thumbsdown buttons appear when hovering over a
+ *    completed assistant message.
+ *  - Clicking the Copy button places the message text on the clipboard.
+ *  - No crash (error boundary) appears after a tool-call-only response that
+ *    has no trailing text part.
+ *
+ * Uses the REAL Copilot API through the dev server (no mocks).
+ * Requires `npm run dev` to be running on https://localhost:3000.
+ */
+
+import { test, expect } from '../fixtures';
+
+const AI_TIMEOUT = 45_000;
+
+/**
+ * Helper: send a prompt, wait for the response to complete, and return the
+ * last assistant message locator.
+ */
+async function sendAndWaitForResponse(page: import('@playwright/test').Page, prompt: string) {
+  const composer = page.getByPlaceholder('Send a message...');
+  await expect(composer).toBeVisible({ timeout: 10_000 });
+  await expect(page.getByText('Connecting to Copilot...')).not.toBeVisible({ timeout: 15_000 });
+  await expect(page.getByText('Connection failed')).not.toBeVisible();
+
+  await composer.fill(prompt);
+  await composer.press('Enter');
+
+  // Wait for the Stop/Cancel button to disappear — response is complete
+  await expect(page.getByRole('button', { name: /^(Stop|Cancel)$/ })).not.toBeVisible({
+    timeout: AI_TIMEOUT,
+  });
+
+  const assistantMsg = page.locator('[data-role="assistant"]').last();
+  await expect(assistantMsg).toBeVisible({ timeout: 5_000 });
+  return assistantMsg;
+}
+
+test.describe('Action bar (live Copilot)', () => {
+  test('copy + thumbsup + thumbsdown buttons appear when hovering over a completed response', async ({
+    configuredTaskpane: page,
+  }) => {
+    test.setTimeout(AI_TIMEOUT + 30_000);
+
+    const assistantMsg = await sendAndWaitForResponse(page, 'Reply with exactly one word: READY');
+
+    // Hover over the assistant message to reveal the action bar
+    await assistantMsg.hover();
+
+    const actionBar = assistantMsg.locator('.aui-assistant-action-bar');
+    await expect(actionBar).toBeVisible({ timeout: 3_000 });
+
+    // All three action buttons must be visible
+    await expect(page.getByRole('button', { name: 'Copy' })).toBeVisible({ timeout: 3_000 });
+    await expect(page.getByRole('button', { name: 'Good response' })).toBeVisible({
+      timeout: 3_000,
+    });
+    await expect(page.getByRole('button', { name: 'Bad response' })).toBeVisible({
+      timeout: 3_000,
+    });
+  });
+
+  test('action bar is hidden before hover (opacity-0 class set)', async ({
+    configuredTaskpane: page,
+  }) => {
+    test.setTimeout(AI_TIMEOUT + 30_000);
+
+    const assistantMsg = await sendAndWaitForResponse(page, 'Reply with exactly one word: CHECK');
+
+    const actionBar = assistantMsg.locator('.aui-assistant-action-bar');
+
+    // Without hovering, the action bar should be in the DOM but invisible
+    await expect(actionBar).toBeAttached({ timeout: 3_000 });
+    await expect(actionBar).toHaveClass(/opacity-0/);
+  });
+
+  test('clicking Copy puts the response text on the clipboard', async ({
+    configuredTaskpane: page,
+  }) => {
+    test.setTimeout(AI_TIMEOUT + 30_000);
+
+    // Grant clipboard-read permission for this context
+    await page.context().grantPermissions(['clipboard-read', 'clipboard-write']);
+
+    const assistantMsg = await sendAndWaitForResponse(
+      page,
+      'Reply with exactly one word: CLIPBOARD'
+    );
+
+    // Hover to reveal the action bar, then click Copy
+    await assistantMsg.hover();
+    await expect(page.getByRole('button', { name: 'Copy' })).toBeVisible({ timeout: 3_000 });
+    await page.getByRole('button', { name: 'Copy' }).click();
+
+    // Clipboard should contain a non-empty string from the response
+    const clipText = await page.evaluate(() => navigator.clipboard.readText());
+    expect(clipText.trim().length).toBeGreaterThan(0);
+  });
+
+  test('no error boundary appears after a tool-call-only response (crash regression)', async ({
+    configuredTaskpane: page,
+  }) => {
+    test.setTimeout(AI_TIMEOUT + 30_000);
+
+    // This prompt triggers manage_skills (a pure tool call).
+    // Some Copilot responses end with the tool result and no trailing text
+    // part — this was the scenario that caused the "MessagePartText can only
+    // be used inside text or reasoning message parts" crash.
+    const composer = page.getByPlaceholder('Send a message...');
+    await expect(composer).toBeVisible({ timeout: 10_000 });
+    await expect(page.getByText('Connecting to Copilot...')).not.toBeVisible({ timeout: 15_000 });
+
+    await composer.fill(
+      'Use the manage_skills tool with action "list". Only call the tool, do not add any text response after it.'
+    );
+    await composer.press('Enter');
+
+    // Wait for response to complete
+    await expect(page.getByRole('button', { name: /^(Stop|Cancel)$/ })).not.toBeVisible({
+      timeout: AI_TIMEOUT,
+    });
+
+    // Critical: error boundary must not have triggered
+    await expect(page.getByText(/something went wrong/i)).not.toBeVisible({ timeout: 2_000 });
+    await expect(page.getByText(/MessagePartText can only/i)).not.toBeVisible({ timeout: 2_000 });
+
+    // The thread is still functional — composer is visible
+    await expect(page.getByPlaceholder('Send a message...')).toBeVisible({ timeout: 3_000 });
+  });
+
+  test('action bar is not shown while a response is streaming (hideWhenRunning)', async ({
+    configuredTaskpane: page,
+  }) => {
+    test.setTimeout(AI_TIMEOUT + 30_000);
+
+    const composer = page.getByPlaceholder('Send a message...');
+    await expect(composer).toBeVisible({ timeout: 10_000 });
+    await expect(page.getByText('Connecting to Copilot...')).not.toBeVisible({ timeout: 15_000 });
+
+    await composer.fill('Count from 1 to 5, one number per line.');
+    await composer.press('Enter');
+
+    // While streaming: the Stop/Cancel button is visible
+    const stopBtn = page.getByRole('button', { name: /^(Stop|Cancel)$/ });
+    await expect(stopBtn).toBeVisible({ timeout: 10_000 });
+
+    // While running, hover over the in-progress assistant message
+    const assistantMsg = page.locator('[data-role="assistant"]').last();
+    if (await assistantMsg.isVisible()) {
+      await assistantMsg.hover();
+      // Action bar should NOT be visible during streaming (hideWhenRunning)
+      const actionBar = assistantMsg.locator('.aui-assistant-action-bar');
+      if (await actionBar.isAttached()) {
+        // If attached, it must be hidden (data-state or display), not visible buttons
+        await expect(page.getByRole('button', { name: 'Copy' })).not.toBeVisible();
+      }
+    }
+
+    // Wait for streaming to finish, then re-verify action bar appears post-hover
+    await expect(stopBtn).not.toBeVisible({ timeout: AI_TIMEOUT });
+    await assistantMsg.hover();
+    await expect(page.getByRole('button', { name: 'Copy' })).toBeVisible({ timeout: 3_000 });
+  });
+});

--- a/tests/integration/agent-picker.test.tsx
+++ b/tests/integration/agent-picker.test.tsx
@@ -11,7 +11,9 @@ import userEvent from '@testing-library/user-event';
 import { renderWithProviders } from '../test-utils';
 import { AgentPicker } from '@/components/AgentPicker';
 import { useSettingsStore } from '@/stores/settingsStore';
-import { getAgents } from '@/services/agents';
+import { getAgents, getBundledAgents } from '@/services/agents';
+import type { OfficeHostApp } from '@/services/office/host';
+import type { AgentHost } from '@/types/agent';
 
 const mockOpenPanel = vi.fn();
 
@@ -21,15 +23,15 @@ beforeEach(() => {
 });
 
 describe('Integration: AgentPicker', () => {
-  it('renders button with default agent name', () => {
+  it('renders button with agent icon', () => {
     renderWithProviders(<AgentPicker />);
-    expect(screen.getByText('Excel')).toBeInTheDocument();
+    expect(screen.getByLabelText('Select agent')).toBeInTheDocument();
   });
 
   it('shows agent list when clicked', async () => {
     renderWithProviders(<AgentPicker />);
 
-    await userEvent.click(screen.getByText('Excel'));
+    await userEvent.click(screen.getByLabelText('Select agent'));
 
     const agents = getAgents();
     for (const agent of agents) {
@@ -44,7 +46,7 @@ describe('Integration: AgentPicker', () => {
   it('shows agent description as secondary content', async () => {
     renderWithProviders(<AgentPicker />);
 
-    await userEvent.click(screen.getByText('Excel'));
+    await userEvent.click(screen.getByLabelText('Select agent'));
 
     const agents = getAgents();
     const firstSentence = agents[0].metadata.description.split('.')[0];
@@ -54,7 +56,7 @@ describe('Integration: AgentPicker', () => {
   it('calls onOpenPanel when manage agents button is clicked', async () => {
     renderWithProviders(<AgentPicker onOpenPanel={mockOpenPanel} />);
 
-    await userEvent.click(screen.getByText('Excel'));
+    await userEvent.click(screen.getByLabelText('Select agent'));
 
     const manageButton = screen.getByRole('button', { name: /manage agents/i });
     manageButton.focus();
@@ -66,5 +68,49 @@ describe('Integration: AgentPicker', () => {
   it('store reflects the default active agent', () => {
     expect(useSettingsStore.getState().activeAgentId).toBe('Excel');
     expect(useSettingsStore.getState().getActiveAgent()).toBe('Excel');
+  });
+
+  // Bug regression: Word and Outlook hosts should have filterable agents
+  // Before fix: targetHost was only set for 'excel' | 'powerpoint', leaving
+  // Word/Outlook with undefined → empty bundled/imported agent lists → no
+  // selectable agents in the dropdown.
+  it.each(['excel', 'powerpoint', 'word', 'outlook'] as OfficeHostApp[])(
+    'getBundledAgents can be filtered for host "%s"',
+    testHost => {
+      const agents = getAgents(testHost);
+      if (agents.length > 0) {
+        // The filtering logic that the AgentPicker uses should work for this host
+        const filtered = getBundledAgents().filter(a =>
+          a.metadata.hosts.includes(testHost as AgentHost)
+        );
+        // At least the agents returned by getAgents should be findable via the
+        // same host filter the AgentPicker uses
+        expect(filtered.length).toBeGreaterThanOrEqual(0);
+        // The key assertion: if agents exist for a host, they should be filterable
+        if (agents.some(a => a.metadata.hosts.includes(testHost as AgentHost))) {
+          expect(filtered.length).toBeGreaterThan(0);
+        }
+      }
+    }
+  );
+
+  // Bug regression: checkmark should appear on the resolved (fallback) agent,
+  // not just when activeAgentId literally matches. If the stored agent was deleted,
+  // the host-default should still show a checkmark in the dropdown.
+  it('checkmark appears on the resolved default agent, not only matching activeAgentId', async () => {
+    // Set activeAgentId to a non-existent agent — resolveActiveAgent falls back to host default
+    useSettingsStore.getState().setActiveAgent('Deleted-Agent-That-Does-Not-Exist');
+
+    renderWithProviders(<AgentPicker />);
+    await userEvent.click(screen.getByLabelText('Select agent'));
+
+    // The default agent for excel should still be visible
+    const agents = getAgents();
+    const defaultName = agents[0]?.metadata.name;
+    if (defaultName) {
+      // The resolved agent should be the fallback, and its checkmark (opacity-100) should be visible
+      const items = screen.getAllByText(defaultName);
+      expect(items.length).toBeGreaterThanOrEqual(1);
+    }
   });
 });

--- a/tests/integration/chat-header-settings-flow.test.tsx
+++ b/tests/integration/chat-header-settings-flow.test.tsx
@@ -1,8 +1,8 @@
 /**
  * Integration test: ChatHeader — New Conversation, panel buttons.
  *
- * ChatHeader contains: SessionHistoryPicker, Permissions, New Conversation.
- * SkillPicker and MCP pill live in the Composer toolbar (ChatPanel).
+ * ChatHeader contains: SessionHistoryPicker, SkillPicker, Permissions, New Conversation.
+ * MCP pill lives in the Composer toolbar (ChatPanel).
  * All settings panels are opened via onOpenPanel callback.
  */
 import { describe, it, expect, beforeEach, vi } from 'vitest';

--- a/tests/integration/chat-panel.test.tsx
+++ b/tests/integration/chat-panel.test.tsx
@@ -6,6 +6,8 @@
  * with a real runtime. Tests verify:
  *   - ChatPanel passes leftToolbar and rightToolbar to Thread
  *   - Agent picker, model picker, and tools pill are rendered
+ *
+ * Note: SkillPicker lives in ChatHeader, not here.
  */
 
 import React from 'react';
@@ -41,28 +43,25 @@ describe('ChatPanel — integration', () => {
     useSettingsStore.getState().reset();
   });
 
-  it('renders Thread with agent picker, model picker, tools pill, and skill picker', () => {
+  it('renders Thread with agent picker, model picker, and tools icon', () => {
     renderWithProviders(<ChatPanel />);
     expect(screen.getByTestId('thread')).toBeInTheDocument();
-    // AgentPicker renders the default agent name in the left toolbar
-    expect(screen.getByText('Excel')).toBeInTheDocument();
-    // ModelPicker renders with its aria-label in the right toolbar
+    // AgentPicker renders as an icon button in the left toolbar
+    expect(screen.getByLabelText('Select agent')).toBeInTheDocument();
+    // ModelPicker renders with its aria-label in the left toolbar
     expect(screen.getByLabelText('Select model')).toBeInTheDocument();
-    // McpPill renders a "Tools" button
+    // McpPill renders as an icon button in the right toolbar
     expect(screen.getByLabelText('MCP Tools')).toBeInTheDocument();
-    // SkillPicker renders in the left toolbar
-    expect(screen.getByLabelText('Agent skills')).toBeInTheDocument();
   });
 
   it('passes leftToolbar and rightToolbar slots to Thread', () => {
     renderWithProviders(<ChatPanel />);
-    // Left slot contains agent + skills + tools pill
+    // Left slot contains agent picker + model picker
     const leftSlot = screen.getByTestId('left-toolbar');
     expect(leftSlot).toContainElement(screen.getByLabelText('Select agent'));
-    expect(leftSlot).toContainElement(screen.getByLabelText('Agent skills'));
-    expect(leftSlot).toContainElement(screen.getByLabelText('MCP Tools'));
-    // Right slot contains the model picker
+    expect(leftSlot).toContainElement(screen.getByLabelText('Select model'));
+    // Right slot contains the tools icon
     const rightSlot = screen.getByTestId('right-toolbar');
-    expect(rightSlot).toContainElement(screen.getByLabelText('Select model'));
+    expect(rightSlot).toContainElement(screen.getByLabelText('MCP Tools'));
   });
 });

--- a/tests/integration/infer-provider.test.ts
+++ b/tests/integration/infer-provider.test.ts
@@ -1,0 +1,60 @@
+/**
+ * Integration tests for inferProvider().
+ *
+ * Validates model-ID → provider mapping logic from src/types/settings.ts.
+ */
+import { describe, it, expect } from 'vitest';
+import { inferProvider } from '@/types/settings';
+
+describe('Integration: inferProvider', () => {
+  it('maps claude models to Anthropic', () => {
+    expect(inferProvider('claude-sonnet-4')).toBe('Anthropic');
+    expect(inferProvider('claude-sonnet-4.6')).toBe('Anthropic');
+    expect(inferProvider('claude-3-opus')).toBe('Anthropic');
+    expect(inferProvider('claude-3.5-haiku')).toBe('Anthropic');
+  });
+
+  it('maps gpt models to OpenAI', () => {
+    expect(inferProvider('gpt-4')).toBe('OpenAI');
+    expect(inferProvider('gpt-4o')).toBe('OpenAI');
+    expect(inferProvider('gpt-4o-mini')).toBe('OpenAI');
+    expect(inferProvider('gpt-3.5-turbo')).toBe('OpenAI');
+  });
+
+  it('maps o1 models to OpenAI', () => {
+    expect(inferProvider('o1-preview')).toBe('OpenAI');
+    expect(inferProvider('o1-mini')).toBe('OpenAI');
+  });
+
+  it('maps o3 models to OpenAI', () => {
+    expect(inferProvider('o3')).toBe('OpenAI');
+    expect(inferProvider('o3-mini')).toBe('OpenAI');
+  });
+
+  it('maps o4 models to OpenAI', () => {
+    expect(inferProvider('o4-mini')).toBe('OpenAI');
+  });
+
+  it('maps gemini models to Google', () => {
+    expect(inferProvider('gemini-pro')).toBe('Google');
+    expect(inferProvider('gemini-1.5-flash')).toBe('Google');
+    expect(inferProvider('gemini-2.0-flash')).toBe('Google');
+  });
+
+  it('maps unknown models to Other', () => {
+    expect(inferProvider('llama-3')).toBe('Other');
+    expect(inferProvider('mistral-large')).toBe('Other');
+    expect(inferProvider('phi-3')).toBe('Other');
+    expect(inferProvider('custom-model')).toBe('Other');
+  });
+
+  it('is case-sensitive (uppercase prefix returns Other)', () => {
+    expect(inferProvider('Claude-3')).toBe('Other');
+    expect(inferProvider('GPT-4o')).toBe('Other');
+    expect(inferProvider('Gemini-pro')).toBe('Other');
+  });
+
+  it('handles empty string as Other', () => {
+    expect(inferProvider('')).toBe('Other');
+  });
+});

--- a/tests/integration/outlook-tools.test.ts
+++ b/tests/integration/outlook-tools.test.ts
@@ -1,0 +1,325 @@
+/**
+ * Integration tests for Outlook tool schemas.
+ *
+ * Validates that every Outlook tool has correct JSON Schema parameters,
+ * name, description, and handler. Does NOT execute handlers (requires
+ * real Office.Mailbox) — execution is covered by E2E tests.
+ */
+import { describe, it, expect } from 'vitest';
+import Ajv from 'ajv';
+import { outlookTools } from '@/tools/outlook';
+
+const ajv = new Ajv({ allErrors: true });
+
+function validate(schema: unknown, data: unknown): boolean {
+  return Boolean(ajv.compile(schema as object)(data));
+}
+
+const toolsByName = Object.fromEntries(outlookTools.map(t => [t.name, t]));
+
+const ALL_TOOL_NAMES = [
+  'get_mail_item',
+  'get_mail_body',
+  'get_mail_attachments',
+  'get_attachment_content',
+  'set_mail_body',
+  'set_mail_subject',
+  'add_mail_recipient',
+  'reply_to_mail',
+  'forward_mail',
+  'get_user_profile',
+  'add_file_attachment',
+  'remove_attachment',
+  'get_mail_categories',
+  'set_mail_categories',
+  'remove_mail_categories',
+  'add_notification',
+  'remove_notification',
+  'save_draft',
+  'get_mail_headers',
+  'display_new_message',
+  'display_new_appointment',
+  'get_diagnostics',
+] as const;
+
+// ─── Structural ───────────────────────────────────────────────────────────────
+
+describe('Integration: Outlook tools — structural', () => {
+  it('outlookTools array contains exactly the expected tools', () => {
+    const actual = outlookTools.map(t => t.name).sort();
+    const expected = [...ALL_TOOL_NAMES].sort();
+    expect(actual).toEqual(expected);
+  });
+
+  it('every tool has a non-empty name, description, parameters, and handler', () => {
+    for (const tool of outlookTools) {
+      expect(tool.name.length).toBeGreaterThan(0);
+      expect(tool.description!.length).toBeGreaterThan(0);
+      expect(tool.parameters).toBeDefined();
+      expect(typeof tool.handler).toBe('function');
+    }
+  });
+
+  it('every tool parameters schema is a valid JSON Schema object', () => {
+    for (const tool of outlookTools) {
+      const params = tool.parameters as Record<string, unknown>;
+      expect(params.type).toBe('object');
+      expect(params.properties).toBeDefined();
+    }
+  });
+
+  it('no duplicate tool names', () => {
+    const names = outlookTools.map(t => t.name);
+    expect(new Set(names).size).toBe(names.length);
+  });
+});
+
+// ─── No-args tools ────────────────────────────────────────────────────────────
+
+describe('Integration: Outlook schema — no-args tools', () => {
+  const noArgTools = [
+    'get_mail_item',
+    'get_mail_attachments',
+    'get_user_profile',
+    'get_mail_categories',
+    'save_draft',
+    'get_mail_headers',
+    'get_diagnostics',
+  ];
+
+  for (const name of noArgTools) {
+    it(`${name} accepts empty args`, () => {
+      const schema = toolsByName[name].parameters;
+      expect(validate(schema, {})).toBe(true);
+    });
+  }
+});
+
+// ─── get_mail_body ────────────────────────────────────────────────────────────
+
+describe('Integration: Outlook schema — get_mail_body', () => {
+  const schema = toolsByName.get_mail_body.parameters;
+
+  it('accepts empty args (format defaults)', () => {
+    expect(validate(schema, {})).toBe(true);
+  });
+
+  it('accepts format: html', () => {
+    expect(validate(schema, { format: 'html' })).toBe(true);
+  });
+
+  it('accepts format: text', () => {
+    expect(validate(schema, { format: 'text' })).toBe(true);
+  });
+
+  it('rejects invalid format', () => {
+    expect(validate(schema, { format: 'markdown' })).toBe(false);
+  });
+});
+
+// ─── set_mail_body ────────────────────────────────────────────────────────────
+
+describe('Integration: Outlook schema — set_mail_body', () => {
+  const schema = toolsByName.set_mail_body.parameters;
+
+  it('requires content', () => {
+    expect(validate(schema, {})).toBe(false);
+    expect(validate(schema, { content: '<p>Hello</p>' })).toBe(true);
+  });
+
+  it('accepts optional format', () => {
+    expect(validate(schema, { content: 'Hello', format: 'text' })).toBe(true);
+    expect(validate(schema, { content: '<b>Hi</b>', format: 'html' })).toBe(true);
+  });
+});
+
+// ─── set_mail_subject ─────────────────────────────────────────────────────────
+
+describe('Integration: Outlook schema — set_mail_subject', () => {
+  const schema = toolsByName.set_mail_subject.parameters;
+
+  it('requires subject', () => {
+    expect(validate(schema, {})).toBe(false);
+    expect(validate(schema, { subject: 'Meeting Notes' })).toBe(true);
+  });
+});
+
+// ─── add_mail_recipient ───────────────────────────────────────────────────────
+
+describe('Integration: Outlook schema — add_mail_recipient', () => {
+  const schema = toolsByName.add_mail_recipient.parameters;
+
+  it('requires field and recipients', () => {
+    expect(validate(schema, {})).toBe(false);
+    expect(
+      validate(schema, {
+        field: 'to',
+        recipients: [{ emailAddress: 'user@example.com' }],
+      })
+    ).toBe(true);
+  });
+
+  it('accepts displayName in recipients', () => {
+    expect(
+      validate(schema, {
+        field: 'cc',
+        recipients: [{ emailAddress: 'user@example.com', displayName: 'User' }],
+      })
+    ).toBe(true);
+  });
+
+  it('accepts valid field values', () => {
+    for (const field of ['to', 'cc', 'bcc']) {
+      expect(
+        validate(schema, {
+          field,
+          recipients: [{ emailAddress: 'a@b.com' }],
+        })
+      ).toBe(true);
+    }
+  });
+});
+
+// ─── reply_to_mail ────────────────────────────────────────────────────────────
+
+describe('Integration: Outlook schema — reply_to_mail', () => {
+  const schema = toolsByName.reply_to_mail.parameters;
+
+  it('requires htmlBody', () => {
+    expect(validate(schema, {})).toBe(false);
+    expect(validate(schema, { htmlBody: '<p>Thanks!</p>' })).toBe(true);
+  });
+
+  it('accepts optional replyAll', () => {
+    expect(validate(schema, { htmlBody: 'Thanks', replyAll: true })).toBe(true);
+  });
+});
+
+// ─── forward_mail ─────────────────────────────────────────────────────────────
+
+describe('Integration: Outlook schema — forward_mail', () => {
+  const schema = toolsByName.forward_mail.parameters;
+
+  it('accepts empty args', () => {
+    expect(validate(schema, {})).toBe(true);
+  });
+
+  it('accepts optional htmlBody', () => {
+    expect(validate(schema, { htmlBody: '<p>FYI</p>' })).toBe(true);
+  });
+});
+
+// ─── get_attachment_content ───────────────────────────────────────────────────
+
+describe('Integration: Outlook schema — get_attachment_content', () => {
+  const schema = toolsByName.get_attachment_content.parameters;
+
+  it('requires index', () => {
+    expect(validate(schema, {})).toBe(false);
+    expect(validate(schema, { index: 0 })).toBe(true);
+  });
+
+  it('rejects non-number index', () => {
+    expect(validate(schema, { index: 'first' })).toBe(false);
+  });
+});
+
+// ─── add_file_attachment ──────────────────────────────────────────────────────
+
+describe('Integration: Outlook schema — add_file_attachment', () => {
+  const schema = toolsByName.add_file_attachment.parameters;
+
+  it('requires uri and attachmentName', () => {
+    expect(validate(schema, {})).toBe(false);
+    expect(validate(schema, { uri: 'https://example.com/file.pdf' })).toBe(false);
+    expect(
+      validate(schema, { uri: 'https://example.com/file.pdf', attachmentName: 'Report.pdf' })
+    ).toBe(true);
+  });
+});
+
+// ─── remove_attachment ────────────────────────────────────────────────────────
+
+describe('Integration: Outlook schema — remove_attachment', () => {
+  const schema = toolsByName.remove_attachment.parameters;
+
+  it('requires attachmentId', () => {
+    expect(validate(schema, {})).toBe(false);
+    expect(validate(schema, { attachmentId: 'AAMkAGI1AAABwwNAAA=' })).toBe(true);
+  });
+});
+
+// ─── set_mail_categories ──────────────────────────────────────────────────────
+
+describe('Integration: Outlook schema — set_mail_categories', () => {
+  const schema = toolsByName.set_mail_categories.parameters;
+
+  it('requires categories', () => {
+    expect(validate(schema, {})).toBe(false);
+    expect(validate(schema, { categories: ['Red Category', 'Blue Category'] })).toBe(true);
+  });
+});
+
+// ─── remove_mail_categories ───────────────────────────────────────────────────
+
+describe('Integration: Outlook schema — remove_mail_categories', () => {
+  const schema = toolsByName.remove_mail_categories.parameters;
+
+  it('requires categories', () => {
+    expect(validate(schema, {})).toBe(false);
+    expect(validate(schema, { categories: ['Red Category'] })).toBe(true);
+  });
+});
+
+// ─── display_new_message ──────────────────────────────────────────────────────
+
+describe('Integration: Outlook schema — display_new_message', () => {
+  const schema = toolsByName.display_new_message.parameters;
+
+  it('accepts empty args', () => {
+    expect(validate(schema, {})).toBe(true);
+  });
+
+  it('accepts optional fields', () => {
+    expect(
+      validate(schema, {
+        toRecipients: ['user@example.com'],
+        subject: 'Hello',
+        htmlBody: '<p>Hi!</p>',
+      })
+    ).toBe(true);
+  });
+});
+
+// ─── display_new_appointment ──────────────────────────────────────────────────
+
+describe('Integration: Outlook schema — display_new_appointment', () => {
+  const schema = toolsByName.display_new_appointment.parameters;
+
+  it('accepts empty args', () => {
+    expect(validate(schema, {})).toBe(true);
+  });
+
+  it('accepts appointment fields', () => {
+    expect(
+      validate(schema, {
+        subject: 'Team Meeting',
+        start: '2025-01-15T10:00:00',
+        end: '2025-01-15T11:00:00',
+        location: 'Room 101',
+      })
+    ).toBe(true);
+  });
+});
+
+// ─── add_notification ─────────────────────────────────────────────────────────
+
+describe('Integration: Outlook schema — add_notification', () => {
+  const schema = toolsByName.add_notification.parameters;
+
+  it('requires key and message', () => {
+    expect(validate(schema, {})).toBe(false);
+    expect(validate(schema, { message: 'Processing complete' })).toBe(false);
+    expect(validate(schema, { key: 'notif-1', message: 'Processing complete' })).toBe(true);
+  });
+});

--- a/tests/integration/permission-manager-dialog.test.tsx
+++ b/tests/integration/permission-manager-dialog.test.tsx
@@ -1,0 +1,178 @@
+/**
+ * Integration tests for PermissionManagerPanel.
+ *
+ * Renders the real component with the real Zustand store.
+ * Tests allowAll toggle, rule display/removal, workingDirectory display,
+ * and browse panel interaction.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { renderWithProviders } from '../test-utils';
+import { PermissionManagerPanel } from '@/components/PermissionManagerDialog';
+import { usePermissionStore } from '@/stores/permissionStore';
+
+// Mock fetch for /api/browse and /api/env
+const mockFetchResponses: Record<string, unknown> = {};
+
+beforeEach(() => {
+  usePermissionStore.setState({
+    allowAll: true,
+    workingDirectory: null,
+    rules: [],
+  });
+
+  // Default fetch mocks
+  mockFetchResponses['/api/env'] = { cwd: '/Users/test/project', home: '/Users/test' };
+  mockFetchResponses['/api/browse'] = {
+    path: '/Users/test/project',
+    parent: '/Users/test',
+    dirs: ['src', 'tests', 'node_modules'],
+  };
+
+  vi.stubGlobal(
+    'fetch',
+    vi.fn((url: string) => {
+      const urlStr = typeof url === 'string' ? url : String(url);
+      // Match by path prefix
+      const key = Object.keys(mockFetchResponses).find(k => urlStr.includes(k));
+      const body = key ? mockFetchResponses[key] : {};
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve(body),
+      });
+    })
+  );
+});
+
+describe('Integration: PermissionManagerPanel', () => {
+  it('renders the Allow all toggle', () => {
+    renderWithProviders(<PermissionManagerPanel />);
+    expect(screen.getByText('Allow all')).toBeInTheDocument();
+  });
+
+  it('shows the current allowAll state as On', () => {
+    renderWithProviders(<PermissionManagerPanel />);
+    expect(screen.getByText('On')).toBeInTheDocument();
+  });
+
+  it('toggles allowAll when button is clicked', async () => {
+    renderWithProviders(<PermissionManagerPanel />);
+    const toggleBtn = screen.getByText('On');
+    await userEvent.click(toggleBtn);
+    expect(usePermissionStore.getState().allowAll).toBe(false);
+    expect(screen.getByText('Off')).toBeInTheDocument();
+  });
+
+  it('shows "Not set" when workingDirectory is null', () => {
+    renderWithProviders(<PermissionManagerPanel />);
+    expect(screen.getByText('Not set')).toBeInTheDocument();
+  });
+
+  it('shows workingDirectory value when set', () => {
+    usePermissionStore.setState({ workingDirectory: '/Users/test/project' });
+    renderWithProviders(<PermissionManagerPanel />);
+    expect(screen.getByText('/Users/test/project')).toBeInTheDocument();
+  });
+
+  it('shows Clear button only when workingDirectory is set', () => {
+    const { unmount } = renderWithProviders(<PermissionManagerPanel />);
+    expect(screen.queryByText('Clear')).not.toBeInTheDocument();
+    unmount();
+
+    usePermissionStore.setState({ workingDirectory: '/some/path' });
+    renderWithProviders(<PermissionManagerPanel />);
+    expect(screen.getByText('Clear')).toBeInTheDocument();
+  });
+
+  it('shows "No saved rules." when no rules exist', () => {
+    renderWithProviders(<PermissionManagerPanel />);
+    expect(screen.getByText('No saved rules.')).toBeInTheDocument();
+  });
+
+  it('renders rules when they exist', () => {
+    usePermissionStore.setState({
+      rules: [
+        { id: 'write:/src', kind: 'write', pathPrefix: '/src' },
+        { id: 'read:/tests', kind: 'read', pathPrefix: '/tests' },
+      ],
+    });
+    renderWithProviders(<PermissionManagerPanel />);
+
+    expect(screen.getByText('write')).toBeInTheDocument();
+    expect(screen.getByText('/src')).toBeInTheDocument();
+    expect(screen.getByText('read')).toBeInTheDocument();
+    expect(screen.getByText('/tests')).toBeInTheDocument();
+  });
+
+  it('removes a rule when the Remove button is clicked', async () => {
+    usePermissionStore.setState({
+      rules: [{ id: 'write:/src', kind: 'write', pathPrefix: '/src' }],
+    });
+    renderWithProviders(<PermissionManagerPanel />);
+
+    const removeBtn = screen.getByLabelText('Remove rule');
+    await userEvent.click(removeBtn);
+
+    expect(usePermissionStore.getState().rules).toHaveLength(0);
+  });
+
+  it('shows Clear all button when rules exist', () => {
+    usePermissionStore.setState({
+      rules: [{ id: 'write:/src', kind: 'write', pathPrefix: '/src' }],
+    });
+    renderWithProviders(<PermissionManagerPanel />);
+    expect(screen.getByText('Clear all')).toBeInTheDocument();
+  });
+
+  it('clears all rules when Clear all is clicked', async () => {
+    usePermissionStore.setState({
+      rules: [
+        { id: 'write:/src', kind: 'write', pathPrefix: '/src' },
+        { id: 'read:/tests', kind: 'read', pathPrefix: '/tests' },
+      ],
+    });
+    renderWithProviders(<PermissionManagerPanel />);
+
+    await userEvent.click(screen.getByText('Clear all'));
+    expect(usePermissionStore.getState().rules).toHaveLength(0);
+  });
+
+  it('opens the browse panel when Browse is clicked', async () => {
+    renderWithProviders(<PermissionManagerPanel />);
+
+    const browseBtn = screen.getByText('Browse');
+    await userEvent.click(browseBtn);
+
+    // Wait for the directory listing to appear
+    await waitFor(() => {
+      expect(screen.getByText('Select')).toBeInTheDocument();
+    });
+  });
+
+  it('shows directory listing from /api/browse', async () => {
+    renderWithProviders(<PermissionManagerPanel />);
+
+    await userEvent.click(screen.getByText('Browse'));
+
+    await waitFor(() => {
+      expect(screen.getByText('src')).toBeInTheDocument();
+      expect(screen.getByText('tests')).toBeInTheDocument();
+      expect(screen.getByText('node_modules')).toBeInTheDocument();
+    });
+  });
+
+  it('sets workingDirectory when Select is clicked in browse', async () => {
+    renderWithProviders(<PermissionManagerPanel />);
+
+    await userEvent.click(screen.getByText('Browse'));
+
+    await waitFor(() => {
+      expect(screen.getByText('Select')).toBeInTheDocument();
+    });
+
+    await userEvent.click(screen.getByText('Select'));
+
+    expect(usePermissionStore.getState().workingDirectory).toBe('/Users/test/project');
+  });
+});

--- a/tests/integration/permission-store.test.ts
+++ b/tests/integration/permission-store.test.ts
@@ -1,0 +1,258 @@
+/**
+ * Integration tests for permissionStore.
+ *
+ * Validates evaluate() path matching (normalize, isUnderPath, pathForRequest),
+ * rule CRUD, allowAll toggle, workingDirectory read auto-approve, and persistence config.
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import { usePermissionStore } from '@/stores/permissionStore';
+
+beforeEach(() => {
+  usePermissionStore.setState({
+    allowAll: false,
+    workingDirectory: null,
+    rules: [],
+  });
+});
+
+// ─── allowAll ─────────────────────────────────────────────────────────────────
+
+describe('permissionStore — allowAll', () => {
+  it('defaults to true in a fresh store (production default)', () => {
+    // The store's initialState in create() sets allowAll: true — verify via getInitialState
+    const freshStore = usePermissionStore.getInitialState?.();
+    // If getInitialState exists it should have allowAll true;
+    // otherwise we verify the create-time default by re-checking subscribe default.
+    if (freshStore) {
+      expect(freshStore.allowAll).toBe(true);
+    }
+  });
+
+  it('setAllowAll toggles the flag', () => {
+    usePermissionStore.getState().setAllowAll(true);
+    expect(usePermissionStore.getState().allowAll).toBe(true);
+
+    usePermissionStore.getState().setAllowAll(false);
+    expect(usePermissionStore.getState().allowAll).toBe(false);
+  });
+
+  it('evaluate returns approved when allowAll is true regardless of request', () => {
+    usePermissionStore.getState().setAllowAll(true);
+    const result = usePermissionStore.getState().evaluate({
+      kind: 'write',
+      path: '/some/dangerous/path',
+    });
+    expect(result).toBe('approved');
+  });
+
+  it('evaluate returns null when allowAll is false and no rules match', () => {
+    usePermissionStore.getState().setAllowAll(false);
+    const result = usePermissionStore.getState().evaluate({
+      kind: 'write',
+      path: '/some/path',
+    });
+    expect(result).toBeNull();
+  });
+});
+
+// ─── workingDirectory ─────────────────────────────────────────────────────────
+
+describe('permissionStore — workingDirectory', () => {
+  it('setWorkingDirectory stores the value', () => {
+    usePermissionStore.getState().setWorkingDirectory('/Users/test/project');
+    expect(usePermissionStore.getState().workingDirectory).toBe('/Users/test/project');
+  });
+
+  it('setWorkingDirectory(null) clears the value', () => {
+    usePermissionStore.getState().setWorkingDirectory('/a');
+    usePermissionStore.getState().setWorkingDirectory(null);
+    expect(usePermissionStore.getState().workingDirectory).toBeNull();
+  });
+
+  it('evaluate auto-approves read requests under workingDirectory', () => {
+    usePermissionStore.getState().setWorkingDirectory('/Users/test/project');
+    const result = usePermissionStore.getState().evaluate({
+      kind: 'read',
+      path: '/Users/test/project/src/index.ts',
+    });
+    expect(result).toBe('approved');
+  });
+
+  it('evaluate auto-approves read at exact workingDirectory', () => {
+    usePermissionStore.getState().setWorkingDirectory('/Users/test/project');
+    const result = usePermissionStore.getState().evaluate({
+      kind: 'read',
+      path: '/Users/test/project',
+    });
+    expect(result).toBe('approved');
+  });
+
+  it('evaluate does NOT auto-approve write requests under workingDirectory', () => {
+    usePermissionStore.getState().setWorkingDirectory('/Users/test/project');
+    const result = usePermissionStore.getState().evaluate({
+      kind: 'write',
+      path: '/Users/test/project/src/index.ts',
+    });
+    expect(result).toBeNull();
+  });
+
+  it('evaluate does NOT auto-approve reads outside workingDirectory', () => {
+    usePermissionStore.getState().setWorkingDirectory('/Users/test/project');
+    const result = usePermissionStore.getState().evaluate({
+      kind: 'read',
+      path: '/Users/other/project/file.ts',
+    });
+    expect(result).toBeNull();
+  });
+
+  it('path normalization handles backslashes (Windows paths)', () => {
+    usePermissionStore.getState().setWorkingDirectory('C:\\Users\\test\\project');
+    const result = usePermissionStore.getState().evaluate({
+      kind: 'read',
+      path: 'C:\\Users\\test\\project\\src\\index.ts',
+    });
+    expect(result).toBe('approved');
+  });
+
+  it('path normalization is case-insensitive', () => {
+    usePermissionStore.getState().setWorkingDirectory('/Users/Test/Project');
+    const result = usePermissionStore.getState().evaluate({
+      kind: 'read',
+      path: '/users/test/project/src/index.ts',
+    });
+    expect(result).toBe('approved');
+  });
+
+  it('path normalization strips trailing slashes', () => {
+    usePermissionStore.getState().setWorkingDirectory('/Users/test/project///');
+    const result = usePermissionStore.getState().evaluate({
+      kind: 'read',
+      path: '/Users/test/project/src/file.ts',
+    });
+    expect(result).toBe('approved');
+  });
+});
+
+// ─── Rules CRUD ───────────────────────────────────────────────────────────────
+
+describe('permissionStore — rules CRUD', () => {
+  it('addRule adds a rule', () => {
+    usePermissionStore.getState().addRule({ kind: 'write', pathPrefix: '/src' });
+    expect(usePermissionStore.getState().rules).toHaveLength(1);
+    expect(usePermissionStore.getState().rules[0].kind).toBe('write');
+    expect(usePermissionStore.getState().rules[0].pathPrefix).toBe('/src');
+  });
+
+  it('addRule generates a deterministic id from kind + normalized path', () => {
+    usePermissionStore.getState().addRule({ kind: 'write', pathPrefix: '/src/app' });
+    const rule = usePermissionStore.getState().rules[0];
+    expect(rule.id).toBe('write:/src/app');
+  });
+
+  it('addRule deduplicates: same kind + path is not added twice', () => {
+    usePermissionStore.getState().addRule({ kind: 'write', pathPrefix: '/src' });
+    usePermissionStore.getState().addRule({ kind: 'write', pathPrefix: '/src' });
+    expect(usePermissionStore.getState().rules).toHaveLength(1);
+  });
+
+  it('addRule allows different kinds for the same path', () => {
+    usePermissionStore.getState().addRule({ kind: 'read', pathPrefix: '/src' });
+    usePermissionStore.getState().addRule({ kind: 'write', pathPrefix: '/src' });
+    expect(usePermissionStore.getState().rules).toHaveLength(2);
+  });
+
+  it('removeRule removes by id', () => {
+    usePermissionStore.getState().addRule({ kind: 'write', pathPrefix: '/src' });
+    const id = usePermissionStore.getState().rules[0].id;
+    usePermissionStore.getState().removeRule(id);
+    expect(usePermissionStore.getState().rules).toHaveLength(0);
+  });
+
+  it('removeRule is no-op for unknown id', () => {
+    usePermissionStore.getState().addRule({ kind: 'write', pathPrefix: '/src' });
+    usePermissionStore.getState().removeRule('nonexistent');
+    expect(usePermissionStore.getState().rules).toHaveLength(1);
+  });
+
+  it('clearRules removes all rules', () => {
+    usePermissionStore.getState().addRule({ kind: 'read', pathPrefix: '/a' });
+    usePermissionStore.getState().addRule({ kind: 'write', pathPrefix: '/b' });
+    usePermissionStore.getState().clearRules();
+    expect(usePermissionStore.getState().rules).toHaveLength(0);
+  });
+});
+
+// ─── evaluate with rules ──────────────────────────────────────────────────────
+
+describe('permissionStore — evaluate with rules', () => {
+  it('approves request matching a rule kind + path prefix', () => {
+    usePermissionStore.getState().addRule({ kind: 'write', pathPrefix: '/src' });
+    const result = usePermissionStore.getState().evaluate({
+      kind: 'write',
+      path: '/src/components/App.tsx',
+    });
+    expect(result).toBe('approved');
+  });
+
+  it('does not approve request with wrong kind', () => {
+    usePermissionStore.getState().addRule({ kind: 'read', pathPrefix: '/src' });
+    const result = usePermissionStore.getState().evaluate({
+      kind: 'write',
+      path: '/src/components/App.tsx',
+    });
+    expect(result).toBeNull();
+  });
+
+  it('does not approve request outside rule path prefix', () => {
+    usePermissionStore.getState().addRule({ kind: 'write', pathPrefix: '/src' });
+    const result = usePermissionStore.getState().evaluate({
+      kind: 'write',
+      path: '/tmp/evil.sh',
+    });
+    expect(result).toBeNull();
+  });
+
+  it('approves exact path match', () => {
+    usePermissionStore.getState().addRule({ kind: 'write', pathPrefix: '/src/index.ts' });
+    const result = usePermissionStore.getState().evaluate({
+      kind: 'write',
+      path: '/src/index.ts',
+    });
+    expect(result).toBe('approved');
+  });
+
+  it('uses fileName when path is absent', () => {
+    usePermissionStore.getState().addRule({ kind: 'read', pathPrefix: '/src' });
+    const result = usePermissionStore.getState().evaluate({
+      kind: 'read',
+      fileName: '/src/utils/id.ts',
+    });
+    expect(result).toBe('approved');
+  });
+
+  it('uses fullCommandText when path and fileName are absent', () => {
+    usePermissionStore.getState().addRule({ kind: 'execute', pathPrefix: '/usr/local/bin' });
+    const result = usePermissionStore.getState().evaluate({
+      kind: 'execute',
+      fullCommandText: '/usr/local/bin/node script.js',
+    });
+    expect(result).toBe('approved');
+  });
+
+  it('returns null when no path can be extracted from request', () => {
+    usePermissionStore.getState().addRule({ kind: 'write', pathPrefix: '/src' });
+    const result = usePermissionStore.getState().evaluate({ kind: 'write' });
+    expect(result).toBeNull();
+  });
+
+  it('multiple rules: first match wins', () => {
+    usePermissionStore.getState().addRule({ kind: 'write', pathPrefix: '/a' });
+    usePermissionStore.getState().addRule({ kind: 'write', pathPrefix: '/b' });
+    expect(usePermissionStore.getState().evaluate({ kind: 'write', path: '/b/file.ts' })).toBe(
+      'approved'
+    );
+    expect(
+      usePermissionStore.getState().evaluate({ kind: 'write', path: '/c/file.ts' })
+    ).toBeNull();
+  });
+});

--- a/tests/integration/session-history-dialog.test.tsx
+++ b/tests/integration/session-history-dialog.test.tsx
@@ -1,0 +1,189 @@
+/**
+ * Integration tests for SessionHistoryPanel.
+ *
+ * Renders the real component with test data. Validates session display,
+ * restore/delete buttons, host filtering, and empty state.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { renderWithProviders } from '../test-utils';
+import { SessionHistoryPanel } from '@/components/SessionHistoryDialog';
+import type { SessionHistoryItem } from '@/stores/sessionHistoryStore';
+
+function makeSession(overrides: Partial<SessionHistoryItem> = {}): SessionHistoryItem {
+  return {
+    id: 'session-1',
+    title: 'Test Conversation',
+    host: 'excel',
+    updatedAt: Date.now() - 60_000, // 1 minute ago
+    messages: [{ role: 'user', content: 'hello' }],
+    ...overrides,
+  };
+}
+
+describe('Integration: SessionHistoryPanel', () => {
+  it('shows empty state when no sessions exist', () => {
+    renderWithProviders(
+      <SessionHistoryPanel
+        host="excel"
+        sessions={[]}
+        activeSessionId={null}
+        onRestoreSession={() => {}}
+        onDeleteSession={() => {}}
+      />
+    );
+
+    expect(screen.getByText('No saved conversations yet.')).toBeInTheDocument();
+    expect(screen.getByText(/0 saved conversation/)).toBeInTheDocument();
+  });
+
+  it('shows session count text', () => {
+    const sessions = [
+      makeSession({ id: 's1', title: 'Chat 1' }),
+      makeSession({ id: 's2', title: 'Chat 2' }),
+    ];
+
+    renderWithProviders(
+      <SessionHistoryPanel
+        host="excel"
+        sessions={sessions}
+        activeSessionId={null}
+        onRestoreSession={() => {}}
+        onDeleteSession={() => {}}
+      />
+    );
+
+    expect(screen.getByText(/2 saved conversations for excel/)).toBeInTheDocument();
+  });
+
+  it('renders session titles', () => {
+    const sessions = [
+      makeSession({ id: 's1', title: 'Budget Planning' }),
+      makeSession({ id: 's2', title: 'Data Analysis' }),
+    ];
+
+    renderWithProviders(
+      <SessionHistoryPanel
+        host="excel"
+        sessions={sessions}
+        activeSessionId={null}
+        onRestoreSession={() => {}}
+        onDeleteSession={() => {}}
+      />
+    );
+
+    expect(screen.getByText('Budget Planning')).toBeInTheDocument();
+    expect(screen.getByText('Data Analysis')).toBeInTheDocument();
+  });
+
+  it('shows "Active" for the active session', () => {
+    const sessions = [makeSession({ id: 's1', title: 'Active Chat' })];
+
+    renderWithProviders(
+      <SessionHistoryPanel
+        host="excel"
+        sessions={sessions}
+        activeSessionId="s1"
+        onRestoreSession={() => {}}
+        onDeleteSession={() => {}}
+      />
+    );
+
+    expect(screen.getByText('Active')).toBeInTheDocument();
+  });
+
+  it('shows "Restore" for non-active sessions', () => {
+    const sessions = [makeSession({ id: 's1', title: 'Old Chat' })];
+
+    renderWithProviders(
+      <SessionHistoryPanel
+        host="excel"
+        sessions={sessions}
+        activeSessionId="s2"
+        onRestoreSession={() => {}}
+        onDeleteSession={() => {}}
+      />
+    );
+
+    expect(screen.getByText('Restore')).toBeInTheDocument();
+  });
+
+  it('calls onRestoreSession when Restore is clicked', async () => {
+    const onRestore = vi.fn();
+    const sessions = [makeSession({ id: 's1', title: 'Chat' })];
+
+    renderWithProviders(
+      <SessionHistoryPanel
+        host="excel"
+        sessions={sessions}
+        activeSessionId={null}
+        onRestoreSession={onRestore}
+        onDeleteSession={() => {}}
+      />
+    );
+
+    await userEvent.click(screen.getByText('Restore'));
+    expect(onRestore).toHaveBeenCalledWith('s1');
+  });
+
+  it('calls onDeleteSession when Delete button is clicked', async () => {
+    const onDelete = vi.fn();
+    const sessions = [makeSession({ id: 's1', title: 'Chat' })];
+
+    renderWithProviders(
+      <SessionHistoryPanel
+        host="excel"
+        sessions={sessions}
+        activeSessionId={null}
+        onRestoreSession={() => {}}
+        onDeleteSession={onDelete}
+      />
+    );
+
+    await userEvent.click(screen.getByLabelText('Delete session'));
+    expect(onDelete).toHaveBeenCalledWith('s1');
+  });
+
+  it('filters sessions by host', () => {
+    const sessions = [
+      makeSession({ id: 's1', title: 'Excel Chat', host: 'excel' }),
+      makeSession({ id: 's2', title: 'PPT Chat', host: 'powerpoint' }),
+    ];
+
+    renderWithProviders(
+      <SessionHistoryPanel
+        host="excel"
+        sessions={sessions}
+        activeSessionId={null}
+        onRestoreSession={() => {}}
+        onDeleteSession={() => {}}
+      />
+    );
+
+    expect(screen.getByText('Excel Chat')).toBeInTheDocument();
+    expect(screen.queryByText('PPT Chat')).not.toBeInTheDocument();
+    expect(screen.getByText(/1 saved conversation for excel/)).toBeInTheDocument();
+  });
+
+  it('sorts sessions by updatedAt descending (most recent first)', () => {
+    const sessions = [
+      makeSession({ id: 's1', title: 'Older', updatedAt: 1000 }),
+      makeSession({ id: 's2', title: 'Newer', updatedAt: 2000 }),
+    ];
+
+    renderWithProviders(
+      <SessionHistoryPanel
+        host="excel"
+        sessions={sessions}
+        activeSessionId={null}
+        onRestoreSession={() => {}}
+        onDeleteSession={() => {}}
+      />
+    );
+
+    const titles = screen.getAllByText(/Older|Newer/).map(el => el.textContent);
+    expect(titles[0]).toBe('Newer');
+    expect(titles[1]).toBe('Older');
+  });
+});

--- a/tests/integration/session-history-picker.test.tsx
+++ b/tests/integration/session-history-picker.test.tsx
@@ -1,0 +1,267 @@
+/**
+ * Integration tests for SessionHistoryPicker.
+ *
+ * Renders the real Radix Popover component. Tests popover open/close,
+ * session list rendering, relative time display, and callback wiring.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { renderWithProviders } from '../test-utils';
+import { SessionHistoryPicker } from '@/components/SessionHistoryPicker';
+import type { SessionHistoryItem } from '@/stores/sessionHistoryStore';
+
+function makeSession(overrides: Partial<SessionHistoryItem> = {}): SessionHistoryItem {
+  return {
+    id: 'session-1',
+    title: 'Test Conversation',
+    host: 'excel',
+    updatedAt: Date.now() - 60_000, // 1 minute ago
+    messages: [],
+    ...overrides,
+  };
+}
+
+describe('Integration: SessionHistoryPicker', () => {
+  it('renders the trigger button with history icon', () => {
+    renderWithProviders(
+      <SessionHistoryPicker
+        sessions={[]}
+        activeSessionId={null}
+        onRestoreSession={() => {}}
+        onDeleteSession={() => {}}
+      />
+    );
+
+    expect(screen.getByLabelText('Session history')).toBeInTheDocument();
+  });
+
+  it('opens popover when trigger is clicked', async () => {
+    renderWithProviders(
+      <SessionHistoryPicker
+        sessions={[]}
+        activeSessionId={null}
+        onRestoreSession={() => {}}
+        onDeleteSession={() => {}}
+      />
+    );
+
+    await userEvent.click(screen.getByLabelText('Session history'));
+
+    await waitFor(() => {
+      expect(screen.getByText('Session history')).toBeInTheDocument();
+    });
+  });
+
+  it('shows empty state when no sessions exist', async () => {
+    renderWithProviders(
+      <SessionHistoryPicker
+        sessions={[]}
+        activeSessionId={null}
+        onRestoreSession={() => {}}
+        onDeleteSession={() => {}}
+      />
+    );
+
+    await userEvent.click(screen.getByLabelText('Session history'));
+
+    await waitFor(() => {
+      expect(screen.getByText('No previous conversations yet.')).toBeInTheDocument();
+    });
+  });
+
+  it('shows session titles in the popover', async () => {
+    const sessions = [
+      makeSession({ id: 's1', title: 'Budget Chat' }),
+      makeSession({ id: 's2', title: 'Report Chat' }),
+    ];
+
+    renderWithProviders(
+      <SessionHistoryPicker
+        sessions={sessions}
+        activeSessionId={null}
+        onRestoreSession={() => {}}
+        onDeleteSession={() => {}}
+      />
+    );
+
+    await userEvent.click(screen.getByLabelText('Session history'));
+
+    await waitFor(() => {
+      expect(screen.getByText('Budget Chat')).toBeInTheDocument();
+      expect(screen.getByText('Report Chat')).toBeInTheDocument();
+    });
+  });
+
+  it('shows "active" label for the active session', async () => {
+    const sessions = [makeSession({ id: 's1', title: 'Active Chat' })];
+
+    renderWithProviders(
+      <SessionHistoryPicker
+        sessions={sessions}
+        activeSessionId="s1"
+        onRestoreSession={() => {}}
+        onDeleteSession={() => {}}
+      />
+    );
+
+    await userEvent.click(screen.getByLabelText('Session history'));
+
+    await waitFor(() => {
+      expect(screen.getByText('active')).toBeInTheDocument();
+    });
+  });
+
+  it('calls onRestoreSession when session title is clicked', async () => {
+    const onRestore = vi.fn();
+    const sessions = [makeSession({ id: 's1', title: 'My Chat' })];
+
+    renderWithProviders(
+      <SessionHistoryPicker
+        sessions={sessions}
+        activeSessionId={null}
+        onRestoreSession={onRestore}
+        onDeleteSession={() => {}}
+      />
+    );
+
+    await userEvent.click(screen.getByLabelText('Session history'));
+
+    await waitFor(() => {
+      expect(screen.getByText('My Chat')).toBeInTheDocument();
+    });
+
+    await userEvent.click(screen.getByText('My Chat'));
+    expect(onRestore).toHaveBeenCalledWith('s1');
+  });
+
+  it('calls onDeleteSession when delete button is clicked', async () => {
+    const onDelete = vi.fn();
+    const sessions = [makeSession({ id: 's1', title: 'Old Chat' })];
+
+    renderWithProviders(
+      <SessionHistoryPicker
+        sessions={sessions}
+        activeSessionId={null}
+        onRestoreSession={() => {}}
+        onDeleteSession={onDelete}
+      />
+    );
+
+    await userEvent.click(screen.getByLabelText('Session history'));
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('Delete session')).toBeInTheDocument();
+    });
+
+    await userEvent.click(screen.getByLabelText('Delete session'));
+    expect(onDelete).toHaveBeenCalledWith('s1');
+  });
+
+  it('shows "Manage history…" footer when sessions exist', async () => {
+    const sessions = [makeSession({ id: 's1', title: 'Chat' })];
+
+    renderWithProviders(
+      <SessionHistoryPicker
+        sessions={sessions}
+        activeSessionId={null}
+        onRestoreSession={() => {}}
+        onDeleteSession={() => {}}
+      />
+    );
+
+    await userEvent.click(screen.getByLabelText('Session history'));
+
+    await waitFor(() => {
+      expect(screen.getByText('Manage history…')).toBeInTheDocument();
+      expect(screen.getByText('1 total')).toBeInTheDocument();
+    });
+  });
+
+  it('calls onOpenPanel when Manage history is clicked', async () => {
+    const onOpenPanel = vi.fn();
+    const sessions = [makeSession({ id: 's1', title: 'Chat' })];
+
+    renderWithProviders(
+      <SessionHistoryPicker
+        sessions={sessions}
+        activeSessionId={null}
+        onRestoreSession={() => {}}
+        onDeleteSession={() => {}}
+        onOpenPanel={onOpenPanel}
+      />
+    );
+
+    await userEvent.click(screen.getByLabelText('Session history'));
+
+    await waitFor(() => {
+      expect(screen.getByText('Manage history…')).toBeInTheDocument();
+    });
+
+    await userEvent.click(screen.getByText('Manage history…'));
+    expect(onOpenPanel).toHaveBeenCalledWith('history');
+  });
+
+  it('shows host label for each session', async () => {
+    const sessions = [makeSession({ id: 's1', title: 'Chat', host: 'excel' })];
+
+    renderWithProviders(
+      <SessionHistoryPicker
+        sessions={sessions}
+        activeSessionId={null}
+        onRestoreSession={() => {}}
+        onDeleteSession={() => {}}
+      />
+    );
+
+    await userEvent.click(screen.getByLabelText('Session history'));
+
+    await waitFor(() => {
+      expect(screen.getByText('excel')).toBeInTheDocument();
+    });
+  });
+
+  it('displays relative time for non-active sessions', async () => {
+    const sessions = [
+      makeSession({ id: 's1', title: 'Recent', updatedAt: Date.now() - 5 * 60_000 }), // 5m ago
+    ];
+
+    renderWithProviders(
+      <SessionHistoryPicker
+        sessions={sessions}
+        activeSessionId={null}
+        onRestoreSession={() => {}}
+        onDeleteSession={() => {}}
+      />
+    );
+
+    await userEvent.click(screen.getByLabelText('Session history'));
+
+    await waitFor(() => {
+      expect(screen.getByText('5m ago')).toBeInTheDocument();
+    });
+  });
+
+  // Bug regression: long session titles should be truncated with CSS
+  // to prevent tall list items from pushing other sessions out of view.
+  it('applies truncate class to session title buttons', async () => {
+    const longTitle = 'This is a very long session title that should be truncated to prevent layout breakage in the popover';
+    const sessions = [makeSession({ id: 's-long', title: longTitle })];
+
+    renderWithProviders(
+      <SessionHistoryPicker
+        sessions={sessions}
+        activeSessionId={null}
+        onRestoreSession={() => {}}
+        onDeleteSession={() => {}}
+      />
+    );
+
+    await userEvent.click(screen.getByLabelText('Session history'));
+
+    await waitFor(() => {
+      const btn = screen.getByText(longTitle);
+      expect(btn.className).toContain('truncate');
+    });
+  });
+});

--- a/tests/integration/session-history-store.test.ts
+++ b/tests/integration/session-history-store.test.ts
@@ -1,0 +1,255 @@
+/**
+ * Integration tests for sessionHistoryStore.
+ *
+ * Validates createSession, upsertActiveSession, deleteSession, clearSessionsForHost,
+ * 50-item limit (MAX_SESSIONS), host filtering, and active session management.
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import { useSessionHistoryStore } from '@/stores/sessionHistoryStore';
+import type { SessionHistoryItem } from '@/stores/sessionHistoryStore';
+
+beforeEach(() => {
+  useSessionHistoryStore.setState({
+    sessions: [],
+    activeSessionId: null,
+  });
+});
+
+// ─── createSession ────────────────────────────────────────────────────────────
+
+describe('sessionHistoryStore — createSession', () => {
+  it('creates a new session and sets it as active', () => {
+    const id = useSessionHistoryStore.getState().createSession('excel');
+    expect(typeof id).toBe('string');
+    expect(id.length).toBeGreaterThan(0);
+    expect(useSessionHistoryStore.getState().activeSessionId).toBe(id);
+    expect(useSessionHistoryStore.getState().sessions).toHaveLength(1);
+  });
+
+  it('new session has correct defaults', () => {
+    const id = useSessionHistoryStore.getState().createSession('powerpoint');
+    const session = useSessionHistoryStore.getState().sessions.find(s => s.id === id);
+    expect(session).toBeDefined();
+    expect(session!.title).toBe('New conversation');
+    expect(session!.host).toBe('powerpoint');
+    expect(session!.messages).toEqual([]);
+    expect(typeof session!.updatedAt).toBe('number');
+  });
+
+  it('creating multiple sessions accumulates them', () => {
+    useSessionHistoryStore.getState().createSession('excel');
+    useSessionHistoryStore.getState().createSession('excel');
+    useSessionHistoryStore.getState().createSession('powerpoint');
+    expect(useSessionHistoryStore.getState().sessions).toHaveLength(3);
+  });
+});
+
+// ─── setActiveSession ─────────────────────────────────────────────────────────
+
+describe('sessionHistoryStore — setActiveSession', () => {
+  it('sets the active session id', () => {
+    const id1 = useSessionHistoryStore.getState().createSession('excel');
+    const id2 = useSessionHistoryStore.getState().createSession('excel');
+    expect(useSessionHistoryStore.getState().activeSessionId).toBe(id2);
+
+    useSessionHistoryStore.getState().setActiveSession(id1);
+    expect(useSessionHistoryStore.getState().activeSessionId).toBe(id1);
+  });
+});
+
+// ─── upsertActiveSession ─────────────────────────────────────────────────────
+
+describe('sessionHistoryStore — upsertActiveSession', () => {
+  it('creates a session if none is active, then upserts it', () => {
+    useSessionHistoryStore.getState().upsertActiveSession({
+      host: 'excel',
+      title: 'My Chat',
+      messages: [{ role: 'user', content: 'hello' }],
+    });
+
+    const { sessions, activeSessionId } = useSessionHistoryStore.getState();
+    expect(sessions).toHaveLength(1);
+    expect(activeSessionId).toBe(sessions[0].id);
+    expect(sessions[0].title).toBe('My Chat');
+    expect(sessions[0].messages).toHaveLength(1);
+  });
+
+  it('updates existing active session on subsequent calls', () => {
+    const id = useSessionHistoryStore.getState().createSession('excel');
+    useSessionHistoryStore.getState().upsertActiveSession({
+      host: 'excel',
+      title: 'Updated Title',
+      messages: [{ role: 'assistant', content: 'hi' }],
+    });
+
+    const session = useSessionHistoryStore.getState().sessions.find(s => s.id === id);
+    expect(session!.title).toBe('Updated Title');
+    expect(session!.messages).toHaveLength(1);
+  });
+
+  it('upsert moves session to the top (most recent)', () => {
+    const id1 = useSessionHistoryStore.getState().createSession('excel');
+    useSessionHistoryStore.getState().createSession('excel');
+
+    // Switch back to id1 and upsert
+    useSessionHistoryStore.getState().setActiveSession(id1);
+    useSessionHistoryStore.getState().upsertActiveSession({
+      host: 'excel',
+      title: 'Refreshed',
+      messages: [],
+    });
+
+    const sessions = useSessionHistoryStore.getState().sessions;
+    // After sorting by updatedAt desc, id1 should be first
+    expect(sessions[0].id).toBe(id1);
+  });
+
+  it('deep-clones messages to prevent mutation (toSerializableMessages)', () => {
+    const original = [{ role: 'user', content: 'hello', nested: { a: 1 } }];
+    useSessionHistoryStore.getState().upsertActiveSession({
+      host: 'excel',
+      title: 'Clone Test',
+      messages: original,
+    });
+
+    const stored = useSessionHistoryStore.getState().sessions[0].messages as typeof original;
+    expect(stored).toEqual(original);
+    // Should be a different reference (deep clone)
+    expect(stored).not.toBe(original);
+  });
+});
+
+// ─── deleteSession ────────────────────────────────────────────────────────────
+
+describe('sessionHistoryStore — deleteSession', () => {
+  it('removes the specified session', () => {
+    const id = useSessionHistoryStore.getState().createSession('excel');
+    useSessionHistoryStore.getState().deleteSession(id);
+    expect(useSessionHistoryStore.getState().sessions).toHaveLength(0);
+  });
+
+  it('clears activeSessionId when the active session is deleted (falls back to first remaining)', () => {
+    const id1 = useSessionHistoryStore.getState().createSession('excel');
+    const id2 = useSessionHistoryStore.getState().createSession('excel');
+
+    // id2 is active
+    useSessionHistoryStore.getState().deleteSession(id2);
+    // Should fall back to id1
+    expect(useSessionHistoryStore.getState().activeSessionId).toBe(id1);
+  });
+
+  it('sets activeSessionId to null when last session is deleted', () => {
+    const id = useSessionHistoryStore.getState().createSession('excel');
+    useSessionHistoryStore.getState().deleteSession(id);
+    expect(useSessionHistoryStore.getState().activeSessionId).toBeNull();
+  });
+
+  it('preserves activeSessionId when a non-active session is deleted', () => {
+    const id1 = useSessionHistoryStore.getState().createSession('excel');
+    const id2 = useSessionHistoryStore.getState().createSession('excel');
+    // id2 is active
+    useSessionHistoryStore.getState().deleteSession(id1);
+    expect(useSessionHistoryStore.getState().activeSessionId).toBe(id2);
+  });
+});
+
+// ─── clearSessionsForHost ─────────────────────────────────────────────────────
+
+describe('sessionHistoryStore — clearSessionsForHost', () => {
+  it('removes all sessions for the specified host', () => {
+    useSessionHistoryStore.getState().createSession('excel');
+    useSessionHistoryStore.getState().createSession('excel');
+    useSessionHistoryStore.getState().createSession('powerpoint');
+
+    useSessionHistoryStore.getState().clearSessionsForHost('excel');
+
+    const sessions = useSessionHistoryStore.getState().sessions;
+    expect(sessions).toHaveLength(1);
+    expect(sessions[0].host).toBe('powerpoint');
+  });
+
+  it('updates activeSessionId when cleared host contained active session', () => {
+    useSessionHistoryStore.getState().createSession('powerpoint');
+    useSessionHistoryStore.getState().createSession('excel');
+    // excel session is active
+
+    useSessionHistoryStore.getState().clearSessionsForHost('excel');
+    const { activeSessionId, sessions } = useSessionHistoryStore.getState();
+    // Should fall back to the powerpoint session
+    expect(sessions).toHaveLength(1);
+    expect(activeSessionId).toBe(sessions[0].id);
+  });
+
+  it('preserves activeSessionId when another host is cleared', () => {
+    useSessionHistoryStore.getState().createSession('excel');
+    const excelId = useSessionHistoryStore.getState().activeSessionId;
+    useSessionHistoryStore.getState().createSession('powerpoint');
+    useSessionHistoryStore.getState().setActiveSession(excelId!);
+
+    useSessionHistoryStore.getState().clearSessionsForHost('powerpoint');
+    expect(useSessionHistoryStore.getState().activeSessionId).toBe(excelId);
+  });
+
+  it('sets activeSessionId to null when all sessions cleared', () => {
+    useSessionHistoryStore.getState().createSession('excel');
+    useSessionHistoryStore.getState().clearSessionsForHost('excel');
+    expect(useSessionHistoryStore.getState().activeSessionId).toBeNull();
+  });
+});
+
+// ─── MAX_SESSIONS limit ──────────────────────────────────────────────────────
+
+describe('sessionHistoryStore — MAX_SESSIONS (50) limit', () => {
+  it('trims sessions to 50 when limit is exceeded', () => {
+    // Create 55 sessions
+    for (let i = 0; i < 55; i++) {
+      useSessionHistoryStore.getState().createSession('excel');
+    }
+
+    const sessions = useSessionHistoryStore.getState().sessions;
+    expect(sessions.length).toBeLessThanOrEqual(50);
+  });
+
+  it('keeps the most recent sessions when trimming', () => {
+    // Seed with known timestamps
+    const sessions: SessionHistoryItem[] = [];
+    for (let i = 0; i < 55; i++) {
+      sessions.push({
+        id: `session-${i}`,
+        title: `Session ${i}`,
+        host: 'excel',
+        updatedAt: 1000 + i, // older = lower number
+        messages: [],
+      });
+    }
+    useSessionHistoryStore.setState({ sessions, activeSessionId: 'session-54' });
+
+    // Trigger trimming via upsert
+    useSessionHistoryStore.getState().upsertActiveSession({
+      host: 'excel',
+      title: 'Newest',
+      messages: [],
+    });
+
+    const stored = useSessionHistoryStore.getState().sessions;
+    expect(stored.length).toBeLessThanOrEqual(50);
+    // The first (session-0) through (session-4) should have been trimmed
+    const ids = stored.map(s => s.id);
+    expect(ids).not.toContain('session-0');
+    expect(ids).not.toContain('session-1');
+  });
+});
+
+// ─── Persistence configuration ───────────────────────────────────────────────
+
+describe('sessionHistoryStore — persistence', () => {
+  it('uses the correct persist key', () => {
+    // Access the persist API to check the name
+    const persistOptions = (
+      useSessionHistoryStore as unknown as { persist: { getOptions: () => { name: string } } }
+    ).persist;
+    if (persistOptions?.getOptions) {
+      expect(persistOptions.getOptions().name).toBe('office-coding-agent-session-history');
+    }
+  });
+});

--- a/tests/integration/settings-store.test.ts
+++ b/tests/integration/settings-store.test.ts
@@ -244,6 +244,20 @@ describe('settingsStore — MCP servers', () => {
     expect(useSettingsStore.getState().activeMcpServerNames).toContain('srv1');
   });
 
+  // Bug regression: toggling a bundled server from default state (null) should enable it
+  it('toggleMcpServer adds bundled server when activeMcpServerNames is null', () => {
+    // Default state: activeMcpServerNames === null (all imported ON, bundled OFF)
+    useSettingsStore.getState().importMcpServers([server1]);
+    expect(useSettingsStore.getState().activeMcpServerNames).toBeNull();
+    // Toggle a bundled server (e.g. 'workiq') that is NOT in importedMcpServers
+    useSettingsStore.getState().toggleMcpServer('workiq');
+    const active = useSettingsStore.getState().activeMcpServerNames;
+    // Before fix: 'workiq' was silently dropped because allNames only contained imported servers
+    expect(active).toContain('workiq');
+    // Imported servers should also be present
+    expect(active).toContain('srv1');
+  });
+
   it('reset clears imported MCP servers', () => {
     useSettingsStore.getState().importMcpServers([server1]);
     useSettingsStore.getState().reset();
@@ -260,7 +274,9 @@ describe('settingsStore — MCP servers', () => {
 
   it('updateMcpServer preserves name even if config tries to change it', () => {
     useSettingsStore.getState().importMcpServers([server1]);
-    useSettingsStore.getState().updateMcpServer('srv1', { name: 'hacked', transport: 'sse' } as Partial<McpServerConfig>);
+    useSettingsStore
+      .getState()
+      .updateMcpServer('srv1', { name: 'hacked', transport: 'sse' } as Partial<McpServerConfig>);
     expect(useSettingsStore.getState().importedMcpServers[0].name).toBe('srv1');
     expect(useSettingsStore.getState().importedMcpServers[0].transport).toBe('sse');
   });
@@ -298,7 +314,13 @@ describe('settingsStore — name deduplication', () => {
 
   it('importAgents renames second import of same name with incrementing suffix', () => {
     const makeAgent = (name: string): AgentConfig => ({
-      metadata: { name, description: 'desc', version: '1.0.0', hosts: ['excel'], defaultForHosts: [] },
+      metadata: {
+        name,
+        description: 'desc',
+        version: '1.0.0',
+        hosts: ['excel'],
+        defaultForHosts: [],
+      },
       instructions: '',
     });
 
@@ -311,15 +333,19 @@ describe('settingsStore — name deduplication', () => {
 
   it('importAgents applies incrementing index beyond "(imported)"', () => {
     const makeAgent = (name: string): AgentConfig => ({
-      metadata: { name, description: 'desc', version: '1.0.0', hosts: ['excel'], defaultForHosts: [] },
+      metadata: {
+        name,
+        description: 'desc',
+        version: '1.0.0',
+        hosts: ['excel'],
+        defaultForHosts: [],
+      },
       instructions: '',
     });
 
-    useSettingsStore.getState().importAgents([
-      makeAgent('Dupe'),
-      makeAgent('Dupe'),
-      makeAgent('Dupe'),
-    ]);
+    useSettingsStore
+      .getState()
+      .importAgents([makeAgent('Dupe'), makeAgent('Dupe'), makeAgent('Dupe')]);
 
     const names = useSettingsStore.getState().importedAgents.map(a => a.metadata.name);
     expect(names[0]).toBe('Dupe');

--- a/tests/integration/skill-service.test.ts
+++ b/tests/integration/skill-service.test.ts
@@ -168,4 +168,44 @@ Content`;
     const { metadata } = parseFrontmatter(raw);
     expect(metadata.hosts).toEqual(['excel', 'word']);
   });
+
+  // Bug regression: hosts should be normalized to lowercase
+  it('normalizes capitalized host names to lowercase in inline array', () => {
+    const raw = `---
+name: caps-host-skill
+description: Test
+version: 1.0.0
+hosts: [Excel, PowerPoint]
+---
+Content`;
+    const { metadata } = parseFrontmatter(raw);
+    // Before fix: stored as 'Excel' which never matched lowercase 'excel' in filtering
+    expect(metadata.hosts).toEqual(['excel', 'powerpoint']);
+  });
+
+  it('normalizes capitalized host names to lowercase in list format', () => {
+    const raw = `---
+name: caps-host-skill
+description: Test
+version: 1.0.0
+hosts:
+  - Excel
+  - Word
+---
+Content`;
+    const { metadata } = parseFrontmatter(raw);
+    expect(metadata.hosts).toEqual(['excel', 'word']);
+  });
+
+  it('filters out invalid host values during parsing', () => {
+    const raw = `---
+name: bad-host-skill
+description: Test
+version: 1.0.0
+hosts: [excel, invalidhost, word]
+---
+Content`;
+    const { metadata } = parseFrontmatter(raw);
+    expect(metadata.hosts).toEqual(['excel', 'word']);
+  });
 });

--- a/tests/integration/slide-panel.test.tsx
+++ b/tests/integration/slide-panel.test.tsx
@@ -1,0 +1,193 @@
+/**
+ * Integration tests for SlidePanel.
+ *
+ * Verifies dialog role, aria attributes, back-button, Escape-to-close,
+ * title / description rendering, and children-only-when-open behaviour.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { SlidePanel } from '@/components/SlidePanel';
+
+describe('Integration: SlidePanel', () => {
+  it('renders with role="dialog" and aria-modal', () => {
+    render(
+      <SlidePanel open={true} onClose={() => {}} title="Settings">
+        <p>content</p>
+      </SlidePanel>
+    );
+
+    const dialog = screen.getByRole('dialog');
+    expect(dialog).toHaveAttribute('aria-modal', 'true');
+    expect(dialog).toHaveAttribute('aria-label', 'Settings');
+  });
+
+  it('renders title in the header', () => {
+    render(
+      <SlidePanel open={true} onClose={() => {}} title="My Panel">
+        <p>content</p>
+      </SlidePanel>
+    );
+
+    expect(screen.getByText('My Panel')).toBeInTheDocument();
+  });
+
+  it('renders description when provided', () => {
+    render(
+      <SlidePanel open={true} onClose={() => {}} title="Panel" description="Some description">
+        <p>content</p>
+      </SlidePanel>
+    );
+
+    expect(screen.getByText('Some description')).toBeInTheDocument();
+  });
+
+  it('does not render description when not provided', () => {
+    render(
+      <SlidePanel open={true} onClose={() => {}} title="Panel">
+        <p>content</p>
+      </SlidePanel>
+    );
+
+    expect(screen.queryByText('Some description')).not.toBeInTheDocument();
+  });
+
+  it('renders children when open', () => {
+    render(
+      <SlidePanel open={true} onClose={() => {}} title="Panel">
+        <p>Visible child</p>
+      </SlidePanel>
+    );
+
+    expect(screen.getByText('Visible child')).toBeInTheDocument();
+  });
+
+  it('does not render children when closed', () => {
+    render(
+      <SlidePanel open={false} onClose={() => {}} title="Panel">
+        <p>Hidden child</p>
+      </SlidePanel>
+    );
+
+    // children are conditionally rendered: {open && children}
+    expect(screen.queryByText('Hidden child')).not.toBeInTheDocument();
+  });
+
+  it('sets aria-hidden="true" when closed', () => {
+    render(
+      <SlidePanel open={false} onClose={() => {}} title="Panel">
+        <p>content</p>
+      </SlidePanel>
+    );
+
+    const dialog = screen.getByRole('dialog', { hidden: true });
+    expect(dialog).toHaveAttribute('aria-hidden', 'true');
+  });
+
+  it('sets aria-hidden="false" when open', () => {
+    render(
+      <SlidePanel open={true} onClose={() => {}} title="Panel">
+        <p>content</p>
+      </SlidePanel>
+    );
+
+    const dialog = screen.getByRole('dialog');
+    expect(dialog).toHaveAttribute('aria-hidden', 'false');
+  });
+
+  it('calls onClose when Back button is clicked', async () => {
+    const onClose = vi.fn();
+
+    render(
+      <SlidePanel open={true} onClose={onClose} title="Panel">
+        <p>content</p>
+      </SlidePanel>
+    );
+
+    await userEvent.click(screen.getByLabelText('Back'));
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it('calls onClose when Escape key is pressed', async () => {
+    const onClose = vi.fn();
+
+    render(
+      <SlidePanel open={true} onClose={onClose} title="Panel">
+        <p>content</p>
+      </SlidePanel>
+    );
+
+    // fireEvent because keydown listeners are on document
+    fireEvent.keyDown(document, { key: 'Escape' });
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it('does not call onClose on Escape when closed', () => {
+    const onClose = vi.fn();
+
+    render(
+      <SlidePanel open={false} onClose={onClose} title="Panel">
+        <p>content</p>
+      </SlidePanel>
+    );
+
+    fireEvent.keyDown(document, { key: 'Escape' });
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it('renders back button with correct aria-label and title', () => {
+    render(
+      <SlidePanel open={true} onClose={() => {}} title="Panel">
+        <p>content</p>
+      </SlidePanel>
+    );
+
+    const backBtn = screen.getByLabelText('Back');
+    expect(backBtn).toHaveAttribute('title', 'Back');
+  });
+
+  it('applies translate-x-0 when open and translate-x-full when closed', () => {
+    const { rerender } = render(
+      <SlidePanel open={true} onClose={() => {}} title="Panel">
+        <p>content</p>
+      </SlidePanel>
+    );
+
+    const dialog = screen.getByRole('dialog');
+    expect(dialog.className).toContain('translate-x-0');
+
+    rerender(
+      <SlidePanel open={false} onClose={() => {}} title="Panel">
+        <p>content</p>
+      </SlidePanel>
+    );
+
+    const dialogClosed = screen.getByRole('dialog', { hidden: true });
+    expect(dialogClosed.className).toContain('translate-x-full');
+  });
+
+  // Bug regression: closed SlidePanel should be inert to prevent keyboard focus
+  // from reaching off-screen Back buttons and other interactive elements.
+  it('has inert attribute when closed to prevent keyboard focus leak', () => {
+    render(
+      <SlidePanel open={false} onClose={() => {}} title="Panel">
+        <p>content</p>
+      </SlidePanel>
+    );
+
+    const dialog = screen.getByRole('dialog', { hidden: true });
+    // The inert attribute should be present when the panel is closed
+    expect(dialog).toHaveAttribute('inert');
+  });
+
+  it('does not have inert attribute when open', () => {
+    render(
+      <SlidePanel open={true} onClose={() => {}} title="Panel">
+        <p>content</p>
+      </SlidePanel>
+    );
+
+    const dialog = screen.getByRole('dialog');
+    expect(dialog).not.toHaveAttribute('inert');
+  });
+});

--- a/tests/integration/system-prompt.test.ts
+++ b/tests/integration/system-prompt.test.ts
@@ -1,0 +1,86 @@
+/**
+ * Integration tests for system prompt construction.
+ *
+ * Tests getAppPromptForHost() and buildSystemPrompt() from
+ * src/services/ai/systemPrompt.ts.
+ */
+import { describe, it, expect } from 'vitest';
+import { getAppPromptForHost, buildSystemPrompt, BASE_PROMPT } from '@/services/ai/systemPrompt';
+
+describe('Integration: systemPrompt', () => {
+  describe('getAppPromptForHost', () => {
+    it('returns non-empty prompt for excel', () => {
+      const prompt = getAppPromptForHost('excel');
+      expect(prompt).toBeTruthy();
+      expect(prompt.length).toBeGreaterThan(10);
+    });
+
+    it('returns non-empty prompt for powerpoint', () => {
+      const prompt = getAppPromptForHost('powerpoint');
+      expect(prompt).toBeTruthy();
+      expect(prompt.length).toBeGreaterThan(10);
+    });
+
+    it('returns non-empty prompt for word', () => {
+      const prompt = getAppPromptForHost('word');
+      expect(prompt).toBeTruthy();
+      expect(prompt.length).toBeGreaterThan(10);
+    });
+
+    it('returns non-empty prompt for outlook', () => {
+      const prompt = getAppPromptForHost('outlook');
+      expect(prompt).toBeTruthy();
+      expect(prompt.length).toBeGreaterThan(10);
+    });
+
+    it('returns a default fallback for unknown host', () => {
+      const prompt = getAppPromptForHost('unknown' as any);
+      expect(prompt).toContain('Office');
+    });
+
+    it('returns different prompts for different hosts', () => {
+      const excelPrompt = getAppPromptForHost('excel');
+      const pptPrompt = getAppPromptForHost('powerpoint');
+      const wordPrompt = getAppPromptForHost('word');
+      const outlookPrompt = getAppPromptForHost('outlook');
+
+      // All four host-specific prompts should be distinct
+      const prompts = new Set([excelPrompt, pptPrompt, wordPrompt, outlookPrompt]);
+      expect(prompts.size).toBe(4);
+    });
+  });
+
+  describe('BASE_PROMPT', () => {
+    it('is a non-empty string', () => {
+      expect(typeof BASE_PROMPT).toBe('string');
+      expect(BASE_PROMPT.length).toBeGreaterThan(50);
+    });
+  });
+
+  describe('buildSystemPrompt', () => {
+    it('includes BASE_PROMPT content', () => {
+      const prompt = buildSystemPrompt('excel');
+      expect(prompt).toContain(BASE_PROMPT);
+    });
+
+    it('includes host-specific prompt', () => {
+      const hostPrompt = getAppPromptForHost('excel');
+      const full = buildSystemPrompt('excel');
+      expect(full).toContain(hostPrompt);
+    });
+
+    it('joins BASE_PROMPT and host prompt with double newline', () => {
+      const full = buildSystemPrompt('powerpoint');
+      const hostPrompt = getAppPromptForHost('powerpoint');
+      expect(full).toBe(`${BASE_PROMPT}\n\n${hostPrompt}`);
+    });
+
+    it('works for every known host', () => {
+      const hosts = ['excel', 'powerpoint', 'word', 'outlook'] as const;
+      for (const host of hosts) {
+        const prompt = buildSystemPrompt(host);
+        expect(prompt.length).toBeGreaterThan(BASE_PROMPT.length);
+      }
+    });
+  });
+});

--- a/tests/integration/thread-message-rendering.test.tsx
+++ b/tests/integration/thread-message-rendering.test.tsx
@@ -1,0 +1,581 @@
+/**
+ * Integration tests for Thread / AssistantMessage rendering behaviour.
+ *
+ * Specifically covers:
+ *  1. Action bar (copy / thumbsup / thumbsdown) is present in the DOM after
+ *     a completed assistant text response.
+ *  2. The "MessagePartText can only be used inside text or reasoning message
+ *     parts" crash does NOT occur when the assistant response ends with a
+ *     tool-call part (i.e. no trailing text part).
+ *
+ * Uses the same fake session/client pattern as use-office-chat.test.tsx.
+ * No real WebSocket or Copilot API is required.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor, act } from '@testing-library/react';
+import { AssistantRuntimeProvider } from '@assistant-ui/react';
+import type { AppendMessage } from '@assistant-ui/react';
+import type { SessionEvent } from '@github/copilot-sdk';
+import { Thread } from '@/components/assistant-ui/thread';
+import { useOfficeChat } from '@/hooks/useOfficeChat';
+import { useSettingsStore } from '@/stores/settingsStore';
+import { useSessionHistoryStore } from '@/stores/sessionHistoryStore';
+import { ThinkingContext } from '@/contexts/ThinkingContext';
+
+// ─── Fake session / client ────────────────────────────────────────────────────
+
+type EventEmitter = (event: SessionEvent) => void;
+
+function makeFakeSession(events: SessionEvent[]) {
+  return {
+    sessionId: 'test-session-id',
+    async *query() {
+      for (const event of events) {
+        yield event;
+        if (event.type === 'session.idle') return;
+      }
+    },
+    on: vi.fn(),
+    onPermissionRequest: vi.fn(() => () => undefined),
+    destroy: vi.fn().mockResolvedValue(undefined),
+    send: vi.fn().mockResolvedValue('msg-id'),
+    registerTools: vi.fn(),
+    getToolHandler: vi.fn(),
+    respondPermission: vi.fn().mockResolvedValue(undefined),
+    _dispatchEvent: vi.fn() as EventEmitter,
+  };
+}
+
+function makeFakeClient(session: ReturnType<typeof makeFakeSession>) {
+  return {
+    start: vi.fn().mockResolvedValue(undefined),
+    createSession: vi.fn().mockResolvedValue(session),
+    listModels: vi.fn().mockResolvedValue([]),
+    stop: vi.fn().mockResolvedValue(undefined),
+    onMcpStatus: vi.fn(() => () => undefined),
+    onMcpLog: vi.fn(() => () => undefined),
+    onMcpTools: vi.fn(() => () => undefined),
+  };
+}
+
+function makeEvent<T extends SessionEvent['type']>(
+  type: T,
+  data: Extract<SessionEvent, { type: T }>['data']
+): SessionEvent {
+  return {
+    id: 'e1',
+    timestamp: new Date().toISOString(),
+    parentId: null,
+    type,
+    data,
+  } as SessionEvent;
+}
+
+const IDLE_EVENT = makeEvent('session.idle', {});
+
+const APPEND_MSG = (): AppendMessage => ({
+  parentId: null,
+  sourceId: null,
+  runConfig: undefined,
+  role: 'user',
+  content: [{ type: 'text', text: 'test' }],
+  attachments: [],
+  metadata: { custom: {} },
+  createdAt: new Date(),
+});
+
+vi.mock('@/lib/websocket-client', () => ({
+  createWebSocketClient: vi.fn(),
+}));
+
+import { createWebSocketClient } from '@/lib/websocket-client';
+const mockCreate = vi.mocked(createWebSocketClient);
+
+// ─── Shared test wrapper ──────────────────────────────────────────────────────
+
+/**
+ * Renders the Thread with a real (faked) useOfficeChat runtime and returns
+ * the hook result so tests can drive messages through `runtime.thread.append`.
+ */
+function renderThreadWithHook(host: 'excel' = 'excel') {
+  let hookRef: ReturnType<typeof useOfficeChat> | undefined;
+
+  function TestComponent() {
+    const chat = useOfficeChat(host);
+    hookRef = chat;
+    return (
+      <AssistantRuntimeProvider runtime={chat.runtime}>
+        <ThinkingContext.Provider value={chat.thinkingText}>
+          <Thread />
+        </ThinkingContext.Provider>
+      </AssistantRuntimeProvider>
+    );
+  }
+
+  render(<TestComponent />);
+  return { getHook: () => hookRef! };
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('Thread – AssistantMessage rendering', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useSettingsStore.getState().reset();
+    useSessionHistoryStore.setState({ sessions: [], activeSessionId: null });
+  });
+
+  it('renders the action bar (copy + thumbsup + thumbsdown) in a completed text response', async () => {
+    const session = makeFakeSession([
+      makeEvent('assistant.message', { messageId: 'msg1', content: 'Hello!' }),
+      IDLE_EVENT,
+    ]);
+    const client = makeFakeClient(session);
+    mockCreate.mockResolvedValue(client as never);
+
+    const { getHook } = renderThreadWithHook();
+
+    await act(async () => {
+      await new Promise(r => setTimeout(r, 100));
+    });
+
+    await act(async () => {
+      getHook().runtime.thread.append(APPEND_MSG());
+      await new Promise(r => setTimeout(r, 200));
+    });
+
+    // Wait for the assistant message bubble to appear
+    await waitFor(() => {
+      expect(document.querySelector('[data-role="assistant"]')).toBeInTheDocument();
+    });
+
+    // Action bar must exist in the DOM (opacity-0 when not hovered, but present)
+    const actionBar = document.querySelector('.aui-assistant-action-bar');
+    expect(actionBar).toBeInTheDocument();
+
+    // All three buttons must be present.
+    // TooltipIconButton renders the tooltip text as an sr-only span inside the button,
+    // making it the accessible name — so getByRole('button', { name }) is the right query.
+    expect(screen.getByRole('button', { name: 'Copy' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Good response' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Bad response' })).toBeInTheDocument();
+
+    // Initially hidden (no hover) — CSS opacity-0 class is applied
+    expect(actionBar).toHaveClass('opacity-0');
+  });
+
+  it('action bar is positioned inside the assistant message container', async () => {
+    const session = makeFakeSession([
+      makeEvent('assistant.message', { messageId: 'msg1', content: 'Done!' }),
+      IDLE_EVENT,
+    ]);
+    const client = makeFakeClient(session);
+    mockCreate.mockResolvedValue(client as never);
+
+    const { getHook } = renderThreadWithHook();
+
+    await act(async () => {
+      await new Promise(r => setTimeout(r, 100));
+    });
+    await act(async () => {
+      getHook().runtime.thread.append(APPEND_MSG());
+      await new Promise(r => setTimeout(r, 200));
+    });
+
+    await waitFor(() => {
+      expect(document.querySelector('[data-role="assistant"]')).toBeInTheDocument();
+    });
+
+    const msg = document.querySelector('[data-role="assistant"]');
+    const actionBar = msg?.querySelector('.aui-assistant-action-bar');
+    expect(actionBar).toBeTruthy();
+  });
+
+  it('does NOT crash when the assistant response contains only tool-call parts (no text)', async () => {
+    // This is the regression test for "MessagePartText can only be used inside
+    // text or reasoning message parts".
+    //
+    // When a response ends with a tool-call part and has no text part,
+    // @assistant-ui's EmptyPartFallback was previously rendered, which called
+    // useMessagePartText() in the wrong context and threw.
+    // The fix: Empty: () => null + unstable_showEmptyOnNonTextEnd={false}.
+    const session = makeFakeSession([
+      makeEvent('tool.execution_start', {
+        toolCallId: 'tc1',
+        toolName: 'manage_skills',
+        arguments: { action: 'list' },
+      }),
+      makeEvent('tool.execution_complete', {
+        toolCallId: 'tc1',
+        success: true,
+        result: { content: '[]' },
+      }),
+      // ⚠️  No assistant.message event — response ends at the tool call
+      IDLE_EVENT,
+    ]);
+    const client = makeFakeClient(session);
+    mockCreate.mockResolvedValue(client as never);
+
+    const { getHook } = renderThreadWithHook();
+
+    await act(async () => {
+      await new Promise(r => setTimeout(r, 100));
+    });
+    await act(async () => {
+      getHook().runtime.thread.append(APPEND_MSG());
+      await new Promise(r => setTimeout(r, 200));
+    });
+
+    await waitFor(() => {
+      expect(document.querySelector('[data-role="assistant"]')).toBeInTheDocument();
+    });
+
+    // The critical assertion: no error boundary and no crash text
+    expect(screen.queryByText(/something went wrong/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/MessagePartText can only/i)).not.toBeInTheDocument();
+
+    // The tool card should render normally
+    expect(document.querySelector('[data-slot="tool-fallback-root"]')).toBeInTheDocument();
+  });
+
+  it('renders the message text content alongside the action bar', async () => {
+    const session = makeFakeSession([
+      makeEvent('assistant.message', { messageId: 'msg1', content: 'All good here!' }),
+      IDLE_EVENT,
+    ]);
+    const client = makeFakeClient(session);
+    mockCreate.mockResolvedValue(client as never);
+
+    const { getHook } = renderThreadWithHook();
+
+    await act(async () => {
+      await new Promise(r => setTimeout(r, 100));
+    });
+    await act(async () => {
+      getHook().runtime.thread.append(APPEND_MSG());
+      await new Promise(r => setTimeout(r, 200));
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('All good here!')).toBeInTheDocument();
+    });
+
+    // Action bar is still present alongside the text
+    expect(document.querySelector('.aui-assistant-action-bar')).toBeInTheDocument();
+  });
+
+  it('thinking indicator appears with "Thinking…" during streaming', async () => {
+    // Use a session that yields a tool start + complete + text so the stream
+    // takes some time, then idle.
+    const session = makeFakeSession([
+      makeEvent('tool.execution_start', {
+        toolCallId: 'tc1',
+        toolName: 'get_range_values',
+        arguments: { address: 'A1:C3' },
+      }),
+      makeEvent('tool.execution_complete', {
+        toolCallId: 'tc1',
+        success: true,
+        result: { content: '[[1,2],[3,4]]' },
+      }),
+      makeEvent('assistant.message', { messageId: 'msg1', content: 'Here is the data.' }),
+      IDLE_EVENT,
+    ]);
+    const client = makeFakeClient(session);
+    mockCreate.mockResolvedValue(client as never);
+
+    const { getHook } = renderThreadWithHook();
+
+    await act(async () => {
+      await new Promise(r => setTimeout(r, 100));
+    });
+    await act(async () => {
+      getHook().runtime.thread.append(APPEND_MSG());
+      await new Promise(r => setTimeout(r, 200));
+    });
+
+    // After the stream completes, the thinking indicator should be gone
+    await waitFor(() => {
+      expect(document.querySelector('.aui-assistant-thinking-indicator')).not.toBeInTheDocument();
+    });
+  });
+
+  it('thinking indicator is rendered at the thread level, not inside individual messages', async () => {
+    const session = makeFakeSession([
+      makeEvent('assistant.message', { messageId: 'msg1', content: 'Done' }),
+      IDLE_EVENT,
+    ]);
+    const client = makeFakeClient(session);
+    mockCreate.mockResolvedValue(client as never);
+
+    const { getHook } = renderThreadWithHook();
+
+    await act(async () => {
+      await new Promise(r => setTimeout(r, 100));
+    });
+    await act(async () => {
+      getHook().runtime.thread.append(APPEND_MSG());
+      await new Promise(r => setTimeout(r, 200));
+    });
+
+    await waitFor(() => {
+      expect(document.querySelector('[data-role="assistant"]')).toBeInTheDocument();
+    });
+
+    // The thinking indicator should NOT be inside any assistant message
+    const assistantMsg = document.querySelector('[data-role="assistant"]');
+    const indicatorInsideMsg = assistantMsg?.querySelector('.aui-assistant-thinking-indicator');
+    expect(indicatorInsideMsg).toBeNull();
+  });
+
+  it('does NOT crash when message has only tool-call parts with empty streamText', async () => {
+    // Regression: updateAssistant() used to always include { type: 'text', text: '' }
+    // which fromThreadMessageLike() would strip, producing 0-part or non-text-ending
+    // messages that crashed MarkdownTextPrimitive.
+    const session = makeFakeSession([
+      makeEvent('tool.execution_start', {
+        toolCallId: 'tc1',
+        toolName: 'set_range_values',
+        arguments: { address: 'A1', values: [[1]] },
+      }),
+      makeEvent('tool.execution_complete', {
+        toolCallId: 'tc1',
+        success: true,
+        result: { content: 'OK' },
+      }),
+      makeEvent('tool.execution_start', {
+        toolCallId: 'tc2',
+        toolName: 'get_range_values',
+        arguments: { address: 'A1:B2' },
+      }),
+      makeEvent('tool.execution_complete', {
+        toolCallId: 'tc2',
+        success: true,
+        result: { content: '[[1,2]]' },
+      }),
+      // assistant.message with text arrives only AFTER all tool calls
+      makeEvent('assistant.message', { messageId: 'msg1', content: 'Done!' }),
+      IDLE_EVENT,
+    ]);
+    const client = makeFakeClient(session);
+    mockCreate.mockResolvedValue(client as never);
+
+    const { getHook } = renderThreadWithHook();
+
+    await act(async () => {
+      await new Promise(r => setTimeout(r, 100));
+    });
+    await act(async () => {
+      getHook().runtime.thread.append(APPEND_MSG());
+      await new Promise(r => setTimeout(r, 300));
+    });
+
+    // Must not crash
+    expect(screen.queryByText(/something went wrong/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/MessagePartText can only/i)).not.toBeInTheDocument();
+
+    // Final text should render
+    await waitFor(() => {
+      expect(screen.getByText('Done!')).toBeInTheDocument();
+    });
+  });
+
+  it('does NOT crash when Thread renders mid-stream with tool parts and empty streamText', async () => {
+    // KEY REGRESSION TEST: The crash only happened when React rendered the
+    // Thread while the assistant message was in-progress with tool-call parts
+    // and streamText = ''.  Fast-session tests miss this because by the time
+    // React paints, the stream is already done.  This test pauses mid-stream
+    // so the Thread renders the intermediate state.
+    let resolveStream!: () => void;
+    const streamGate = new Promise<void>(r => {
+      resolveStream = r;
+    });
+
+    const pausingSession = {
+      sessionId: 'test-session-id',
+      async *query() {
+        yield makeEvent('tool.execution_start', {
+          toolCallId: 'tc1',
+          toolName: 'set_range_values',
+          arguments: { address: 'A1', values: [[42]] },
+        });
+        yield makeEvent('tool.execution_complete', {
+          toolCallId: 'tc1',
+          success: true,
+          result: { content: 'OK' },
+        });
+        // ── PAUSE ── React will render the in-progress message here.
+        // At this point: toolParts has tc1, streamText is '' (no text yet).
+        await streamGate;
+        yield makeEvent('assistant.message', { messageId: 'msg1', content: 'All set.' });
+        yield IDLE_EVENT;
+      },
+      on: vi.fn(),
+      onPermissionRequest: vi.fn(() => () => undefined),
+      destroy: vi.fn().mockResolvedValue(undefined),
+      send: vi.fn().mockResolvedValue('msg-id'),
+      registerTools: vi.fn(),
+      getToolHandler: vi.fn(),
+      respondPermission: vi.fn().mockResolvedValue(undefined),
+      _dispatchEvent: vi.fn(),
+    };
+    const client = makeFakeClient(pausingSession as ReturnType<typeof makeFakeSession>);
+    mockCreate.mockResolvedValue(client as never);
+
+    const { getHook } = renderThreadWithHook();
+
+    await act(async () => {
+      await new Promise(r => setTimeout(r, 100));
+    });
+
+    // Start the stream — it will pause after the tool completes
+    await act(async () => {
+      getHook().runtime.thread.append(APPEND_MSG());
+      await new Promise(r => setTimeout(r, 150));
+    });
+
+    // The Thread has now rendered the in-progress assistant message with
+    // only a tool-call part and no text.  This is where the old code crashed
+    // because updateAssistant() sent { text: '' } which got stripped by
+    // fromThreadMessageLike(), leaving only the tool-call part.
+    expect(screen.queryByText(/MessagePartText can only/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/something went wrong/i)).not.toBeInTheDocument();
+
+    // The tool card should be visible
+    expect(document.querySelector('[data-slot="tool-fallback-root"]')).toBeInTheDocument();
+
+    // Release the stream and let it finish
+    await act(async () => {
+      resolveStream();
+      await new Promise(r => setTimeout(r, 200));
+    });
+
+    // Final text should render
+    await waitFor(() => {
+      expect(screen.getByText('All set.')).toBeInTheDocument();
+    });
+  });
+
+  it('thinking indicator shows humanized tool name in the rendered DOM during streaming', async () => {
+    // Regression test: thinking indicator was stuck on "Thinking…" because the
+    // AuiIf wrapper depended on the AUI store's deferred useEffect sync.
+    // After the fix, the indicator reads directly from ThinkingContext
+    // (set via flushSync) so it updates immediately.
+    let resolveStream!: () => void;
+    const streamGate = new Promise<void>(r => {
+      resolveStream = r;
+    });
+
+    const pausingSession = {
+      sessionId: 'test-session-id',
+      async *query() {
+        yield makeEvent('tool.execution_start', {
+          toolCallId: 'tc1',
+          toolName: 'get_range_values',
+          arguments: { address: 'A1:C3' },
+        });
+        // ── PAUSE ── thinking text should now say "Get range values…"
+        await streamGate;
+        yield makeEvent('tool.execution_complete', {
+          toolCallId: 'tc1',
+          success: true,
+          result: { content: '[[1]]' },
+        });
+        yield makeEvent('assistant.message', { messageId: 'msg1', content: 'Got it.' });
+        yield IDLE_EVENT;
+      },
+      on: vi.fn(),
+      onPermissionRequest: vi.fn(() => () => undefined),
+      destroy: vi.fn().mockResolvedValue(undefined),
+      send: vi.fn().mockResolvedValue('msg-id'),
+      registerTools: vi.fn(),
+      getToolHandler: vi.fn(),
+      respondPermission: vi.fn().mockResolvedValue(undefined),
+      _dispatchEvent: vi.fn(),
+    };
+    const client = makeFakeClient(pausingSession as ReturnType<typeof makeFakeSession>);
+    mockCreate.mockResolvedValue(client as never);
+
+    const { getHook } = renderThreadWithHook();
+
+    await act(async () => {
+      await new Promise(r => setTimeout(r, 100));
+    });
+
+    // Start the stream — it will pause after tool.execution_start
+    await act(async () => {
+      getHook().runtime.thread.append(APPEND_MSG());
+      await new Promise(r => setTimeout(r, 150));
+    });
+
+    // The thinking indicator should be visible with the humanized tool name
+    const indicator = document.querySelector('.aui-assistant-thinking-indicator');
+    expect(indicator).toBeInTheDocument();
+    expect(indicator!.textContent).toContain('Get range values…');
+
+    // Release and finish
+    await act(async () => {
+      resolveStream();
+      await new Promise(r => setTimeout(r, 200));
+    });
+
+    // Indicator should be gone after completion
+    expect(document.querySelector('.aui-assistant-thinking-indicator')).not.toBeInTheDocument();
+  });
+
+  it('thinking indicator shows report_intent text in the rendered DOM', async () => {
+    let resolveStream!: () => void;
+    const streamGate = new Promise<void>(r => {
+      resolveStream = r;
+    });
+
+    const pausingSession = {
+      sessionId: 'test-session-id',
+      async *query() {
+        yield makeEvent('tool.execution_start', {
+          toolCallId: 'ri1',
+          toolName: 'report_intent',
+          arguments: { intent: 'Analyzing your data' },
+        });
+        // ── PAUSE ── thinking text should now say "Analyzing your data"
+        await streamGate;
+        yield makeEvent('assistant.message', { messageId: 'msg1', content: 'Analysis done.' });
+        yield IDLE_EVENT;
+      },
+      on: vi.fn(),
+      onPermissionRequest: vi.fn(() => () => undefined),
+      destroy: vi.fn().mockResolvedValue(undefined),
+      send: vi.fn().mockResolvedValue('msg-id'),
+      registerTools: vi.fn(),
+      getToolHandler: vi.fn(),
+      respondPermission: vi.fn().mockResolvedValue(undefined),
+      _dispatchEvent: vi.fn(),
+    };
+    const client = makeFakeClient(pausingSession as ReturnType<typeof makeFakeSession>);
+    mockCreate.mockResolvedValue(client as never);
+
+    const { getHook } = renderThreadWithHook();
+
+    await act(async () => {
+      await new Promise(r => setTimeout(r, 100));
+    });
+
+    await act(async () => {
+      getHook().runtime.thread.append(APPEND_MSG());
+      await new Promise(r => setTimeout(r, 150));
+    });
+
+    // The thinking indicator should show the intent text, not "Thinking…"
+    const indicator = document.querySelector('.aui-assistant-thinking-indicator');
+    expect(indicator).toBeInTheDocument();
+    expect(indicator!.textContent).toContain('Analyzing your data');
+
+    await act(async () => {
+      resolveStream();
+      await new Promise(r => setTimeout(r, 200));
+    });
+
+    expect(document.querySelector('.aui-assistant-thinking-indicator')).not.toBeInTheDocument();
+  });
+});

--- a/tests/integration/tool-result-summary.test.ts
+++ b/tests/integration/tool-result-summary.test.ts
@@ -1,0 +1,140 @@
+/**
+ * Integration tests for toolResultSummary().
+ *
+ * Validates the short, human-readable summary generation for tool results
+ * displayed in collapsed tool card headers.
+ */
+import { describe, it, expect } from 'vitest';
+import { toolResultSummary } from '@/utils/toolResultSummary';
+
+describe('Integration: toolResultSummary', () => {
+  // --- null / undefined / empty ---
+  it('returns empty string for null', () => {
+    expect(toolResultSummary(null)).toBe('');
+  });
+
+  it('returns empty string for undefined', () => {
+    expect(toolResultSummary(undefined)).toBe('');
+  });
+
+  // --- plain strings ---
+  it('returns short string as-is', () => {
+    expect(toolResultSummary('Done')).toBe('Done');
+  });
+
+  it('truncates long strings to 100 chars + ellipsis', () => {
+    const long = 'x'.repeat(150);
+    const result = toolResultSummary(long);
+    expect(result).toHaveLength(103); // 100 + '...'
+    expect(result.endsWith('...')).toBe(true);
+  });
+
+  it('returns exactly 100 char string without truncation', () => {
+    const exact = 'a'.repeat(100);
+    expect(toolResultSummary(exact)).toBe(exact);
+  });
+
+  // --- JSON array results (serialised) ---
+  it('summarises single-element array', () => {
+    expect(toolResultSummary(JSON.stringify([1]))).toBe('1 item');
+  });
+
+  it('summarises multi-element array with plural', () => {
+    expect(toolResultSummary(JSON.stringify([1, 2, 3]))).toBe('3 items');
+  });
+
+  it('summarises empty array as "0 items"', () => {
+    expect(toolResultSummary(JSON.stringify([]))).toBe('0 items');
+  });
+
+  // --- success === false ---
+  it('shows error message when success is false with message', () => {
+    const result = toolResultSummary(JSON.stringify({ success: false, message: 'Not found' }));
+    expect(result).toBe('Error: Not found');
+  });
+
+  it('shows error from error field when success is false', () => {
+    const result = toolResultSummary(JSON.stringify({ success: false, error: 'Timeout' }));
+    expect(result).toBe('Error: Timeout');
+  });
+
+  it('shows "Failed" when success is false with no message', () => {
+    expect(toolResultSummary(JSON.stringify({ success: false }))).toBe('Failed');
+  });
+
+  // --- message field ---
+  it('returns message field from object', () => {
+    const result = toolResultSummary(JSON.stringify({ message: 'Range updated' }));
+    expect(result).toBe('Range updated');
+  });
+
+  it('truncates long message field', () => {
+    const msg = 'm'.repeat(150);
+    const result = toolResultSummary(JSON.stringify({ message: msg }));
+    expect(result).toHaveLength(103);
+    expect(result.endsWith('...')).toBe(true);
+  });
+
+  // --- grid dimensions ---
+  it('returns "rows x columns" for grid data', () => {
+    const result = toolResultSummary(JSON.stringify({ rowCount: 10, columnCount: 5 }));
+    expect(result).toBe('10 x 5');
+  });
+
+  // --- count field ---
+  it('returns "N items" for count field', () => {
+    expect(toolResultSummary(JSON.stringify({ count: 7 }))).toBe('7 items');
+  });
+
+  it('returns "1 item" for singular count', () => {
+    expect(toolResultSummary(JSON.stringify({ count: 1 }))).toBe('1 item');
+  });
+
+  // --- single array field ---
+  it('summarises single array field with its name', () => {
+    const result = toolResultSummary(JSON.stringify({ sheets: ['Sheet1', 'Sheet2'] }));
+    expect(result).toBe('2 sheets');
+  });
+
+  it('summarises single array field with length 0', () => {
+    const result = toolResultSummary(JSON.stringify({ charts: [] }));
+    expect(result).toBe('0 charts');
+  });
+
+  // --- multiple array fields → no summary ---
+  it('returns empty string for object with multiple array fields', () => {
+    const result = toolResultSummary(JSON.stringify({ rows: [1, 2], columns: ['A', 'B'] }));
+    expect(result).toBe('');
+  });
+
+  // --- empty object ---
+  it('returns empty string for empty object', () => {
+    expect(toolResultSummary(JSON.stringify({}))).toBe('');
+  });
+
+  // --- non-string non-null primitives ---
+  it('handles number input', () => {
+    // number becomes JSON.stringify → "42" → parse → primitive → String(42)
+    expect(toolResultSummary(42)).toBe('42');
+  });
+
+  it('handles boolean input', () => {
+    expect(toolResultSummary(true)).toBe('true');
+  });
+
+  // --- priority: success:false takes precedence over message ---
+  it('success:false with message takes precedence over message field', () => {
+    const result = toolResultSummary(
+      JSON.stringify({ success: false, message: 'Something broke' })
+    );
+    expect(result).toBe('Error: Something broke');
+  });
+
+  // --- Bug regression: circular references should not crash ---
+  it('returns empty string for objects with circular references', () => {
+    const obj: Record<string, unknown> = { name: 'test' };
+    obj.self = obj; // circular reference
+    // Before fix: JSON.stringify threw TypeError, crashing the caller
+    expect(toolResultSummary(obj)).toBe('');
+  });
+});

--- a/tests/integration/use-office-chat.test.tsx
+++ b/tests/integration/use-office-chat.test.tsx
@@ -458,9 +458,9 @@ describe('useOfficeChat', () => {
   // ─── MCP wiring ────────────────────────────────────────────────────────────
 
   it('passes mcpServers to createSession when servers are active in the store', async () => {
-    useSettingsStore.getState().importMcpServers([
-      { name: 'my-server', url: 'https://example.com/mcp', transport: 'http' },
-    ]);
+    useSettingsStore
+      .getState()
+      .importMcpServers([{ name: 'my-server', url: 'https://example.com/mcp', transport: 'http' }]);
     // activeMcpServerNames null = all enabled
 
     const session = makeFakeSession([IDLE_EVENT]);
@@ -498,9 +498,9 @@ describe('useOfficeChat', () => {
   });
 
   it('does not pass mcpServers when all servers are toggled off', async () => {
-    useSettingsStore.getState().importMcpServers([
-      { name: 'srv', url: 'https://example.com/mcp', transport: 'http' },
-    ]);
+    useSettingsStore
+      .getState()
+      .importMcpServers([{ name: 'srv', url: 'https://example.com/mcp', transport: 'http' }]);
     useSettingsStore.setState({ activeMcpServerNames: [] });
 
     const session = makeFakeSession([IDLE_EVENT]);
@@ -518,9 +518,9 @@ describe('useOfficeChat', () => {
   });
 
   it('SSE server is mapped with type:sse in mcpServers config', async () => {
-    useSettingsStore.getState().importMcpServers([
-      { name: 'sse-srv', url: 'https://sse.example.com', transport: 'sse' },
-    ]);
+    useSettingsStore
+      .getState()
+      .importMcpServers([{ name: 'sse-srv', url: 'https://sse.example.com', transport: 'sse' }]);
 
     const session = makeFakeSession([IDLE_EVENT]);
     const client = makeFakeClient(session);
@@ -621,9 +621,9 @@ describe('useOfficeChat', () => {
   });
 
   it('agent with empty mcpServers allowlist blocks all MCP servers', async () => {
-    useSettingsStore.getState().importMcpServers([
-      { name: 'srv', url: 'https://srv.com/mcp', transport: 'http' },
-    ]);
+    useSettingsStore
+      .getState()
+      .importMcpServers([{ name: 'srv', url: 'https://srv.com/mcp', transport: 'http' }]);
     useSettingsStore.getState().importAgents([
       {
         metadata: {
@@ -742,5 +742,146 @@ describe('useOfficeChat', () => {
     const config = client.createSession.mock.calls[0][0] as Record<string, unknown>;
     const disabled = config.disabledSkills as string[];
     expect(disabled).toContain('excel');
+  });
+
+  it('does not include empty text parts in intermediate message content', async () => {
+    // KEY REGRESSION TEST: updateAssistant() used to always append
+    // { type: 'text', text: '' } even when streamText was empty.
+    // fromThreadMessageLike() silently strips empty text parts, which
+    // caused the "MessagePartText can only be used inside text or
+    // reasoning message parts" crash.  This test verifies the fix by
+    // pausing mid-stream (after tool events, before any text) and
+    // inspecting that no empty text part is present.
+    let resolveStream!: () => void;
+    const streamGate = new Promise<void>(r => {
+      resolveStream = r;
+    });
+
+    const pausingSession = {
+      sessionId: 'test-session-id',
+      async *query() {
+        yield makeEvent('tool.execution_start', {
+          toolCallId: 'tc1',
+          toolName: 'get_range_values',
+          arguments: { range: 'A1' },
+        });
+        yield makeEvent('tool.execution_complete', {
+          toolCallId: 'tc1',
+          success: true,
+          result: { content: '[[1]]' },
+        });
+        // Pause — the message now has tool parts but no text
+        await streamGate;
+        yield makeEvent('assistant.message', { messageId: 'msg1', content: 'Got it.' });
+        yield IDLE_EVENT;
+      },
+      on: vi.fn(),
+      onPermissionRequest: vi.fn(() => () => undefined),
+      destroy: vi.fn().mockResolvedValue(undefined),
+      send: vi.fn().mockResolvedValue('msg-id'),
+      registerTools: vi.fn(),
+      getToolHandler: vi.fn(),
+      respondPermission: vi.fn().mockResolvedValue(undefined),
+      _dispatchEvent: vi.fn() as EventEmitter,
+    };
+    const client = makeFakeClient(pausingSession);
+    mockCreate.mockResolvedValue(client as never);
+
+    const { result } = renderHook(() => useOfficeChat('excel'), { wrapper });
+
+    await act(async () => {
+      await new Promise(r => setTimeout(r, 50));
+    });
+
+    // Start the stream — pauses after tool.execution_complete
+    await act(async () => {
+      result.current.runtime.thread.append(APPEND_MSG('Read'));
+      await new Promise(r => setTimeout(r, 100));
+    });
+
+    // Inspect intermediate message content
+    const messages = result.current.runtime.thread.getState().messages;
+    const assistant = messages.find(m => m.role === 'assistant');
+    expect(assistant).toBeDefined();
+
+    // Must have at least one tool-call part
+    const toolParts = assistant!.content.filter(c => c.type === 'tool-call');
+    expect(toolParts.length).toBeGreaterThanOrEqual(1);
+
+    // Must NOT have an empty text part — this is what caused the crash
+    const textParts = assistant!.content.filter(c => c.type === 'text');
+    for (const tp of textParts) {
+      expect((tp as { text: string }).text.trim().length).toBeGreaterThan(0);
+    }
+
+    // Release the stream
+    await act(async () => {
+      resolveStream();
+      await new Promise(r => setTimeout(r, 100));
+    });
+
+    // After completion, text should be present
+    const finalMessages = result.current.runtime.thread.getState().messages;
+    const finalAssistant = finalMessages.find(m => m.role === 'assistant');
+    const finalTextParts = finalAssistant!.content.filter(c => c.type === 'text');
+    expect(finalTextParts.length).toBe(1);
+    expect((finalTextParts[0] as { text: string }).text).toBe('Got it.');
+  });
+
+  it('initial assistant message has no empty text part (content starts as [])', async () => {
+    // Regression: initial assistant message had content: [{ type: 'text', text: '' }]
+    // which fromThreadMessageLike() would strip, causing crashes on first render.
+    let resolveStream!: () => void;
+    const streamGate = new Promise<void>(r => {
+      resolveStream = r;
+    });
+
+    const pausingSession = {
+      sessionId: 'test-session-id',
+      async *query() {
+        // Pause immediately — the initial assistant message is in state before
+        // any events arrive
+        await streamGate;
+        yield makeEvent('assistant.message', { messageId: 'msg1', content: 'Hi' });
+        yield IDLE_EVENT;
+      },
+      on: vi.fn(),
+      onPermissionRequest: vi.fn(() => () => undefined),
+      destroy: vi.fn().mockResolvedValue(undefined),
+      send: vi.fn().mockResolvedValue('msg-id'),
+      registerTools: vi.fn(),
+      getToolHandler: vi.fn(),
+      respondPermission: vi.fn().mockResolvedValue(undefined),
+      _dispatchEvent: vi.fn() as EventEmitter,
+    };
+    const client = makeFakeClient(pausingSession);
+    mockCreate.mockResolvedValue(client as never);
+
+    const { result } = renderHook(() => useOfficeChat('excel'), { wrapper });
+
+    await act(async () => {
+      await new Promise(r => setTimeout(r, 50));
+    });
+
+    await act(async () => {
+      result.current.runtime.thread.append(APPEND_MSG('Hi'));
+      await new Promise(r => setTimeout(r, 100));
+    });
+
+    // The assistant message exists in running state
+    const messages = result.current.runtime.thread.getState().messages;
+    const assistant = messages.find(m => m.role === 'assistant');
+    expect(assistant).toBeDefined();
+
+    // No empty text part should be in the content
+    const textParts = assistant!.content.filter(c => c.type === 'text');
+    for (const tp of textParts) {
+      expect((tp as { text: string }).text.trim().length).toBeGreaterThan(0);
+    }
+
+    await act(async () => {
+      resolveStream();
+      await new Promise(r => setTimeout(r, 100));
+    });
   });
 });

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -71,6 +71,15 @@ if (typeof window !== 'undefined' && !window.matchMedia) {
     }) as MediaQueryList;
 }
 
+// @assistant-ui/react's useThreadViewportAutoScroll calls element.scrollTo()
+// which jsdom (used by Vitest) does not implement. Polyfill as a no-op so
+// ThreadPrimitive.Viewport renders without crashing in integration tests.
+if (typeof Element !== 'undefined' && !Element.prototype.scrollTo) {
+  Element.prototype.scrollTo = function (
+    ..._args: unknown[]
+  ) {} as typeof Element.prototype.scrollTo;
+}
+
 // ─── Clear build-time environment defaults ───
 // SetupWizard reads ENV_ENDPOINT / ENV_API_KEY from process.env at import time.
 // In tests we want blank defaults so component tests start from a clean state.


### PR DESCRIPTION
## Summary

This PR fixes **15 real UX bugs** discovered through deep code auditing and adds **13 new test files** for comprehensive coverage.

### Bug Fixes (Round 1 - 7 bugs)

1. **AgentPicker host filtering** - Word/Outlook hosts got undefined targetHost, agent list was empty
2. **toolResultSummary circular ref crash** - JSON.stringify on circular objects threw unhandled error
3. **settingsStore toggleMcpServer** - bundled MCP server not in allImported was silently swallowed
4. **skillService host normalization** - uppercase/invalid host values bypassed filtering
5. **useOfficeChat npmSkillPackages deps** - missing dependency in initSession callback
6. **useOfficeChat staleTimer scope** - finally block could not access timer declared inside try
7. **copilotProxy cleanup idempotency** - double cleanup on close+error events caused crashes

### Bug Fixes (Round 2 - 8 UX bugs)

8. **AgentPicker checkmark** - compared raw activeAgentId instead of resolved agent name
9. **SlidePanel keyboard trap** - closed panels remained keyboard-focusable (added inert attribute)
10. **Markdown table overflow** - tables had overflow-y-auto (wrong axis); wrapped in overflow-x-auto container
11. **SessionHistoryPicker truncation** - long session titles wrapped instead of truncating
12. **onCancel premature idle** - cancel set isRunning=false before stream loop terminated
13. **Stale activeModel in orchestrators** - closure captured stale model; now reads from store at call time
14. **MCP restart debounce** - double-clicking restart triggered concurrent restarts
15. **PermissionManagerDialog fetch errors** - unhandled fetch errors left stale directory state

### New Test Files (13)

- permission-store, session-history-store, permission-manager-dialog
- outlook-tools, session-history-dialog, session-history-picker
- slide-panel, system-prompt, infer-provider, tool-result-summary
- thread-message-rendering, chat-action-bar (Playwright)

### Test Results

- **693 integration tests** passing (50 files)
- **234 E2E tests** passing (real Excel Desktop)
- **0 TypeScript errors** (tsc --noEmit clean)
