### PR TITLE
fix: put text part before tool-call parts to prevent index-shift tearing (again)

### DIFF
--- a/src/hooks/useOfficeChat.ts
+++ b/src/hooks/useOfficeChat.ts
@@ -649,14 +649,15 @@ export function useOfficeChat(host: OfficeHostApp) {
     let streamText = '';
 
     const updateAssistant = (extra?: Partial<Pick<ThreadMessageLike, 'status'>>) => {
-      // Keep tool-call parts in the completed message so they remain visible
-      // as a collapsible "thinking" section above the text response, matching
-      // VS Code Copilot Chat's behavior where completed tool calls stay visible.
+      // Text part MUST come before tool-call parts to prevent index-shift
+      // tearing: when text is streaming at index 0 and a tool-call arrives,
+      // prepending the tool-call would shift the text to index 1, causing
+      // React 18's useSyncExternalStore to see a tool-call where it expects
+      // text → "MessagePartText can only be used inside text or reasoning
+      // message parts." Keeping text at index 0 avoids the shift entirely.
       const content: ThreadMessageLike['content'] = [
-        // Tool-call parts come FIRST so they appear above the text response,
-        // matching VS Code's layout: thinking/tools section → then text.
-        ...Array.from(toolParts.values()),
         ...(streamText ? [{ type: 'text' as const, text: streamText }] : []),
+        ...Array.from(toolParts.values()),
       ];
       setMessages(prev => prev.map(m => (m.id === assistantId ? { ...m, content, ...extra } : m)));
     };


### PR DESCRIPTION
## Problem

The VS Code UI pivot (53b96be) reverted the fix from #56 by placing tool-call parts before text parts in the content array. When text is already streaming at index 0 and a tool-call arrives, prepending it shifts the text part to index 1. React 18's useSyncExternalStore tearing-detection then sees a tool-call where MarkdownText expects text, throwing:

> MessagePartText can only be used inside text or reasoning message parts.

## Fix

Restore the text-first ordering so the text part stays at a stable index throughout streaming.

## Testing

- \
px tsc --noEmit\ — clean
- \
pm run test:integration\ — 731/731 pass