### PR TITLE
chore: release v0.4.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "office-coding-agent",
-  "version": "0.4.3",
+  "version": "0.4.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "office-coding-agent",
-      "version": "0.4.3",
+      "version": "0.4.5",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "office-coding-agent",
-  "version": "0.4.3",
+  "version": "0.4.5",
   "private": true,
   "main": "src/tray/main.cjs",
   "description": "Office coding agent add-in with host-routed AI chat",


### PR DESCRIPTION
Bump version to v0.4.5 (patch release for #70 — tool cards render above text + tearing prevention).