### PR TITLE
chore: release v0.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "office-coding-agent",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "private": true,
   "main": "src/tray/main.cjs",
   "description": "Office coding agent add-in with host-routed AI chat",


### PR DESCRIPTION
Bumps package.json version to 0.4.0 ahead of the v0.4.0 tag.