### PR TITLE
fix: load all 13 bundled skills and fix host-directory discovery

### DIFF
--- a/src/copilotProxy.mjs
+++ b/src/copilotProxy.mjs
@@ -356,11 +356,26 @@ async function handleConnection(ws) {
           },
         }));
 
-        // Point to the host-specific bundled skills directory if it exists
+        // Discover all bundled skill directories for the current host.
+        // Skill dirs use the naming convention: <host>/ and <host>-<specialization>/
+        // e.g. for host "powerpoint": powerpoint/, powerpoint-deck-builder/, powerpoint-formatting/
         const skillDirectories = [];
-        const hostSkillDir = host ? join(BUNDLED_SKILLS_ROOT, slugify(host)) : null;
-        if (hostSkillDir && existsSync(hostSkillDir)) {
-          skillDirectories.push(hostSkillDir);
+        if (host && existsSync(BUNDLED_SKILLS_ROOT)) {
+          const hostSlug = slugify(host);
+          try {
+            const entries = await readdir(BUNDLED_SKILLS_ROOT, { withFileTypes: true });
+            for (const entry of entries) {
+              if (entry.isDirectory() && (entry.name === hostSlug || entry.name.startsWith(hostSlug + '-'))) {
+                skillDirectories.push(join(BUNDLED_SKILLS_ROOT, entry.name));
+              }
+            }
+          } catch {
+            // Fall back to single-directory approach if readdir fails
+            const hostSkillDir = join(BUNDLED_SKILLS_ROOT, hostSlug);
+            if (existsSync(hostSkillDir)) {
+              skillDirectories.push(hostSkillDir);
+            }
+          }
         }
 
         // Write imported skills to a temp directory so the SDK can load them

--- a/src/services/skills/skillService.ts
+++ b/src/services/skills/skillService.ts
@@ -1,7 +1,21 @@
 import type { AgentSkill, SkillMetadata } from '@/types/skill';
 import type { AgentHost } from '@/types/agent';
 import type { OfficeHostApp } from '@/services/office/host';
+
+// Bundled skill imports — one per host-specific skill directory
 import excelSkillRaw from '@/skills/excel/SKILL.md';
+import powerpointSkillRaw from '@/skills/powerpoint/SKILL.md';
+import powerpointDeckBuilderSkillRaw from '@/skills/powerpoint-deck-builder/SKILL.md';
+import powerpointFormattingSkillRaw from '@/skills/powerpoint-formatting/SKILL.md';
+import powerpointRedesignSkillRaw from '@/skills/powerpoint-redesign/SKILL.md';
+import wordSkillRaw from '@/skills/word/SKILL.md';
+import wordDocumentBuilderSkillRaw from '@/skills/word-document-builder/SKILL.md';
+import wordFormattingSkillRaw from '@/skills/word-formatting/SKILL.md';
+import wordTablesSkillRaw from '@/skills/word-tables/SKILL.md';
+import outlookSkillRaw from '@/skills/outlook/SKILL.md';
+import outlookCalendarSkillRaw from '@/skills/outlook-calendar/SKILL.md';
+import outlookDraftingSkillRaw from '@/skills/outlook-drafting/SKILL.md';
+import outlookEmailAnalysisSkillRaw from '@/skills/outlook-email-analysis/SKILL.md';
 
 /**
  * Parse YAML frontmatter from a skill markdown file.
@@ -145,7 +159,21 @@ function setMetadataField(metadata: SkillMetadata, key: string, value: string): 
 }
 
 function loadBundledSkills(): AgentSkill[] {
-  const bundledRawSkills = [excelSkillRaw];
+  const bundledRawSkills = [
+    excelSkillRaw,
+    powerpointSkillRaw,
+    powerpointDeckBuilderSkillRaw,
+    powerpointFormattingSkillRaw,
+    powerpointRedesignSkillRaw,
+    wordSkillRaw,
+    wordDocumentBuilderSkillRaw,
+    wordFormattingSkillRaw,
+    wordTablesSkillRaw,
+    outlookSkillRaw,
+    outlookCalendarSkillRaw,
+    outlookDraftingSkillRaw,
+    outlookEmailAnalysisSkillRaw,
+  ];
 
   const loaded = bundledRawSkills.map(raw => {
     const parsed = parseFrontmatter(raw);

--- a/tests/integration/copilot-custom-agent.integration.test.ts
+++ b/tests/integration/copilot-custom-agent.integration.test.ts
@@ -460,4 +460,103 @@ function handleRequest(req) {
     },
     TIMEOUT_MS
   );
+
+  // ── Bundled skill loading via skillDirectories ──────────────────────────
+
+  it(
+    'bundled Excel skill is loaded by the SDK when host=excel is passed',
+    async () => {
+      // Create a session with host='excel' — the proxy should discover
+      // src/skills/excel/ and pass it as a skillDirectory to the SDK.
+      // We do NOT inject skills via systemMessage; we rely on the SDK
+      // loading them from disk via skillDirectories.
+      const client = await createWebSocketClient(SERVER_URL);
+      try {
+        const session = await client.createSession({
+          host: 'excel',
+          // Minimal system message — no skill content injected manually.
+          systemMessage: {
+            mode: 'replace',
+            content:
+              'You are a helpful assistant. Answer questions concisely. ' +
+              'If you have been given an Excel skill with an "Operating Loop", ' +
+              'list its five steps as a numbered list. ' +
+              'If you have no such skill, reply with exactly: NO_SKILL_FOUND',
+          },
+        });
+
+        // The SDK may request file-read permissions (e.g. to read skill files).
+        // Auto-approve so the session doesn't hang waiting for a response.
+        session.onPermissionRequest(async payload => {
+          await session.respondPermission(payload.requestId, 'approved');
+        });
+
+        let fullText = '';
+        for await (const event of session.query({
+          prompt: 'What are the five steps of the Excel Operating Loop from the Excel skill?',
+        })) {
+          if (event.type === 'assistant.message_delta') {
+            fullText += event.data.deltaContent;
+          }
+          if (event.type === 'assistant.message') {
+            fullText = event.data.content;
+          }
+          if (event.type === 'session.idle') break;
+        }
+
+        // The Excel skill defines: Discover, Read, Execute, Verify, Summarize
+        expect(fullText).not.toContain('NO_SKILL_FOUND');
+        expect(fullText.toLowerCase()).toContain('discover');
+        expect(fullText.toLowerCase()).toContain('verify');
+        expect(fullText.toLowerCase()).toContain('summarize');
+      } finally {
+        await client.stop();
+      }
+    },
+    TIMEOUT_MS
+  );
+
+  it(
+    'disabledSkills is accepted by the SDK and session still works',
+    async () => {
+      // Pass host='excel' so the proxy discovers the bundled Excel skill,
+      // but also disable it via disabledSkills. Verify the session still
+      // creates and responds (disabledSkills doesn't break the SDK).
+      const client = await createWebSocketClient(SERVER_URL);
+      try {
+        const session = await client.createSession({
+          host: 'excel',
+          disabledSkills: ['excel'],
+          systemMessage: {
+            mode: 'replace',
+            content: 'You are a helpful assistant. Reply with exactly one word: PONG',
+          },
+        });
+
+        // Auto-approve any permission requests to prevent 60s proxy timeout.
+        session.onPermissionRequest(async payload => {
+          await session.respondPermission(payload.requestId, 'approved');
+        });
+
+        let fullText = '';
+        for await (const event of session.query({
+          prompt: 'Ping',
+        })) {
+          if (event.type === 'assistant.message_delta') {
+            fullText += event.data.deltaContent;
+          }
+          if (event.type === 'assistant.message') {
+            fullText = event.data.content;
+          }
+          if (event.type === 'session.idle') break;
+        }
+
+        // The session should work and the model should respond
+        expect(fullText.toLowerCase()).toContain('pong');
+      } finally {
+        await client.stop();
+      }
+    },
+    TIMEOUT_MS
+  );
 });

--- a/tests/integration/skill-service.test.ts
+++ b/tests/integration/skill-service.test.ts
@@ -11,6 +11,7 @@ import {
   buildSkillContext,
   getSkills,
   getSkill,
+  getBundledSkills,
   parseFrontmatter,
   setImportedSkills,
 } from '@/services/skills/skillService';
@@ -73,10 +74,13 @@ describe('buildSkillContext', () => {
 });
 
 describe('getSkills', () => {
-  it('returns bundled skills', () => {
+  it('returns all 13 bundled skills', () => {
     const skills = getSkills();
-    expect(skills.length).toBeGreaterThan(0);
-    expect(skills.some(skill => skill.metadata.name === 'excel')).toBe(true);
+    expect(skills.length).toBe(13);
+  });
+
+  it('includes the excel skill', () => {
+    expect(getSkills().some(skill => skill.metadata.name === 'excel')).toBe(true);
   });
 
   it('each skill has metadata with a name', () => {
@@ -102,6 +106,82 @@ describe('getSkill', () => {
     expect(skill).toBeDefined();
     expect(skill?.metadata.name).toBe('excel');
     expect(skill?.metadata.hosts).toEqual(['excel']);
+  });
+});
+
+// Regression: all 13 bundled skills must be loaded (not just excel)
+describe('bundled skill loading', () => {
+  const expectedSkills = [
+    { name: 'excel', host: 'excel' },
+    { name: 'powerpoint', host: 'powerpoint' },
+    { name: 'powerpoint-deck-builder', host: 'powerpoint' },
+    { name: 'powerpoint-formatting', host: 'powerpoint' },
+    { name: 'powerpoint-redesign', host: 'powerpoint' },
+    { name: 'Word Document Editing', host: 'word' },
+    { name: 'word-document-builder', host: 'word' },
+    { name: 'word-formatting', host: 'word' },
+    { name: 'word-tables', host: 'word' },
+    { name: 'outlook', host: 'outlook' },
+    { name: 'outlook-calendar', host: 'outlook' },
+    { name: 'outlook-drafting', host: 'outlook' },
+    { name: 'outlook-email-analysis', host: 'outlook' },
+  ];
+
+  it('loads exactly 13 bundled skills', () => {
+    expect(getBundledSkills()).toHaveLength(13);
+  });
+
+  it.each(expectedSkills)('loads $name skill targeting $host', ({ name, host }) => {
+    const skill = getSkill(name);
+    expect(skill).toBeDefined();
+    expect(skill!.metadata.hosts).toContain(host);
+    expect(skill!.content.length).toBeGreaterThan(0);
+  });
+
+  it('includes 1 excel skill', () => {
+    const excelSkills = getBundledSkills().filter(s => s.metadata.hosts.includes('excel'));
+    expect(excelSkills).toHaveLength(1);
+  });
+
+  it('includes 4 powerpoint skills', () => {
+    const pptSkills = getBundledSkills().filter(s => s.metadata.hosts.includes('powerpoint'));
+    expect(pptSkills).toHaveLength(4);
+  });
+
+  it('includes 4 word skills', () => {
+    const wordSkills = getBundledSkills().filter(s => s.metadata.hosts.includes('word'));
+    expect(wordSkills).toHaveLength(4);
+  });
+
+  it('includes 4 outlook skills', () => {
+    const outlookSkills = getBundledSkills().filter(s => s.metadata.hosts.includes('outlook'));
+    expect(outlookSkills).toHaveLength(4);
+  });
+
+  it('buildSkillContext returns skills for powerpoint host', () => {
+    const ctx = buildSkillContext(undefined, 'powerpoint');
+    expect(ctx).toContain('Agent Skill: powerpoint');
+    expect(ctx).toContain('Agent Skill: powerpoint-deck-builder');
+  });
+
+  it('buildSkillContext returns skills for word host', () => {
+    const ctx = buildSkillContext(undefined, 'word');
+    expect(ctx).toContain('Agent Skill: Word Document Editing');
+    expect(ctx).toContain('Agent Skill: word-tables');
+  });
+
+  it('buildSkillContext returns skills for outlook host', () => {
+    const ctx = buildSkillContext(undefined, 'outlook');
+    expect(ctx).toContain('Agent Skill: outlook');
+    expect(ctx).toContain('Agent Skill: outlook-calendar');
+  });
+
+  it('buildSkillContext filters out non-matching host skills', () => {
+    const ctx = buildSkillContext(undefined, 'excel');
+    expect(ctx).toContain('Agent Skill: excel');
+    expect(ctx).not.toContain('Agent Skill: powerpoint');
+    expect(ctx).not.toContain('Agent Skill: word');
+    expect(ctx).not.toContain('Agent Skill: outlook');
   });
 });
 


### PR DESCRIPTION
## Summary

Fixes two critical bugs that caused 12 of 13 bundled skills to be invisible:

### Bug 1 - Client-side (skillService.ts)
loadBundledSkills() only imported excelSkillRaw - the remaining 12 skills (4 PowerPoint, 4 Word, 4 Outlook) were never loaded. The SkillPicker showed only one skill.

**Fix:** Import all 13 SKILL.md files and include them in the bundled skills array.

### Bug 2 - Server-side (copilotProxy.mjs)
skillDirectories used join(BUNDLED_SKILLS_ROOT, slugify(host)) which matched only the exact host directory (e.g. powerpoint/). Sibling directories like powerpoint-deck-builder/, powerpoint-formatting/, powerpoint-redesign/ were silently dropped.

**Fix:** Scan BUNDLED_SKILLS_ROOT with readdir() and match directories whose name equals the host slug or starts with hostSlug + '-'.

### Tests added
- **skill-service.test.ts:** Asserts exactly 13 bundled skills, parameterised it.each for all 13, per-host count checks (1 Excel, 4 PPT, 4 Word, 4 Outlook), buildSkillContext host filtering
- **copilot-custom-agent.integration.test.ts:** Two new live SDK tests:
  1. Verifies skillDirectories are loaded by the SDK when host=excel
  2. Verifies disabledSkills is accepted without breaking the session
  - Both include onPermissionRequest auto-approve handlers to prevent the 60s proxy timeout

### Test results
718/718 integration tests passing. 0 failures.