### PR TITLE
chore: release v0.4.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "office-coding-agent",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "private": true,
   "main": "src/tray/main.cjs",
   "description": "Office coding agent add-in with host-routed AI chat",


### PR DESCRIPTION
Bump version to 0.4.2.

Includes:
- fix: `get_slide_image` region param (full/top-left/top-right/bottom-left/bottom-right) with canvas crop
- fix: graceful failure when PowerPoint version does not support `getImageAsBase64`
- fix: Playwright `locator.isAttached()` replaced with `(await count()) > 0`
