### PR TITLE
fix: get_slide_image region crop, graceful failure, and Playwright isAttached

### DIFF
--- a/src/tools/powerpoint/index.ts
+++ b/src/tools/powerpoint/index.ts
@@ -175,7 +175,9 @@ export const powerPointConfigs: readonly PptToolConfig[] = [
   {
     name: 'get_slide_image',
     description:
-      'Capture a slide as a PNG image to see its visual design, layout, colors, and styling. Requires PowerPoint on Windows (16.0.17628+), Mac (16.85+), or PowerPoint on the web.',
+      'Capture a slide as a PNG image to see its visual design, layout, colors, and styling. ' +
+      'Use region="full" for an overview, or "bottom-left"/"bottom-right" for 2× zoom into the bottom corners to check text overflow. ' +
+      'Requires PowerPoint on Windows (16.0.17628+), Mac (16.85+), or PowerPoint on the web.',
     params: {
       slideIndex: { type: 'number', description: '0-based slide index.' },
       width: {
@@ -183,9 +185,27 @@ export const powerPointConfigs: readonly PptToolConfig[] = [
         required: false,
         description: 'Image width in pixels. Aspect ratio is preserved. Default: 800.',
       },
+      region: {
+        type: 'string',
+        required: false,
+        description:
+          'Which part of the slide to return. "full" (default) = entire slide. ' +
+          '"top-left", "top-right", "bottom-left", "bottom-right" = that quadrant zoomed 2×. ' +
+          'Use bottom quadrants to inspect text overflow at the bottom of slides.',
+        enum: ['full', 'top-left', 'top-right', 'bottom-left', 'bottom-right'],
+        default: 'full',
+      },
     },
     execute: async (context, args) => {
-      const { slideIndex, width = 800 } = args as { slideIndex: number; width?: number };
+      const {
+        slideIndex,
+        width = 800,
+        region = 'full',
+      } = args as {
+        slideIndex: number;
+        width?: number;
+        region?: 'full' | 'top-left' | 'top-right' | 'bottom-left' | 'bottom-right';
+      };
 
       const slides = context.presentation.slides;
       slides.load('items');
@@ -203,10 +223,73 @@ export const powerPointConfigs: readonly PptToolConfig[] = [
       interface SlideWithImage {
         getImageAsBase64(width: number): { value: string };
       }
-      const imageResult = (slide as unknown as SlideWithImage).getImageAsBase64(width);
-      await context.sync();
 
-      return `data:image/png;base64,${imageResult.value}`;
+      let imageResult: { value: string };
+      try {
+        imageResult = (slide as unknown as SlideWithImage).getImageAsBase64(width);
+        await context.sync();
+      } catch {
+        return (
+          'Slide image capture is not available in this version of PowerPoint. ' +
+          'Image capture requires PowerPoint on Windows (16.0.17628+), Mac (16.85+), or PowerPoint on the web. ' +
+          'Use get_slide_shapes and get_presentation_content to inspect the slide via text instead.'
+        );
+      }
+
+      const fullDataUrl = `data:image/png;base64,${imageResult.value}`;
+
+      if (region === 'full') {
+        return fullDataUrl;
+      }
+
+      // Crop to the requested quadrant and scale up 2× using an offscreen canvas.
+      // This gives the model a zoomed view to check for text overflow / layout issues.
+      return new Promise<string>((resolve, reject) => {
+        const img = new Image();
+        img.onload = () => {
+          const halfW = Math.floor(img.width / 2);
+          const halfH = Math.floor(img.height / 2);
+
+          let sx: number;
+          let sy: number;
+          switch (region) {
+            case 'top-left':
+              sx = 0;
+              sy = 0;
+              break;
+            case 'top-right':
+              sx = halfW;
+              sy = 0;
+              break;
+            case 'bottom-left':
+              sx = 0;
+              sy = halfH;
+              break;
+            case 'bottom-right':
+              sx = halfW;
+              sy = halfH;
+              break;
+            default:
+              sx = 0;
+              sy = 0;
+          }
+
+          const canvas = document.createElement('canvas');
+          canvas.width = img.width; // output is full-size — the quadrant is stretched 2×
+          canvas.height = img.height;
+          const ctx = canvas.getContext('2d');
+          if (!ctx) {
+            resolve(fullDataUrl); // canvas not available — fall back to full image
+            return;
+          }
+          ctx.drawImage(img, sx, sy, halfW, halfH, 0, 0, img.width, img.height);
+          resolve(canvas.toDataURL('image/png'));
+        };
+        img.onerror = () => {
+          reject(new Error('Failed to load slide image for region crop'));
+        };
+        img.src = fullDataUrl;
+      });
     },
   },
 

--- a/tests-ui/chat/chat-action-bar.spec.ts
+++ b/tests-ui/chat/chat-action-bar.spec.ts
@@ -153,7 +153,7 @@ test.describe('Action bar (live Copilot)', () => {
       await assistantMsg.hover();
       // Action bar should NOT be visible during streaming (hideWhenRunning)
       const actionBar = assistantMsg.locator('.aui-assistant-action-bar');
-      if (await actionBar.isAttached()) {
+      if ((await actionBar.count()) > 0) {
         // If attached, it must be hidden (data-state or display), not visible buttons
         await expect(page.getByRole('button', { name: 'Copy' })).not.toBeVisible();
       }

--- a/tests/integration/powerpoint-tools.test.ts
+++ b/tests/integration/powerpoint-tools.test.ts
@@ -120,6 +120,16 @@ describe('Integration: slide-index tool schemas', () => {
     expect(validate(schema, { slideIndex: 0, width: 1024 })).toBe(true);
   });
 
+  it('get_slide_image accepts optional region (enum)', () => {
+    const schema = toolsByName.get_slide_image.parameters;
+    expect(validate(schema, { slideIndex: 0, region: 'full' })).toBe(true);
+    expect(validate(schema, { slideIndex: 0, region: 'bottom-left' })).toBe(true);
+    expect(validate(schema, { slideIndex: 0, region: 'bottom-right' })).toBe(true);
+    expect(validate(schema, { slideIndex: 0, region: 'top-left' })).toBe(true);
+    expect(validate(schema, { slideIndex: 0, region: 'top-right' })).toBe(true);
+    expect(validate(schema, { slideIndex: 0, region: 'invalid' })).toBe(false);
+  });
+
   it('clear_slide requires slideIndex', () => {
     const schema = toolsByName.clear_slide.parameters;
     expect(validate(schema, { slideIndex: 2 })).toBe(true);


### PR DESCRIPTION
## Summary

Two separate fixes shipped together.

### 1. `get_slide_image` enhancements

**Problem:** The `get_slide_image` tool had no try/catch around `getImageAsBase64`, so any version mismatch threw a hard crash visible to the user. Additionally, the `region` parameter was referenced extensively in agent prompts and skills (e.g. `region: "bottom-left"`) but never existed in the tool schema.

**Fix:**

- Add `region` param with enum `full | top-left | top-right | bottom-left | bottom-right` (optional, default: `full`)
- Implement quadrant crop via browser canvas: draws the full slide image, then crops and 2x scales the selected half-region
- Wrap `getImageAsBase64` in try/catch — on failure returns a user-readable message explaining the minimum PowerPoint version required, and suggests `get_slide_shapes` / `get_presentation_content` as fallback
- Canvas unavailable fallback returns the full image rather than crashing

### 2. Playwright `locator.isAttached()` bug

**Problem:** `actionBar.isAttached()` is not a valid Playwright Locator method — only the assertion form `expect(locator).toBeAttached()` exists. This caused a runtime TypeError in all 5 tests in `chat-action-bar.spec.ts`.

**Fix:** Replace `if (await actionBar.isAttached())` with `if ((await actionBar.count()) > 0)`.

## Test Results

- Integration: 708/708 pass (pre-commit hook ran full suite)
- New test: `get_slide_image accepts optional region (enum)` validates all 5 valid enum values and rejects invalid ones

## Related Issues

None
