### PR TITLE
chore: release v0.4.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "office-coding-agent",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "private": true,
   "main": "src/tray/main.cjs",
   "description": "Office coding agent add-in with host-routed AI chat",


### PR DESCRIPTION
Bump version to 0.4.1 to release the fix for the \MessagePartText\ crash in PowerPoint (PR #56).