### PR TITLE
fix: put text part before tool-call parts to prevent index-shift tearing

### DIFF
--- a/src/hooks/useOfficeChat.ts
+++ b/src/hooks/useOfficeChat.ts
@@ -621,15 +621,15 @@ export function useOfficeChat(host: OfficeHostApp) {
 
     const updateAssistant = (extra?: Partial<Pick<ThreadMessageLike, 'status'>>) => {
       const content: ThreadMessageLike['content'] = [
-        ...Array.from(toolParts.values()),
-        // Only append a text part when there is actual text — the
-        // external-store adapter's fromThreadMessageLike() silently strips
-        // empty text parts (text.trim().length === 0 → null → filtered).
-        // Sending an empty text part causes a 0-part message or a message
-        // that ends on a tool-call part, which can trigger the
-        // "MessagePartText can only be used inside text or reasoning
-        // message parts" crash in @assistant-ui/react-markdown.
+        // Text part comes FIRST so its array index stays stable even as tool-call
+        // parts are appended. Prepending tool-calls would shift the text part's
+        // index on every new tool invocation, causing React's useSyncExternalStore
+        // tearing-detection in MarkdownTextPrimitive (useMessagePartText) to see
+        // s.part.type === "tool-call" while MarkdownText is still mounted at the
+        // old index — triggering "MessagePartText can only be used inside text or
+        // reasoning message parts".
         ...(streamText ? [{ type: 'text' as const, text: streamText }] : []),
+        ...Array.from(toolParts.values()),
       ];
       setMessages(prev => prev.map(m => (m.id === assistantId ? { ...m, content, ...extra } : m)));
     };


### PR DESCRIPTION
## Problem

When vision-enabled PowerPoint tools are used, the model often emits text first (`assistant.message_delta`) and then calls a follow-up tool (`tool.execution_start`). The previous `updateAssistant()` content order was **tool-calls first, text last**:

```
content = [...toolParts.values(), { type: 'text', text: streamText }]
```

When a tool call arrives **after** text has already accumulated in `streamText`:

| Event | Previous content array | Text index |
|---|---|---|
| `assistant.message_delta` | `[text]` | 0 |
| `tool.execution_start` | `[tool-call, text]` | **1 ← shifted!** |

React 18's `useSyncExternalStore` tearing-detection re-runs `getSnapshot` in `MarkdownText` (which was mounted at index 0). The AUI store now reports `s.part.type === 'tool-call'` at that index → `useMessagePartText` throws:

> **MessagePartText can only be used inside text or reasoning message parts.**

This crash is specific to PowerPoint + vision because `get_slide_image` / `get_presentation_overview` return images via `binaryResultsForLlm`, causing the model to respond with commentary text before issuing follow-up tool calls — a pattern that rarely occurs in Excel.

## Fix

Swap the content order: **text first, tool-calls after**:

```typescript
content = [
  ...(streamText ? [{ type: 'text', text: streamText }] : []),
  ...Array.from(toolParts.values()),
]
```

With this order the text part stays at index 0 from the moment it appears, and subsequent tool calls are appended after it — no index shift, no tearing.

## Testing

- `npx tsc --noEmit` — clean
- `npm run test:integration` — 718/718 pass
