### PR TITLE
fix: tool cards render above text (VS Code layout) + tearing prevention

### DIFF
--- a/src/components/assistant-ui/thread.tsx
+++ b/src/components/assistant-ui/thread.tsx
@@ -264,6 +264,20 @@ const AssistantActionBar: FC = () => {
   );
 };
 
+/**
+ * ToolGroup wrapper — rendered by assistant-ui around consecutive tool-call
+ * parts. Uses CSS `order: -1` so tool cards appear visually ABOVE the text
+ * response (matching VS Code Copilot Chat) while keeping text at DOM index 0
+ * to prevent React 18 useSyncExternalStore tearing.
+ */
+const ToolGroup: FC<{ startIndex: number; endIndex: number; children?: ReactNode }> = ({
+  children,
+}) => (
+  <div className="aui-tool-group" style={{ order: -1 }}>
+    {children}
+  </div>
+);
+
 const AssistantMessage: FC = () => {
   return (
     <MessagePrimitive.Root
@@ -287,10 +301,11 @@ const AssistantMessage: FC = () => {
           Copilot
         </span>
       </div>
-      <div className="aui-assistant-message-content wrap-break-word px-4 text-foreground text-[13px] leading-[1.5em]">
+      <div className="aui-assistant-message-content flex flex-col wrap-break-word px-4 text-foreground text-[13px] leading-[1.5em]">
         <MessagePrimitive.Parts
           components={{
             Text: MarkdownText,
+            ToolGroup,
             tools: { Fallback: ToolFallback },
             Empty: () => null,
           }}

--- a/src/hooks/useOfficeChat.ts
+++ b/src/hooks/useOfficeChat.ts
@@ -649,14 +649,13 @@ export function useOfficeChat(host: OfficeHostApp) {
     let streamText = '';
 
     const updateAssistant = (extra?: Partial<Pick<ThreadMessageLike, 'status'>>) => {
-      // Text part MUST come before tool-call parts to prevent index-shift
-      // tearing: when text is streaming at index 0 and a tool-call arrives,
-      // prepending the tool-call would shift the text to index 1, causing
-      // React 18's useSyncExternalStore to see a tool-call where it expects
-      // text → "MessagePartText can only be used inside text or reasoning
-      // message parts." Keeping text at index 0 avoids the shift entirely.
+      // Text part is ALWAYS at index 0 — even when empty — to prevent
+      // React 18 useSyncExternalStore tearing. Without a stable text part,
+      // adding text later would prepend it, shifting tool-call indices and
+      // causing MarkdownText to read a tool-call part → crash. Tool cards
+      // appear visually above text via CSS order (ToolGroup has order: -1).
       const content: ThreadMessageLike['content'] = [
-        ...(streamText ? [{ type: 'text' as const, text: streamText }] : []),
+        { type: 'text' as const, text: streamText },
         ...Array.from(toolParts.values()),
       ];
       setMessages(prev => prev.map(m => (m.id === assistantId ? { ...m, content, ...extra } : m)));

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -142,8 +142,10 @@ summary:focus-visible,
 }
 
 /* ── VS Code Chain-of-Thought Timeline ── */
-/* The assistant message content area acts as the timeline container.
-   Tool cards and thinking indicators inside it get the vertical line. */
+/* The assistant message content area is a flex column so the ToolGroup
+   wrapper (order: -1) renders visually above the text part (order: 0),
+   matching VS Code Copilot Chat's layout: tools above → text below.
+   The DOM order stays text-first to prevent React 18 tearing. */
 .aui-assistant-message-content {
   position: relative;
 }
@@ -170,8 +172,8 @@ summary:focus-visible,
   background-color: var(--vscode-chat-requestBorder);
 }
 
-/* Single tool card: short line just beside the icon */
-[data-slot='tool-fallback-root']:only-of-type::before {
+/* Single tool card: hide vertical line (no chain to connect) */
+[data-slot='tool-fallback-root']:only-child::before {
   display: none;
 }
 

--- a/tests/integration/thread-message-rendering.test.tsx
+++ b/tests/integration/thread-message-rendering.test.tsx
@@ -580,6 +580,442 @@ describe('Thread – AssistantMessage rendering', () => {
 });
 
 // ────────────────────────────────────────────────────────────────────────────
+// Tool-call visual ordering & tearing prevention
+// ────────────────────────────────────────────────────────────────────────────
+
+describe('Tool-call visual ordering (VS Code layout: tools above text)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useSettingsStore.getState().reset();
+    useSessionHistoryStore.setState({ sessions: [], activeSessionId: null });
+  });
+
+  it('tool cards are wrapped in a ToolGroup div with order: -1', async () => {
+    const session = makeFakeSession([
+      makeEvent('tool.execution_start', {
+        toolCallId: 'tc1',
+        toolName: 'get_range_values',
+        arguments: { address: 'A1' },
+      }),
+      makeEvent('tool.execution_complete', {
+        toolCallId: 'tc1',
+        success: true,
+        result: { content: '[[1]]' },
+      }),
+      makeEvent('assistant.message', { messageId: 'msg1', content: 'Got it.' }),
+      IDLE_EVENT,
+    ]);
+    const client = makeFakeClient(session);
+    mockCreate.mockResolvedValue(client as never);
+
+    const { getHook } = renderThreadWithHook();
+
+    await act(async () => {
+      await new Promise(r => setTimeout(r, 100));
+    });
+    await act(async () => {
+      getHook().runtime.thread.append(APPEND_MSG());
+      await new Promise(r => setTimeout(r, 300));
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('Got it.')).toBeInTheDocument();
+    });
+
+    // Tool card must be inside a .aui-tool-group wrapper
+    const toolGroup = document.querySelector('.aui-tool-group');
+    expect(toolGroup).toBeInTheDocument();
+    expect(toolGroup!.querySelector('[data-slot="tool-fallback-root"]')).toBeInTheDocument();
+
+    // The ToolGroup wrapper must have order: -1 for CSS visual reordering
+    expect((toolGroup as HTMLElement).style.order).toBe('-1');
+  });
+
+  it('message content area uses flex column layout', async () => {
+    const session = makeFakeSession([
+      makeEvent('assistant.message', { messageId: 'msg1', content: 'Hi' }),
+      IDLE_EVENT,
+    ]);
+    const client = makeFakeClient(session);
+    mockCreate.mockResolvedValue(client as never);
+
+    const { getHook } = renderThreadWithHook();
+
+    await act(async () => {
+      await new Promise(r => setTimeout(r, 100));
+    });
+    await act(async () => {
+      getHook().runtime.thread.append(APPEND_MSG());
+      await new Promise(r => setTimeout(r, 200));
+    });
+
+    await waitFor(() => {
+      expect(document.querySelector('.aui-assistant-message-content')).toBeInTheDocument();
+    });
+
+    const content = document.querySelector('.aui-assistant-message-content');
+    expect(content!.classList.contains('flex')).toBe(true);
+    expect(content!.classList.contains('flex-col')).toBe(true);
+  });
+
+  it('ToolGroup has order:-1 so tools render visually above text', async () => {
+    const session = makeFakeSession([
+      makeEvent('tool.execution_start', {
+        toolCallId: 'tc1',
+        toolName: 'set_range_values',
+        arguments: { address: 'B1', values: [[99]] },
+      }),
+      makeEvent('tool.execution_complete', {
+        toolCallId: 'tc1',
+        success: true,
+        result: { content: 'OK' },
+      }),
+      makeEvent('assistant.message', { messageId: 'msg1', content: 'Updated B1.' }),
+      IDLE_EVENT,
+    ]);
+    const client = makeFakeClient(session);
+    mockCreate.mockResolvedValue(client as never);
+
+    const { getHook } = renderThreadWithHook();
+
+    await act(async () => {
+      await new Promise(r => setTimeout(r, 100));
+    });
+    await act(async () => {
+      getHook().runtime.thread.append(APPEND_MSG());
+      await new Promise(r => setTimeout(r, 300));
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('Updated B1.')).toBeInTheDocument();
+    });
+
+    // Verify both text and ToolGroup exist inside message content
+    const content = document.querySelector('.aui-assistant-message-content');
+    const toolGroup = content!.querySelector('.aui-tool-group');
+    const toolCard = toolGroup!.querySelector('[data-slot="tool-fallback-root"]');
+    expect(toolGroup).toBeInTheDocument();
+    expect(toolCard).toBeInTheDocument();
+
+    // ToolGroup has order: -1 → visually above text (order: 0 default)
+    expect((toolGroup as HTMLElement).style.order).toBe('-1');
+  });
+
+  it('multiple tool cards are all inside the same ToolGroup wrapper', async () => {
+    const session = makeFakeSession([
+      makeEvent('tool.execution_start', {
+        toolCallId: 'tc1',
+        toolName: 'get_range_values',
+        arguments: { address: 'A1' },
+      }),
+      makeEvent('tool.execution_complete', {
+        toolCallId: 'tc1',
+        success: true,
+        result: { content: '[[1]]' },
+      }),
+      makeEvent('tool.execution_start', {
+        toolCallId: 'tc2',
+        toolName: 'set_range_values',
+        arguments: { address: 'B1', values: [[2]] },
+      }),
+      makeEvent('tool.execution_complete', {
+        toolCallId: 'tc2',
+        success: true,
+        result: { content: 'OK' },
+      }),
+      makeEvent('assistant.message', { messageId: 'msg1', content: 'Both done.' }),
+      IDLE_EVENT,
+    ]);
+    const client = makeFakeClient(session);
+    mockCreate.mockResolvedValue(client as never);
+
+    const { getHook } = renderThreadWithHook();
+
+    await act(async () => {
+      await new Promise(r => setTimeout(r, 100));
+    });
+    await act(async () => {
+      getHook().runtime.thread.append(APPEND_MSG());
+      await new Promise(r => setTimeout(r, 300));
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('Both done.')).toBeInTheDocument();
+    });
+
+    const toolGroups = document.querySelectorAll('.aui-tool-group');
+    expect(toolGroups).toHaveLength(1);
+
+    const toolCards = toolGroups[0]!.querySelectorAll('[data-slot="tool-fallback-root"]');
+    expect(toolCards).toHaveLength(2);
+  });
+
+  it('no crash when tools arrive before text (tools-first event sequence)', async () => {
+    let resolveStream!: () => void;
+    const streamGate = new Promise<void>(r => {
+      resolveStream = r;
+    });
+
+    const pausingSession = {
+      sessionId: 'test-session-id',
+      async *query() {
+        yield makeEvent('tool.execution_start', {
+          toolCallId: 'tc1',
+          toolName: 'get_range_values',
+          arguments: { address: 'A1:C3' },
+        });
+        yield makeEvent('tool.execution_complete', {
+          toolCallId: 'tc1',
+          success: true,
+          result: { content: '[[1,2,3]]' },
+        });
+        // ── PAUSE ── React renders: text part (empty) + tool card
+        await streamGate;
+        yield makeEvent('assistant.message', { messageId: 'msg1', content: 'Here is A1:C3.' });
+        yield IDLE_EVENT;
+      },
+      on: vi.fn(),
+      onPermissionRequest: vi.fn(() => () => undefined),
+      destroy: vi.fn().mockResolvedValue(undefined),
+      send: vi.fn().mockResolvedValue('msg-id'),
+      registerTools: vi.fn(),
+      getToolHandler: vi.fn(),
+      respondPermission: vi.fn().mockResolvedValue(undefined),
+      _dispatchEvent: vi.fn(),
+    };
+    const client = makeFakeClient(pausingSession as ReturnType<typeof makeFakeSession>);
+    mockCreate.mockResolvedValue(client as never);
+
+    const { getHook } = renderThreadWithHook();
+
+    await act(async () => {
+      await new Promise(r => setTimeout(r, 100));
+    });
+
+    await act(async () => {
+      getHook().runtime.thread.append(APPEND_MSG());
+      await new Promise(r => setTimeout(r, 150));
+    });
+
+    // Mid-stream: tool card visible, no crash
+    expect(screen.queryByText(/MessagePartText can only/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/something went wrong/i)).not.toBeInTheDocument();
+    expect(document.querySelector('[data-slot="tool-fallback-root"]')).toBeInTheDocument();
+
+    await act(async () => {
+      resolveStream();
+      await new Promise(r => setTimeout(r, 200));
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('Here is A1:C3.')).toBeInTheDocument();
+    });
+  });
+
+  it('no crash when text streams first then a tool call arrives (text-first tearing scenario)', async () => {
+    // THIS IS THE EXACT TEARING SCENARIO from #56:
+    // Text starts streaming at index 0, then a tool call arrives.
+    let resolveStream!: () => void;
+    const streamGate = new Promise<void>(r => {
+      resolveStream = r;
+    });
+
+    const pausingSession = {
+      sessionId: 'test-session-id',
+      async *query() {
+        yield makeEvent('assistant.message_delta', {
+          deltaContent: 'Let me check ',
+        } as never);
+        // ── PAUSE ── React renders: text part at index 0 ("Let me check ")
+        await streamGate;
+        yield makeEvent('tool.execution_start', {
+          toolCallId: 'tc1',
+          toolName: 'get_range_values',
+          arguments: { address: 'Sheet1!A1' },
+        });
+        yield makeEvent('tool.execution_complete', {
+          toolCallId: 'tc1',
+          success: true,
+          result: { content: '[[42]]' },
+        });
+        yield makeEvent('assistant.message_delta', {
+          deltaContent: 'your data.',
+        } as never);
+        yield IDLE_EVENT;
+      },
+      on: vi.fn(),
+      onPermissionRequest: vi.fn(() => () => undefined),
+      destroy: vi.fn().mockResolvedValue(undefined),
+      send: vi.fn().mockResolvedValue('msg-id'),
+      registerTools: vi.fn(),
+      getToolHandler: vi.fn(),
+      respondPermission: vi.fn().mockResolvedValue(undefined),
+      _dispatchEvent: vi.fn(),
+    };
+    const client = makeFakeClient(pausingSession as ReturnType<typeof makeFakeSession>);
+    mockCreate.mockResolvedValue(client as never);
+
+    const { getHook } = renderThreadWithHook();
+
+    await act(async () => {
+      await new Promise(r => setTimeout(r, 100));
+    });
+
+    await act(async () => {
+      getHook().runtime.thread.append(APPEND_MSG());
+      await new Promise(r => setTimeout(r, 150));
+    });
+
+    // Mid-stream: text is visible, no crash
+    expect(screen.queryByText(/MessagePartText can only/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/something went wrong/i)).not.toBeInTheDocument();
+
+    await act(async () => {
+      resolveStream();
+      await new Promise(r => setTimeout(r, 300));
+    });
+
+    // After completion: both text and tool card visible, no crash
+    expect(screen.queryByText(/MessagePartText can only/i)).not.toBeInTheDocument();
+    expect(document.querySelector('[data-slot="tool-fallback-root"]')).toBeInTheDocument();
+  });
+
+  it('no crash with interleaved text → tool → text sequence', async () => {
+    const session = makeFakeSession([
+      makeEvent('assistant.message_delta', { deltaContent: 'Checking...' } as never),
+      makeEvent('tool.execution_start', {
+        toolCallId: 'tc1',
+        toolName: 'get_range_values',
+        arguments: { address: 'A1' },
+      }),
+      makeEvent('tool.execution_complete', {
+        toolCallId: 'tc1',
+        success: true,
+        result: { content: '[[5]]' },
+      }),
+      makeEvent('assistant.message_delta', { deltaContent: ' Value is 5.' } as never),
+      IDLE_EVENT,
+    ]);
+    const client = makeFakeClient(session);
+    mockCreate.mockResolvedValue(client as never);
+
+    const { getHook } = renderThreadWithHook();
+
+    await act(async () => {
+      await new Promise(r => setTimeout(r, 100));
+    });
+    await act(async () => {
+      getHook().runtime.thread.append(APPEND_MSG());
+      await new Promise(r => setTimeout(r, 300));
+    });
+
+    // No crash
+    expect(screen.queryByText(/MessagePartText can only/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/something went wrong/i)).not.toBeInTheDocument();
+
+    // Tool card visible
+    expect(document.querySelector('[data-slot="tool-fallback-root"]')).toBeInTheDocument();
+  });
+
+  it('no crash with multiple tool calls and no text at all', async () => {
+    const session = makeFakeSession([
+      makeEvent('tool.execution_start', {
+        toolCallId: 'tc1',
+        toolName: 'manage_skills',
+        arguments: { action: 'list' },
+      }),
+      makeEvent('tool.execution_complete', {
+        toolCallId: 'tc1',
+        success: true,
+        result: { content: '["skill1"]' },
+      }),
+      makeEvent('tool.execution_start', {
+        toolCallId: 'tc2',
+        toolName: 'manage_agents',
+        arguments: { action: 'list' },
+      }),
+      makeEvent('tool.execution_complete', {
+        toolCallId: 'tc2',
+        success: true,
+        result: { content: '["agent1"]' },
+      }),
+      IDLE_EVENT,
+    ]);
+    const client = makeFakeClient(session);
+    mockCreate.mockResolvedValue(client as never);
+
+    const { getHook } = renderThreadWithHook();
+
+    await act(async () => {
+      await new Promise(r => setTimeout(r, 100));
+    });
+    await act(async () => {
+      getHook().runtime.thread.append(APPEND_MSG());
+      await new Promise(r => setTimeout(r, 300));
+    });
+
+    await waitFor(() => {
+      expect(document.querySelector('[data-role="assistant"]')).toBeInTheDocument();
+    });
+
+    // No crash
+    expect(screen.queryByText(/MessagePartText can only/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/something went wrong/i)).not.toBeInTheDocument();
+
+    // Both tool cards rendered
+    const toolCards = document.querySelectorAll('[data-slot="tool-fallback-root"]');
+    expect(toolCards.length).toBe(2);
+  });
+
+  it('after completion, tool cards remain visible inside ToolGroup above text', async () => {
+    const session = makeFakeSession([
+      makeEvent('tool.execution_start', {
+        toolCallId: 'tc1',
+        toolName: 'get_range_values',
+        arguments: { address: 'A1:A5' },
+      }),
+      makeEvent('tool.execution_complete', {
+        toolCallId: 'tc1',
+        success: true,
+        result: { content: '[[1],[2],[3],[4],[5]]' },
+      }),
+      makeEvent('assistant.message', { messageId: 'msg1', content: 'Here are rows 1-5.' }),
+      IDLE_EVENT,
+    ]);
+    const client = makeFakeClient(session);
+    mockCreate.mockResolvedValue(client as never);
+
+    const { getHook } = renderThreadWithHook();
+
+    await act(async () => {
+      await new Promise(r => setTimeout(r, 100));
+    });
+    await act(async () => {
+      getHook().runtime.thread.append(APPEND_MSG());
+      await new Promise(r => setTimeout(r, 300));
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('Here are rows 1-5.')).toBeInTheDocument();
+    });
+
+    // Tool cards must still be visible after completion
+    const toolGroup = document.querySelector('.aui-tool-group');
+    expect(toolGroup).toBeInTheDocument();
+
+    const toolCard = toolGroup!.querySelector('[data-slot="tool-fallback-root"]');
+    expect(toolCard).toBeInTheDocument();
+
+    // The completed tool card should show the checkmark icon (not spinner)
+    const checkIcon = toolCard!.querySelector('.codicon-check');
+    expect(checkIcon).toBeInTheDocument();
+
+    // Thinking indicator must be gone
+    expect(document.querySelector('.aui-assistant-thinking-indicator')).not.toBeInTheDocument();
+  });
+});
+
+// ────────────────────────────────────────────────────────────────────────────
 // ChoiceCards rendering & interaction
 // ────────────────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Problem

Two visual mismatches with VS Code Copilot Chat:

1. **Tool calls appeared BELOW text response** — VS Code shows tools above text
2. **The MessagePartText tearing crash kept recurring** — text/tool index shifts caused React 18 useSyncExternalStore to read wrong part types

## Root Cause

\MessagePrimitive.Parts\ renders parts in array order. Previous fixes chose between visual order (tools first → tearing) or stability (text first → tools at bottom). Neither was right alone.

## Fix (three-part, holistic)

### 1. Always include text part at index 0
Even when \streamText\ is empty (\''\), the text part stays at index 0. No content part ever shifts indices regardless of event order. This **permanently** prevents the tearing crash.

### 2. ToolGroup wrapper with CSS \order: -1\
assistant-ui's \MessagePrimitive.Parts\ accepts a \ToolGroup\ component that wraps consecutive tool-call parts. We wrap them in a \<div>\ with \order: -1\ inside a \lex flex-col\ container, so tool cards render **visually above** the text — matching VS Code's layout.

### 3. Updated timeline CSS
Changed \:only-of-type\ to \:only-child\ for the single-tool-card vertical line selector, since tool cards are now inside a ToolGroup wrapper.

## Visual Result

\\\
[Copilot avatar + label]
  ✓ Read range A1:B10        ← tool cards (order: -1, visually first)
  ✓ Write range C1:C5
  Here is the response...     ← text (order: 0, visually after tools)
  [Copy button]
\\\

## Testing

- \
px tsc --noEmit\ — clean
- \
pm run test:integration\ — **740/740 pass** (9 new tests added)

### New tests (9):
- ToolGroup wrapper rendering with \order: -1\
- Flex column layout on message content
- Tools-first, text-first, and interleaved event sequences
- Multiple tool cards in a single ToolGroup
- Tool cards remaining visible after completion
- All tearing scenarios (mid-stream pauses with React rendering)