### PR TITLE
fix: strip stale tool parts + prevent mid-conversation session teardown

### DIFF
--- a/src/components/assistant-ui/markdown-text.tsx
+++ b/src/components/assistant-ui/markdown-text.tsx
@@ -6,7 +6,7 @@ import {
 } from '@assistant-ui/react-markdown';
 import { useThreadRuntime } from '@assistant-ui/react';
 import remarkGfm from 'remark-gfm';
-import { type FC, memo, useState, useCallback } from 'react';
+import { type FC, Children, isValidElement, memo, useState, useCallback } from 'react';
 import { CheckIcon, CopyIcon, SparklesIcon } from 'lucide-react';
 import { TooltipIconButton } from '@/components/assistant-ui/tooltip-icon-button';
 import { cn } from '@/lib/utils';
@@ -322,15 +322,27 @@ const defaultComponents = memoizeMarkdownComponents({
   sup: ({ className, ...props }) => (
     <sup className={cn('aui-md-sup [&>a]:text-xs [&>a]:no-underline', className)} {...props} />
   ),
-  pre: ({ className, ...props }) => (
-    <pre
-      className={cn(
-        'aui-md-pre overflow-x-auto rounded-t-none rounded-b-lg border border-border/50 border-t-0 bg-muted/30 p-3 text-xs leading-relaxed',
-        className
-      )}
-      {...props}
-    />
-  ),
+  pre: ({ className, children, ...props }) => {
+    // Hide the raw pre/code wrapper for custom-rendered blocks (choices, suggestions)
+    const isCustomBlock = Children.toArray(children).some(
+      kid =>
+        isValidElement<{ className?: string }>(kid) &&
+        (kid.props.className?.includes('language-choices') === true ||
+          kid.props.className?.includes('language-suggestions') === true)
+    );
+    if (isCustomBlock) return null;
+    return (
+      <pre
+        className={cn(
+          'aui-md-pre overflow-x-auto rounded-t-none rounded-b-lg border border-border/50 border-t-0 bg-muted/30 p-3 text-xs leading-relaxed',
+          className
+        )}
+        {...props}
+      >
+        {children}
+      </pre>
+    );
+  },
   code: function Code({ className, ...props }) {
     const isCodeBlock = useIsMarkdownCodeBlock();
     return (

--- a/src/components/assistant-ui/markdown-text.tsx
+++ b/src/components/assistant-ui/markdown-text.tsx
@@ -7,7 +7,7 @@ import {
 import { useThreadRuntime } from '@assistant-ui/react';
 import remarkGfm from 'remark-gfm';
 import { type FC, memo, useState, useCallback } from 'react';
-import { CheckIcon, CopyIcon } from 'lucide-react';
+import { CheckIcon, CopyIcon, SparklesIcon } from 'lucide-react';
 import { TooltipIconButton } from '@/components/assistant-ui/tooltip-icon-button';
 import { cn } from '@/lib/utils';
 
@@ -48,6 +48,11 @@ const CodeHeader: FC<CodeHeaderProps> = ({ language, code }) => {
   // choices blocks: render cards instead of code header + code block
   if (language === 'choices') {
     return <ChoiceCards code={code} />;
+  }
+
+  // suggestions blocks: render VS Code-style follow-up links
+  if (language === 'suggestions') {
+    return <SuggestionLinks code={code} />;
   }
 
   return (
@@ -141,6 +146,43 @@ const ChoiceCards: FC<{ code: string }> = ({ code }) => {
           }}
         />
       </div>
+    </div>
+  );
+};
+
+// ─── Suggestion Links ───
+// Parses ```suggestions JSON blocks into VS Code-style follow-up links.
+// Same JSON format as choices: [{"label": "..."}]
+// Rendered as plain text-link buttons with a sparkle icon (no border, no freeform).
+
+const SuggestionLinks: FC<{ code: string }> = ({ code }) => {
+  const threadRuntime = useThreadRuntime();
+  const suggestions = parseChoices(code); // reuse same parser
+
+  const handleClick = useCallback(
+    (label: string) => {
+      threadRuntime.append({
+        role: 'user',
+        content: [{ type: 'text', text: label }],
+      });
+    },
+    [threadRuntime]
+  );
+
+  if (!suggestions || suggestions.length === 0) return null;
+
+  return (
+    <div className="aui-suggestions-wrapper mt-3 flex flex-col items-start gap-1.5">
+      {suggestions.map(suggestion => (
+        <button
+          key={suggestion.label}
+          onClick={() => handleClick(suggestion.label)}
+          className="flex items-center gap-1.5 border-none bg-transparent p-0 text-left text-xs text-muted-foreground transition-colors hover:text-foreground"
+        >
+          <SparklesIcon className="size-3 shrink-0" />
+          {suggestion.label}
+        </button>
+      ))}
     </div>
   );
 };

--- a/src/components/assistant-ui/markdown-text.tsx
+++ b/src/components/assistant-ui/markdown-text.tsx
@@ -7,7 +7,7 @@ import {
 import { useThreadRuntime } from '@assistant-ui/react';
 import remarkGfm from 'remark-gfm';
 import { type FC, memo, useState, useCallback } from 'react';
-import { CheckIcon, CopyIcon, SparklesIcon } from 'lucide-react';
+import { CheckIcon, CopyIcon } from 'lucide-react';
 import { TooltipIconButton } from '@/components/assistant-ui/tooltip-icon-button';
 import { cn } from '@/lib/utils';
 
@@ -84,8 +84,9 @@ function parseChoices(code: string): ChoiceItem[] | null {
 const ChoiceCards: FC<{ code: string }> = ({ code }) => {
   const threadRuntime = useThreadRuntime();
   const choices = parseChoices(code);
+  const [freeformText, setFreeformText] = useState('');
 
-  const handleClick = useCallback(
+  const handleChoice = useCallback(
     (label: string) => {
       threadRuntime.append({
         role: 'user',
@@ -95,25 +96,51 @@ const ChoiceCards: FC<{ code: string }> = ({ code }) => {
     [threadRuntime]
   );
 
+  const handleFreeform = useCallback(() => {
+    const trimmed = freeformText.trim();
+    if (!trimmed) return;
+    threadRuntime.append({
+      role: 'user',
+      content: [{ type: 'text', text: trimmed }],
+    });
+    setFreeformText('');
+  }, [threadRuntime, freeformText]);
+
   if (!choices || choices.length === 0) return null;
 
   return (
-    <div className="aui-choices-wrapper my-2 flex flex-col gap-1.5">
-      {choices.map(choice => (
+    <div className="aui-choices-wrapper mt-2 flex flex-col">
+      {choices.map((choice, i) => (
         <button
           key={choice.label}
-          onClick={() => handleClick(choice.label)}
-          className="flex items-center gap-2 rounded-xl border border-border bg-background px-3 py-2 text-left text-sm text-foreground shadow-sm transition-all hover:bg-accent hover:shadow-md active:scale-[0.98]"
+          onClick={() => handleChoice(choice.label)}
+          title={choice.description}
+          className="flex items-baseline gap-3 rounded px-2 py-1 text-left text-sm transition-colors hover:bg-accent"
         >
-          <SparklesIcon className="size-3.5 shrink-0 text-primary" />
-          <div className="min-w-0">
-            <div className="font-medium">{choice.label}</div>
-            {choice.description && (
-              <div className="text-xs text-muted-foreground">{choice.description}</div>
-            )}
-          </div>
+          <span className="w-4 shrink-0 text-right text-xs text-muted-foreground select-none">
+            {i + 1}
+          </span>
+          <span className="text-foreground">{choice.label}</span>
         </button>
       ))}
+      <div className="flex items-baseline gap-3 px-2 py-1">
+        <span className="w-4 shrink-0 text-right text-xs text-muted-foreground select-none">
+          {choices.length + 1}
+        </span>
+        <textarea
+          className="flex-1 resize-none bg-transparent text-sm text-foreground placeholder:text-muted-foreground outline-none border-b border-border focus:border-foreground transition-colors"
+          placeholder="Enter custom answer"
+          rows={1}
+          value={freeformText}
+          onChange={e => setFreeformText(e.target.value)}
+          onKeyDown={e => {
+            if (e.key === 'Enter' && !e.shiftKey) {
+              e.preventDefault();
+              handleFreeform();
+            }
+          }}
+        />
+      </div>
     </div>
   );
 };

--- a/src/hooks/useOfficeChat.ts
+++ b/src/hooks/useOfficeChat.ts
@@ -99,6 +99,25 @@ export function useOfficeChat(host: OfficeHostApp) {
   const initCounterRef = useRef(0);
   const restoredInitialSessionRef = useRef(false);
 
+  // Stable refs for settings that should NOT trigger session re-init when they change.
+  // initSession reads from these refs so the useCallback only re-creates when host
+  // or activeModel change — not on every skill/agent/MCP toggle mid-conversation.
+  // Without this, any store update (e.g. WorkIQ connecting) would tear down and
+  // restart the Copilot session, losing all conversation context.
+  const activeSkillNamesRef = useRef(activeSkillNames);
+  const activeAgentIdRef = useRef(activeAgentId);
+  const importedMcpServersRef = useRef(importedMcpServers);
+  const activeMcpServerNamesRef = useRef(activeMcpServerNames);
+  const npmSkillPackagesRef = useRef(npmSkillPackages);
+  const evaluatePermissionRef = useRef(evaluatePermission);
+  // Keep refs in sync on every render (runs synchronously, before any effects)
+  activeSkillNamesRef.current = activeSkillNames;
+  activeAgentIdRef.current = activeAgentId;
+  importedMcpServersRef.current = importedMcpServers;
+  activeMcpServerNamesRef.current = activeMcpServerNames;
+  npmSkillPackagesRef.current = npmSkillPackages;
+  evaluatePermissionRef.current = evaluatePermission;
+
   const [messages, setMessages] = useState<ThreadMessageLike[]>([]);
   const [isRunning, setIsRunning] = useState(false);
   const [sessionError, setSessionError] = useState<Error | null>(null);
@@ -192,7 +211,7 @@ export function useOfficeChat(host: OfficeHostApp) {
         useMcpStatusStore.getState().setTools(payload.server, payload.tools);
       });
 
-      const resolvedAgent = resolveActiveAgent(activeAgentId, host);
+      const resolvedAgent = resolveActiveAgent(activeAgentIdRef.current, host);
 
       // System prompt: only base + app prompt (no agent/skill concatenation)
       const systemContent = buildSystemPrompt(host);
@@ -211,8 +230,8 @@ export function useOfficeChat(host: OfficeHostApp) {
         .filter(s => s.metadata.hosts.length === 0 || s.metadata.hosts.includes(host as AgentHost))
         .map(s => s.metadata.name);
       const disabledSkills =
-        activeSkillNames !== null
-          ? allHostSkillNames.filter(name => !activeSkillNames.includes(name))
+        activeSkillNamesRef.current !== null
+          ? allHostSkillNames.filter(name => !activeSkillNamesRef.current!.includes(name))
           : [];
 
       // Build custom agent config for the SDK
@@ -229,13 +248,13 @@ export function useOfficeChat(host: OfficeHostApp) {
       // Resolve active MCP servers (bundled + imported), intersect with agent allowlist if specified
       // Bundled servers require explicit opt-in (name must be in activeMcpServerNames).
       // When activeMcpServerNames is null (all active), only imported servers are included.
-      const allServers = getAllMcpServers(BUNDLED_MCP_SERVERS, importedMcpServers);
+      const allServers = getAllMcpServers(BUNDLED_MCP_SERVERS, importedMcpServersRef.current);
       let activeServers: typeof allServers;
-      if (activeMcpServerNames === null) {
+      if (activeMcpServerNamesRef.current === null) {
         // null = all imported active, bundled NOT active (require explicit opt-in)
         activeServers = allServers.filter(s => !BUNDLED_MCP_SERVERS.some(b => b.name === s.name));
       } else {
-        activeServers = allServers.filter(s => activeMcpServerNames.includes(s.name));
+        activeServers = allServers.filter(s => activeMcpServerNamesRef.current!.includes(s.name));
       }
       if (resolvedAgent?.metadata.mcpServers !== undefined) {
         const agentMcpAllowlist = new Set(resolvedAgent.metadata.mcpServers);
@@ -257,7 +276,8 @@ export function useOfficeChat(host: OfficeHostApp) {
           skills,
           disabledSkills,
           customAgents,
-          npmSkillPackages: npmSkillPackages.length > 0 ? npmSkillPackages : undefined,
+          npmSkillPackages:
+            npmSkillPackagesRef.current.length > 0 ? npmSkillPackagesRef.current : undefined,
         }),
         60_000,
         'session.create'
@@ -278,7 +298,7 @@ export function useOfficeChat(host: OfficeHostApp) {
       console.log('[chat] Session created:', session.sessionId);
 
       session.onPermissionRequest(payload => {
-        const autoDecision = evaluatePermission(payload.request);
+        const autoDecision = evaluatePermissionRef.current(payload.request);
         if (autoDecision === 'approved') {
           void session.respondPermission(payload.requestId, 'approved');
           return;
@@ -300,14 +320,11 @@ export function useOfficeChat(host: OfficeHostApp) {
       }
     }
   }, [
+    // Only re-init the session when host or model change — these require a genuinely
+    // new connection. All other settings (skills, agents, MCP servers) are read via
+    // refs above so mid-conversation store updates never tear down an active session.
     activeModel,
     host,
-    activeSkillNames,
-    activeAgentId,
-    importedMcpServers,
-    activeMcpServerNames,
-    evaluatePermission,
-    npmSkillPackages,
   ]);
 
   useEffect(() => {

--- a/src/hooks/useOfficeChat.ts
+++ b/src/hooks/useOfficeChat.ts
@@ -101,9 +101,11 @@ export function useOfficeChat(host: OfficeHostApp) {
 
   // Stable refs for settings that should NOT trigger session re-init when they change.
   // initSession reads from these refs so the useCallback only re-creates when host
-  // or activeModel change — not on every skill/agent/MCP toggle mid-conversation.
-  // Without this, any store update (e.g. WorkIQ connecting) would tear down and
-  // restart the Copilot session, losing all conversation context.
+  // changes — not on every skill/agent/MCP/model toggle mid-conversation.
+  // Without this, any store update (e.g. WorkIQ connecting, switching model) would
+  // tear down and restart the Copilot session, losing all conversation context.
+  // Model changes take effect on the next new conversation (same as VS Code Copilot).
+  const activeModelRef = useRef(activeModel);
   const activeSkillNamesRef = useRef(activeSkillNames);
   const activeAgentIdRef = useRef(activeAgentId);
   const importedMcpServersRef = useRef(importedMcpServers);
@@ -111,6 +113,7 @@ export function useOfficeChat(host: OfficeHostApp) {
   const npmSkillPackagesRef = useRef(npmSkillPackages);
   const evaluatePermissionRef = useRef(evaluatePermission);
   // Keep refs in sync on every render (runs synchronously, before any effects)
+  activeModelRef.current = activeModel;
   activeSkillNamesRef.current = activeSkillNames;
   activeAgentIdRef.current = activeAgentId;
   importedMcpServersRef.current = importedMcpServers;
@@ -267,7 +270,7 @@ export function useOfficeChat(host: OfficeHostApp) {
 
       const session = await withTimeout(
         client.createSession({
-          model: activeModel,
+          model: activeModelRef.current,
           systemMessage: { mode: 'replace', content: systemContent },
           tools: getToolsForHost(host),
           mcpServers,
@@ -320,10 +323,10 @@ export function useOfficeChat(host: OfficeHostApp) {
       }
     }
   }, [
-    // Only re-init the session when host or model change — these require a genuinely
-    // new connection. All other settings (skills, agents, MCP servers) are read via
-    // refs above so mid-conversation store updates never tear down an active session.
-    activeModel,
+    // Only re-init the session when host changes — that requires a genuinely new
+    // connection. All other settings (model, skills, agents, MCP servers) are read
+    // via refs above so mid-conversation store updates never tear down an active
+    // session. The new values take effect on the next fresh conversation.
     host,
   ]);
 

--- a/src/hooks/useOfficeChat.ts
+++ b/src/hooks/useOfficeChat.ts
@@ -620,6 +620,15 @@ export function useOfficeChat(host: OfficeHostApp) {
     let streamText = '';
 
     const updateAssistant = (extra?: Partial<Pick<ThreadMessageLike, 'status'>>) => {
+      // When the message is complete and has text, drop tool-call parts so they no
+      // longer render below the final response. Tool calls are already surfaced as
+      // progress indicators during streaming — keeping them in the completed content
+      // makes past actions visible at the bottom of every response, cluttering the
+      // thread. If the message has no text (tool-only result) we keep tool parts so
+      // the message is not empty.
+      const isComplete = extra?.status?.type === 'complete';
+      const includeToolParts = !isComplete || !streamText;
+
       const content: ThreadMessageLike['content'] = [
         // Text part comes FIRST so its array index stays stable even as tool-call
         // parts are appended. Prepending tool-calls would shift the text part's
@@ -629,7 +638,7 @@ export function useOfficeChat(host: OfficeHostApp) {
         // old index — triggering "MessagePartText can only be used inside text or
         // reasoning message parts".
         ...(streamText ? [{ type: 'text' as const, text: streamText }] : []),
-        ...Array.from(toolParts.values()),
+        ...(includeToolParts ? Array.from(toolParts.values()) : []),
       ];
       setMessages(prev => prev.map(m => (m.id === assistantId ? { ...m, content, ...extra } : m)));
     };

--- a/src/services/ai/BASE_PROMPT.md
+++ b/src/services/ai/BASE_PROMPT.md
@@ -32,3 +32,25 @@ Rules:
 - **Never** write "you can do X, Y, or Z — tell me which one" as prose. Always emit a `choices` block instead.
 - You may include additional prose before the choices block to provide context, but the options themselves must be in the block.
 - Keep each label short and action-oriented (e.g., "Create a chart" not "I can create a chart for you").
+
+## Proactive follow-up suggestions
+
+After completing a task, optionally end your response with a `suggestions` code block offering 2–4 natural follow-up actions the user might want to do next. These appear as VS Code-style follow-up links the user can click to continue.
+
+Format: same as `choices` — a fenced code block with the language tag `suggestions` containing a JSON array with `label` fields.
+
+Example (after summarizing data):
+
+```suggestions
+[
+  {"label": "Create a chart from this data"},
+  {"label": "Export summary to a new sheet"},
+  {"label": "Add conditional formatting"}
+]
+```
+
+Rules:
+- Only emit `suggestions` after **completing** a task — not when asking a clarifying question or presenting `choices`.
+- Never emit both `choices` and `suggestions` in the same response.
+- Keep labels short and action-oriented.
+- Omit `suggestions` if the task is conversational, or if there are no obvious next steps.

--- a/tests/integration/thread-message-rendering.test.tsx
+++ b/tests/integration/thread-message-rendering.test.tsx
@@ -13,7 +13,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, waitFor, act } from '@testing-library/react';
+import { render, screen, waitFor, act, fireEvent } from '@testing-library/react';
 import { AssistantRuntimeProvider } from '@assistant-ui/react';
 import type { AppendMessage } from '@assistant-ui/react';
 import type { SessionEvent } from '@github/copilot-sdk';
@@ -577,5 +577,442 @@ describe('Thread – AssistantMessage rendering', () => {
     });
 
     expect(document.querySelector('.aui-assistant-thinking-indicator')).not.toBeInTheDocument();
+  });
+});
+
+// ────────────────────────────────────────────────────────────────────────────
+// ChoiceCards rendering & interaction
+// ────────────────────────────────────────────────────────────────────────────
+
+describe('ChoiceCards', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useSettingsStore.getState().reset();
+    useSessionHistoryStore.setState({ sessions: [], activeSessionId: null });
+  });
+
+  it('renders a numbered list of choices from a markdown choices block', async () => {
+    const choicesJson = JSON.stringify([{ label: 'CSV' }, { label: 'Excel' }, { label: 'PDF' }]);
+    const content = `Which format?\n\`\`\`choices\n${choicesJson}\n\`\`\``;
+
+    const session = makeFakeSession([
+      makeEvent('assistant.message', { messageId: 'msg1', content }),
+      IDLE_EVENT,
+    ]);
+    const client = makeFakeClient(session);
+    mockCreate.mockResolvedValue(client as never);
+
+    const { getHook } = renderThreadWithHook();
+
+    await act(async () => {
+      await new Promise(r => setTimeout(r, 100));
+    });
+    await act(async () => {
+      getHook().runtime.thread.append(APPEND_MSG());
+      await new Promise(r => setTimeout(r, 200));
+    });
+
+    await waitFor(() => {
+      expect(document.querySelector('.aui-choices-wrapper')).toBeInTheDocument();
+    });
+
+    // All three choice labels are present
+    expect(screen.getByText('CSV')).toBeInTheDocument();
+    expect(screen.getByText('Excel')).toBeInTheDocument();
+    expect(screen.getByText('PDF')).toBeInTheDocument();
+
+    // Number badges 1, 2, 3 are present
+    const wrapper = document.querySelector('.aui-choices-wrapper')!;
+    const badges = wrapper.querySelectorAll('span.text-right');
+    expect(badges[0]?.textContent?.trim()).toBe('1');
+    expect(badges[1]?.textContent?.trim()).toBe('2');
+    expect(badges[2]?.textContent?.trim()).toBe('3');
+
+    // Freeform textarea is present with the correct placeholder
+    const textarea = wrapper.querySelector('textarea');
+    expect(textarea).toBeInTheDocument();
+    expect(textarea?.placeholder).toBe('Enter custom answer');
+
+    // Freeform row is numbered n+1 (4)
+    const allBadges = wrapper.querySelectorAll('span.text-right');
+    expect(allBadges[3]?.textContent?.trim()).toBe('4');
+  });
+
+  it('clicking a choice appends the label as a user message', async () => {
+    const choicesJson = JSON.stringify([{ label: 'Use CSV' }, { label: 'Use Excel' }]);
+    const content = `Pick one:\n\`\`\`choices\n${choicesJson}\n\`\`\``;
+
+    const session = makeFakeSession([
+      makeEvent('assistant.message', { messageId: 'msg1', content }),
+      IDLE_EVENT,
+    ]);
+    const client = makeFakeClient(session);
+    mockCreate.mockResolvedValue(client as never);
+
+    const { getHook } = renderThreadWithHook();
+
+    await act(async () => {
+      await new Promise(r => setTimeout(r, 100));
+    });
+    await act(async () => {
+      getHook().runtime.thread.append(APPEND_MSG());
+      await new Promise(r => setTimeout(r, 200));
+    });
+
+    await waitFor(() => {
+      expect(document.querySelector('.aui-choices-wrapper')).toBeInTheDocument();
+    });
+
+    // Click the first choice
+    const choiceButton = screen.getByText('Use CSV').closest('button')!;
+    await act(async () => {
+      fireEvent.click(choiceButton);
+      await new Promise(r => setTimeout(r, 100));
+    });
+
+    // A user message with that label should now appear in the thread
+    await waitFor(() => {
+      const userMessages = document.querySelectorAll('[data-role="user"]');
+      const texts = Array.from(userMessages).map(el => el.textContent);
+      expect(texts.some(t => t?.includes('Use CSV'))).toBe(true);
+    });
+  });
+
+  it('submitting freeform textarea appends the typed text as a user message', async () => {
+    const choicesJson = JSON.stringify([{ label: 'Option A' }]);
+    const content = `\`\`\`choices\n${choicesJson}\n\`\`\``;
+
+    const session = makeFakeSession([
+      makeEvent('assistant.message', { messageId: 'msg1', content }),
+      IDLE_EVENT,
+    ]);
+    const client = makeFakeClient(session);
+    mockCreate.mockResolvedValue(client as never);
+
+    const { getHook } = renderThreadWithHook();
+
+    await act(async () => {
+      await new Promise(r => setTimeout(r, 100));
+    });
+    await act(async () => {
+      getHook().runtime.thread.append(APPEND_MSG());
+      await new Promise(r => setTimeout(r, 200));
+    });
+
+    await waitFor(() => {
+      expect(document.querySelector('textarea[placeholder="Enter custom answer"]')).toBeInTheDocument();
+    });
+
+    const textarea = document.querySelector<HTMLTextAreaElement>('textarea[placeholder="Enter custom answer"]')!;
+
+    await act(async () => {
+      fireEvent.change(textarea, { target: { value: 'My custom answer' } });
+      fireEvent.keyDown(textarea, { key: 'Enter', shiftKey: false });
+      await new Promise(r => setTimeout(r, 100));
+    });
+
+    await waitFor(() => {
+      const userMessages = document.querySelectorAll('[data-role="user"]');
+      const texts = Array.from(userMessages).map(el => el.textContent);
+      expect(texts.some(t => t?.includes('My custom answer'))).toBe(true);
+    });
+  });
+
+  it('does not submit freeform text when Shift+Enter is pressed', async () => {
+    const choicesJson = JSON.stringify([{ label: 'Option A' }]);
+    const content = `\`\`\`choices\n${choicesJson}\n\`\`\``;
+
+    const session = makeFakeSession([
+      makeEvent('assistant.message', { messageId: 'msg1', content }),
+      IDLE_EVENT,
+    ]);
+    const client = makeFakeClient(session);
+    mockCreate.mockResolvedValue(client as never);
+
+    const { getHook } = renderThreadWithHook();
+
+    await act(async () => {
+      await new Promise(r => setTimeout(r, 100));
+    });
+    await act(async () => {
+      getHook().runtime.thread.append(APPEND_MSG());
+      await new Promise(r => setTimeout(r, 200));
+    });
+
+    await waitFor(() => {
+      expect(document.querySelector('textarea[placeholder="Enter custom answer"]')).toBeInTheDocument();
+    });
+
+    const textarea = document.querySelector<HTMLTextAreaElement>('textarea[placeholder="Enter custom answer"]')!;
+    const initialUserMessageCount = document.querySelectorAll('[data-role="user"]').length;
+
+    await act(async () => {
+      fireEvent.change(textarea, { target: { value: 'Draft text' } });
+      // Shift+Enter should NOT submit
+      fireEvent.keyDown(textarea, { key: 'Enter', shiftKey: true });
+      await new Promise(r => setTimeout(r, 100));
+    });
+
+    // User message count should not have changed
+    expect(document.querySelectorAll('[data-role="user"]').length).toBe(initialUserMessageCount);
+  });
+});
+
+// ────────────────────────────────────────────────────────────────────────────
+// SuggestionLinks rendering & interaction
+// ────────────────────────────────────────────────────────────────────────────
+
+describe('SuggestionLinks', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useSettingsStore.getState().reset();
+    useSessionHistoryStore.setState({ sessions: [], activeSessionId: null });
+  });
+
+  it('renders follow-up suggestion links from a markdown suggestions block', async () => {
+    const suggestionsJson = JSON.stringify([
+      { label: 'Create a chart' },
+      { label: 'Add a formula' },
+    ]);
+    const content = `Done! Here are some ideas:\n\`\`\`suggestions\n${suggestionsJson}\n\`\`\``;
+
+    const session = makeFakeSession([
+      makeEvent('assistant.message', { messageId: 'msg1', content }),
+      IDLE_EVENT,
+    ]);
+    const client = makeFakeClient(session);
+    mockCreate.mockResolvedValue(client as never);
+
+    const { getHook } = renderThreadWithHook();
+
+    await act(async () => {
+      await new Promise(r => setTimeout(r, 100));
+    });
+    await act(async () => {
+      getHook().runtime.thread.append(APPEND_MSG());
+      await new Promise(r => setTimeout(r, 200));
+    });
+
+    await waitFor(() => {
+      expect(document.querySelector('.aui-suggestions-wrapper')).toBeInTheDocument();
+    });
+
+    expect(screen.getByText('Create a chart')).toBeInTheDocument();
+    expect(screen.getByText('Add a formula')).toBeInTheDocument();
+
+    // Should be plain link-style buttons (no border, bg-transparent)
+    const wrapper = document.querySelector('.aui-suggestions-wrapper')!;
+    const buttons = wrapper.querySelectorAll('button');
+    expect(buttons.length).toBe(2);
+  });
+
+  it('does NOT render a freeform textarea (unlike choices)', async () => {
+    const suggestionsJson = JSON.stringify([{ label: 'Try something' }]);
+    const content = `\`\`\`suggestions\n${suggestionsJson}\n\`\`\``;
+
+    const session = makeFakeSession([
+      makeEvent('assistant.message', { messageId: 'msg1', content }),
+      IDLE_EVENT,
+    ]);
+    const client = makeFakeClient(session);
+    mockCreate.mockResolvedValue(client as never);
+
+    const { getHook } = renderThreadWithHook();
+
+    await act(async () => {
+      await new Promise(r => setTimeout(r, 100));
+    });
+    await act(async () => {
+      getHook().runtime.thread.append(APPEND_MSG());
+      await new Promise(r => setTimeout(r, 200));
+    });
+
+    await waitFor(() => {
+      expect(document.querySelector('.aui-suggestions-wrapper')).toBeInTheDocument();
+    });
+
+    // Suggestions have no freeform textarea
+    expect(document.querySelector('.aui-suggestions-wrapper textarea')).not.toBeInTheDocument();
+  });
+
+  it('clicking a suggestion appends the label as a user message', async () => {
+    const suggestionsJson = JSON.stringify([{ label: 'Add a pivot table' }]);
+    const content = `\`\`\`suggestions\n${suggestionsJson}\n\`\`\``;
+
+    const session = makeFakeSession([
+      makeEvent('assistant.message', { messageId: 'msg1', content }),
+      IDLE_EVENT,
+    ]);
+    const client = makeFakeClient(session);
+    mockCreate.mockResolvedValue(client as never);
+
+    const { getHook } = renderThreadWithHook();
+
+    await act(async () => {
+      await new Promise(r => setTimeout(r, 100));
+    });
+    await act(async () => {
+      getHook().runtime.thread.append(APPEND_MSG());
+      await new Promise(r => setTimeout(r, 200));
+    });
+
+    await waitFor(() => {
+      expect(document.querySelector('.aui-suggestions-wrapper')).toBeInTheDocument();
+    });
+
+    const suggestionButton = screen.getByText('Add a pivot table').closest('button')!;
+    await act(async () => {
+      fireEvent.click(suggestionButton);
+      await new Promise(r => setTimeout(r, 100));
+    });
+
+    await waitFor(() => {
+      const userMessages = document.querySelectorAll('[data-role="user"]');
+      const texts = Array.from(userMessages).map(el => el.textContent);
+      expect(texts.some(t => t?.includes('Add a pivot table'))).toBe(true);
+    });
+  });
+});
+
+// ────────────────────────────────────────────────────────────────────────────
+// Thread UI — Reload / BranchPicker / Edit buttons
+// ────────────────────────────────────────────────────────────────────────────
+
+describe('Thread UI: Reload, BranchPicker, and Edit buttons', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useSettingsStore.getState().reset();
+    useSessionHistoryStore.setState({ sessions: [], activeSessionId: null });
+  });
+
+  it('renders "Regenerate response" button in the assistant action bar', async () => {
+    const session = makeFakeSession([
+      makeEvent('assistant.message', { messageId: 'msg1', content: 'Hello world.' }),
+      IDLE_EVENT,
+    ]);
+    const client = makeFakeClient(session);
+    mockCreate.mockResolvedValue(client as never);
+
+    const { getHook } = renderThreadWithHook();
+
+    await act(async () => {
+      await new Promise(r => setTimeout(r, 100));
+    });
+    await act(async () => {
+      getHook().runtime.thread.append(APPEND_MSG());
+      await new Promise(r => setTimeout(r, 200));
+    });
+
+    await waitFor(() => {
+      expect(document.querySelector('[data-role="assistant"]')).toBeInTheDocument();
+    });
+
+    // The action bar should exist
+    expect(document.querySelector('.aui-assistant-action-bar')).toBeInTheDocument();
+
+    // TooltipIconButton renders accessible name via sr-only span — use getByRole
+    const reloadBtn = screen.getByRole('button', { name: 'Regenerate response' });
+    expect(reloadBtn).toBeInTheDocument();
+  });
+
+  it('does NOT render branch navigation buttons when there is only one branch', async () => {
+    const session = makeFakeSession([
+      makeEvent('assistant.message', { messageId: 'msg1', content: 'Single response.' }),
+      IDLE_EVENT,
+    ]);
+    const client = makeFakeClient(session);
+    mockCreate.mockResolvedValue(client as never);
+
+    const { getHook } = renderThreadWithHook();
+
+    await act(async () => {
+      await new Promise(r => setTimeout(r, 100));
+    });
+    await act(async () => {
+      getHook().runtime.thread.append(APPEND_MSG());
+      await new Promise(r => setTimeout(r, 200));
+    });
+
+    await waitFor(() => {
+      expect(document.querySelector('[data-role="assistant"]')).toBeInTheDocument();
+    });
+
+    // BranchPickerPrimitive has hideWhenSingleBranch — prev/next should not be in DOM
+    const prevBtn = document.querySelector('button[title="Previous response"]');
+    const nextBtn = document.querySelector('button[title="Next response"]');
+    expect(prevBtn).not.toBeInTheDocument();
+    expect(nextBtn).not.toBeInTheDocument();
+  });
+
+  it('renders "Edit message" button in the user message action bar', async () => {
+    // Use a full session so the thread properly idles (hideWhenRunning needs the run to complete)
+    const session = makeFakeSession([
+      makeEvent('assistant.message', { messageId: 'msg1', content: 'Hello!' }),
+      IDLE_EVENT,
+    ]);
+    const client = makeFakeClient(session);
+    mockCreate.mockResolvedValue(client as never);
+
+    const { getHook } = renderThreadWithHook();
+
+    await act(async () => {
+      await new Promise(r => setTimeout(r, 100));
+    });
+    await act(async () => {
+      getHook().runtime.thread.append(APPEND_MSG());
+      await new Promise(r => setTimeout(r, 300));
+    });
+
+    await waitFor(() => {
+      expect(document.querySelector('[data-role="user"]')).toBeInTheDocument();
+    });
+
+    // ActionBarPrimitive.Root with autohide="always" requires isHovering=true to render.
+    // AUI uses native addEventListener("mouseenter"), so fireEvent.mouseEnter triggers it.
+    const userMsg = document.querySelector('[data-role="user"]')!;
+    await act(async () => {
+      fireEvent.mouseEnter(userMsg);
+      await new Promise(r => setTimeout(r, 50));
+    });
+
+    // TooltipIconButton renders accessible name via sr-only span — use getByRole
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Edit message' })).toBeInTheDocument();
+    });
+  });
+
+  it('user action bar has aui-user-action-bar class', async () => {
+    // Use a full session so the thread properly idles (hideWhenRunning needs the run to complete)
+    const session = makeFakeSession([
+      makeEvent('assistant.message', { messageId: 'msg1', content: 'Hello!' }),
+      IDLE_EVENT,
+    ]);
+    const client = makeFakeClient(session);
+    mockCreate.mockResolvedValue(client as never);
+
+    const { getHook } = renderThreadWithHook();
+
+    await act(async () => {
+      await new Promise(r => setTimeout(r, 100));
+    });
+    await act(async () => {
+      getHook().runtime.thread.append(APPEND_MSG());
+      await new Promise(r => setTimeout(r, 300));
+    });
+
+    await waitFor(() => {
+      expect(document.querySelector('[data-role="user"]')).toBeInTheDocument();
+    });
+
+    // Trigger hover so autohide="always" allows rendering
+    const userMsg = document.querySelector('[data-role="user"]')!;
+    await act(async () => {
+      fireEvent.mouseEnter(userMsg);
+      await new Promise(r => setTimeout(r, 50));
+    });
+
+    await waitFor(() => {
+      expect(document.querySelector('.aui-user-action-bar')).toBeInTheDocument();
+    });
   });
 });

--- a/tests/integration/use-office-chat.test.tsx
+++ b/tests/integration/use-office-chat.test.tsx
@@ -181,7 +181,9 @@ describe('useOfficeChat', () => {
     expect((textPart as { type: 'text'; text: string }).text).toBe('Hello!');
   });
 
-  it('includes tool-call parts when tool events fire', async () => {
+  it('drops tool-call parts from completed message when text is present', async () => {
+    // Tool-call parts are shown during streaming but stripped from the final content
+    // once the message is complete with text, so they do not clutter the thread.
     const session = makeFakeSession([
       makeEvent('tool.execution_start', {
         toolCallId: 'tc1',
@@ -212,9 +214,49 @@ describe('useOfficeChat', () => {
 
     const messages = result.current.runtime.thread.getState().messages;
     const assistantContent = messages[1].content;
+    // Text part must be present
+    const textPart = assistantContent.find(c => c.type === 'text');
+    expect(textPart).toBeDefined();
+    expect((textPart as { type: 'text'; text: string }).text).toBe('Done!');
+    // Tool-call parts must be absent in the completed message (dropped to avoid cluttering thread)
+    const toolPart = assistantContent.find(c => c.type === 'tool-call');
+    expect(toolPart).toBeUndefined();
+  });
+
+  it('keeps tool-call parts in completed message when there is no text', async () => {
+    // If the AI response is tool-only (no text), tool parts must be kept so the
+    // message is not empty.
+    const session = makeFakeSession([
+      makeEvent('tool.execution_start', {
+        toolCallId: 'tc2',
+        toolName: 'get_range_values',
+        arguments: { range: 'A1' },
+      }),
+      makeEvent('tool.execution_complete', {
+        toolCallId: 'tc2',
+        success: true,
+        result: { content: '42' },
+      }),
+      IDLE_EVENT,
+    ]);
+    const client = makeFakeClient(session);
+    mockCreate.mockResolvedValue(client as never);
+
+    const { result } = renderHook(() => useOfficeChat('excel'), { wrapper });
+
+    await act(async () => {
+      await new Promise(r => setTimeout(r, 50));
+    });
+
+    await act(async () => {
+      result.current.runtime.thread.append(APPEND_MSG('Get A1'));
+      await new Promise(r => setTimeout(r, 100));
+    });
+
+    const messages = result.current.runtime.thread.getState().messages;
+    const assistantContent = messages[1].content;
     const toolPart = assistantContent.find(c => c.type === 'tool-call');
     expect(toolPart).toBeDefined();
-    expect(toolPart!.type).toBe('tool-call');
     expect((toolPart as { type: 'tool-call'; toolName: string }).toolName).toBe('get_range_values');
   });
 


### PR DESCRIPTION
Two conversation-quality fixes in `useOfficeChat`:

## 1. Strip tool-call parts from completed messages

**Problem:** Tool invocations were stored in message content even after the AI finished responding. They rendered below the final text (choice cards, tables, etc.), cluttering the thread with collapsed "Workiq-ask work iq" entries.

**Fix:** On completion, tool-call parts are dropped from content when `streamText` is non-empty. If the response has no text (tool-only), parts are kept so the message is not empty.

## 2. Prevent session teardown on mid-conversation store updates

**Problem:** `initSession` included `activeSkillNames`, `activeAgentId`, `importedMcpServers`, `activeMcpServerNames`, `npmSkillPackages`, and `evaluatePermission` in its `useCallback` deps. Any store update — a skill toggle, WorkIQ connecting, an MCP server status change — recreated the callback, fired the `useEffect`, and tore down the active Copilot session. The AI woke up cold with no context, producing messages like *"It looks like you may have switched to a different deck."*

**Fix:** All six volatile settings are now read via refs inside `initSession`. The callback only re-creates (and the session only resets) when `host` or `activeModel` genuinely change. Refs are synced on every render so new conversations always use the latest values.

## Tests

- 52/52 `use-office-chat.test.tsx` pass
- Two tests updated/added to reflect the new tool-part behavior
- No TypeScript errors
