### PR TITLE
chore: release v0.4.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "office-coding-agent",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "office-coding-agent",
-      "version": "0.4.2",
+      "version": "0.4.3",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "office-coding-agent",
-  "version": "0.4.2",
+  "version": "0.4.3",
   "private": true,
   "main": "src/tray/main.cjs",
   "description": "Office coding agent add-in with host-routed AI chat",


### PR DESCRIPTION
Patch release: VS Code UI pivot + SDK 0.1.30 upgrade.

### Changes since v0.4.2
- VS Code Copilot Chat design system (vscode-theme.css, codicons, 13px typography)
- Tool cards persist with chain-of-thought timeline
- Stable thinking indicator (no flashing)
- SDK 0.1.30: session.setModel(), session.compact(), clientName, auto-approve custom-tool permissions
- Golden rule: look identical to VS Code
- Zero hardcoded colors, zero lucide-react imports