### PR TITLE
feat: VS Code UX matching, Stop/Steer, PPT fixes

### DIFF
--- a/src/components/assistant-ui/markdown-text.tsx
+++ b/src/components/assistant-ui/markdown-text.tsx
@@ -125,38 +125,42 @@ const ChoiceCards: FC<{ code: string }> = ({ code }) => {
   if (!choices || choices.length === 0) return null;
 
   return (
-    <div className="aui-choices-wrapper mt-2 flex flex-col">
-      {choices.map((choice, i) => (
-        <button
-          key={choice.label}
-          onClick={() => handleChoice(choice.label)}
-          title={choice.description}
-          className="flex items-baseline gap-3 rounded-[var(--vscode-cornerRadius-medium)] px-2 py-1 text-left text-sm transition-colors hover:bg-[var(--vscode-list-hoverBackground)]"
-        >
-          <span className="w-4 shrink-0 text-right text-xs text-muted-foreground select-none">
-            {i + 1}
-          </span>
-          <span className="text-foreground">{choice.label}</span>
-        </button>
-      ))}
-      <div className="flex items-baseline gap-3 px-2 py-1">
-        <span className="w-4 shrink-0 text-right text-xs text-muted-foreground select-none">
-          {choices.length + 1}
-        </span>
-        <textarea
-          className="flex-1 resize-none bg-transparent text-sm text-foreground outline-none border-b transition-colors placeholder:text-[var(--vscode-input-placeholderForeground)]"
-          style={{ borderColor: 'var(--vscode-widget-border)' }}
-          placeholder="Enter custom answer"
-          rows={1}
-          value={freeformText}
-          onChange={e => setFreeformText(e.target.value)}
-          onKeyDown={e => {
-            if (e.key === 'Enter' && !e.shiftKey) {
-              e.preventDefault();
-              handleFreeform();
-            }
-          }}
-        />
+    <div className="aui-choices-wrapper chat-question-carousel-container">
+      <div className="chat-question-input-container">
+        <div className="chat-question-list">
+          {choices.map((choice, i) => (
+            <button
+              key={choice.label}
+              onClick={() => handleChoice(choice.label)}
+              title={choice.description}
+              className="chat-question-list-item"
+            >
+              <span className="chat-question-list-number">{i + 1}</span>
+              <span className="chat-question-list-label">
+                <span className="chat-question-list-label-title">{choice.label}</span>
+                {choice.description && (
+                  <span className="chat-question-list-label-desc">{choice.description}</span>
+                )}
+              </span>
+            </button>
+          ))}
+        </div>
+        <div className="chat-question-freeform">
+          <span className="chat-question-freeform-number">{choices.length + 1}</span>
+          <textarea
+            className="chat-question-freeform-textarea"
+            placeholder="Enter custom answer"
+            rows={1}
+            value={freeformText}
+            onChange={e => setFreeformText(e.target.value)}
+            onKeyDown={e => {
+              if (e.key === 'Enter' && !e.shiftKey) {
+                e.preventDefault();
+                handleFreeform();
+              }
+            }}
+          />
+        </div>
       </div>
     </div>
   );

--- a/src/components/assistant-ui/thread.tsx
+++ b/src/components/assistant-ui/thread.tsx
@@ -188,17 +188,20 @@ const MessageError: FC = () => {
 const InlineWorkingProgress: FC = () => {
   const thinkingText = useThinkingText();
   const isRunning = useAuiState(s => s.thread.isRunning);
-  const hasContent = useAuiState(s => {
-    const parts = s.message.parts;
-    return parts.some(
-      p =>
-        (p.type === 'text' && p.text.trim().length > 0) ||
-        p.type === 'tool-call'
-    );
-  });
 
-  // Hide when: no thinking text, message has any content (text or tools), or not running
-  if (!thinkingText || hasContent || !isRunning) return null;
+  const hasTextContent = useAuiState(s =>
+    s.message.parts.some(p => p.type === 'text' && p.text.trim().length > 0)
+  );
+
+  const hasRunningTool = useAuiState(s =>
+    s.message.parts.some(p => p.type === 'tool-call' && p.status?.type === 'running')
+  );
+
+  // Show when: thinking text is set, thread is running, no text content yet,
+  // and no tool is currently executing (tools have their own shimmer).
+  // This covers: initial "Thinking…", AND the gap between tool completion
+  // and the next action where the model is deciding what to do.
+  if (!thinkingText || !isRunning || hasTextContent || hasRunningTool) return null;
 
   return (
     <div className="inline-working-progress progress-container shimmer-progress" style={{ order: -2 }}>

--- a/src/components/assistant-ui/thread.tsx
+++ b/src/components/assistant-ui/thread.tsx
@@ -13,8 +13,18 @@ import {
 } from '@assistant-ui/react';
 import { Codicon } from '@/components/Codicon';
 import { cn } from '@/lib/utils';
-import { type FC, type ReactNode, useCallback, useEffect, useRef, useState } from 'react';
+import { type FC, type ReactNode, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useThinkingText } from '@/contexts/ThinkingContext';
+
+/**
+ * Pool of rotating progress labels matching VS Code's
+ * defaultThinkingMessages and toolMessages arrays.
+ */
+const TOOL_LABELS = ['Processing', 'Preparing', 'Loading', 'Analyzing', 'Evaluating'];
+
+function pickLabel(pool: string[]): string {
+  return pool[Math.floor(Math.random() * pool.length)];
+}
 
 export const Thread: FC<{ leftToolbar?: ReactNode; rightToolbar?: ReactNode }> = ({
   leftToolbar,
@@ -38,7 +48,7 @@ export const Thread: FC<{ leftToolbar?: ReactNode; rightToolbar?: ReactNode }> =
           }}
         />
 
-        <ThreadLevelThinkingIndicator />
+        {/* Thinking indicator is now inline inside AssistantMessage — no thread-level indicator */}
 
         <ThreadPrimitive.ViewportFooter className="aui-thread-viewport-footer sticky bottom-0 mt-auto flex w-full flex-col gap-2 overflow-visible bg-background px-3 pb-3">
           <ThreadScrollToBottom />
@@ -175,21 +185,26 @@ const MessageError: FC = () => {
 };
 
 /**
- * Thread-level thinking indicator with VS Code shimmer effect.
- * Rendered once after ThreadPrimitive.Messages so it always appears below the
- * last message. Reads directly from ThinkingContext.
+ * Inline working progress line, rendered inside AssistantMessage.
+ * Matches VS Code's ChatWorkingProgressContentPart —
+ * a shimmer "Working" / "Thinking" line that appears before
+ * any response text and disappears when text arrives.
  */
-const ThreadLevelThinkingIndicator: FC = () => {
+const InlineWorkingProgress: FC = () => {
   const thinkingText = useThinkingText();
-  if (thinkingText === null) return null;
+  const isRunning = useAuiState(s => s.thread.isRunning);
+  const hasTextContent = useAuiState(s => {
+    const parts = s.message.parts;
+    return parts.some(p => p.type === 'text' && p.text.trim().length > 0);
+  });
+
+  // Hide when: no thinking text, message has text content, or not running
+  if (!thinkingText || hasTextContent || !isRunning) return null;
+
   return (
-    <div className="aui-assistant-message-root" data-role="assistant">
-      <div
-        className="aui-assistant-thinking-indicator fade-in animate-in duration-150 flex items-center gap-2 px-4 py-1.5"
-        style={{ fontSize: 13 }}
-      >
-        <span className="chat-thinking-shimmer-text">{thinkingText}</span>
-      </div>
+    <div className="progress-container shimmer-progress" style={{ order: -2 }}>
+      <Codicon name="circle-filled" className="progress-status-icon shrink-0" />
+      <span className="progress-step">{thinkingText}</span>
     </div>
   );
 };
@@ -268,14 +283,11 @@ const AssistantActionBar: FC = () => {
 
 /**
  * ToolGroup wrapper — rendered by assistant-ui around consecutive tool-call
- * parts. Uses CSS `order: -1` so tool cards appear visually ABOVE the text
- * response (matching VS Code Copilot Chat) while keeping text at DOM index 0
- * to prevent React 18 useSyncExternalStore tearing.
+ * parts. Matches VS Code's "Working" collapsible box pattern.
  *
- * When there are 2+ tools, shows a collapsible "Used N tools" header
- * (matching VS Code Copilot Chat's grouped tool invocations). The group
- * auto-collapses once all tools complete and stays expanded while any tool
- * is still running. A single tool renders without the group header.
+ * Single tool: bare progress line with order:-1 positioning.
+ * Multi-tool: VS Code "Working" collapsible box with chain-of-thought
+ * line, shimmer title, and auto-collapse on completion.
  */
 const ToolGroup: FC<{ startIndex: number; endIndex: number; children?: ReactNode }> = ({
   startIndex,
@@ -284,7 +296,6 @@ const ToolGroup: FC<{ startIndex: number; endIndex: number; children?: ReactNode
 }) => {
   const toolCount = endIndex - startIndex + 1;
 
-  // Read whether any tool in this range is still running
   const isRunning = useAuiState(s => {
     for (let i = startIndex; i <= endIndex; i++) {
       const part = s.message.parts[i];
@@ -293,27 +304,27 @@ const ToolGroup: FC<{ startIndex: number; endIndex: number; children?: ReactNode
     return false;
   });
 
-  // Single tool — no group header, just render the card directly
+  // Single tool — bare progress line, no Working box
   if (toolCount <= 1) {
     return (
-      <div className="aui-tool-group" style={{ order: -1 }}>
+      <div className="chat-tool-single" style={{ order: -1 }}>
         {children}
       </div>
     );
   }
 
   return (
-    <ToolGroupCollapsible isRunning={isRunning} toolCount={toolCount}>
+    <WorkingCollapsible isRunning={isRunning} toolCount={toolCount}>
       {children}
-    </ToolGroupCollapsible>
+    </WorkingCollapsible>
   );
 };
 
 /**
- * Inner collapsible component for ToolGroup (2+ tools).
- * Extracted so the hooks are only active when we actually need the collapsible.
+ * VS Code "Working" collapsible box for multi-tool groups.
+ * Matches ChatThinkingContentPart from VS Code source.
  */
-const ToolGroupCollapsible: FC<{
+const WorkingCollapsible: FC<{
   isRunning: boolean;
   toolCount: number;
   children?: ReactNode;
@@ -321,7 +332,14 @@ const ToolGroupCollapsible: FC<{
   const [isExpanded, setIsExpanded] = useState(true);
   const hasAutoCollapsed = useRef(false);
 
-  // Auto-collapse once when every tool in the group completes
+  // Rotating spinner label
+  const spinnerLabel = useMemo(
+    () => (isRunning ? pickLabel(TOOL_LABELS) : ''),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [isRunning]
+  );
+
+  // Auto-collapse once when every tool completes
   useEffect(() => {
     if (!isRunning && !hasAutoCollapsed.current) {
       hasAutoCollapsed.current = true;
@@ -331,31 +349,56 @@ const ToolGroupCollapsible: FC<{
 
   const toggle = useCallback(() => setIsExpanded(prev => !prev), []);
 
-  const headerText = isRunning ? `Running tools\u2026` : `Used ${toolCount} tools`;
+  const completionTitle = `Finished with ${toolCount} step${toolCount !== 1 ? 's' : ''}`;
 
   return (
-    <div className="aui-tool-group" style={{ order: -1 }}>
+    <div
+      className={cn(
+        'chat-thinking-box',
+        isRunning && 'chat-thinking-active',
+        !isExpanded && 'chat-thinking-collapsed'
+      )}
+      style={{ order: -1 }}
+    >
+      {/* Collapsible header button */}
       <button
         type="button"
         onClick={toggle}
-        className="aui-tool-group-trigger flex w-full items-center gap-1.5 py-1 text-sm text-left"
+        className="chat-thinking-header"
         aria-expanded={isExpanded}
-        data-slot="tool-group-trigger"
       >
         <Codicon
-          name={isExpanded ? 'chevron-down' : 'chevron-right'}
-          className="text-xs text-muted-foreground shrink-0"
+          name={isRunning ? 'circle-filled' : 'check'}
+          className={cn(
+            'chat-thinking-header-icon',
+            !isRunning && 'text-muted-foreground'
+          )}
         />
-        <Codicon
-          name={isRunning ? 'loading~spin' : 'check'}
-          className={cn('shrink-0 text-sm', isRunning && 'codicon-modifier-spin')}
-        />
-        <span className={cn('font-medium', isRunning && 'chat-thinking-shimmer-text')}>
-          {headerText}
+        <span className={cn(isRunning ? 'chat-thinking-title-shimmer' : 'chat-thinking-title-done')}>
+          {isRunning ? 'Working' : completionTitle}
         </span>
+        <Codicon
+          name={isExpanded ? 'chevron-down' : 'chevron-right'}
+          className="chat-collapsible-hover-chevron"
+        />
       </button>
-      <div className="aui-tool-group-content" style={{ display: isExpanded ? undefined : 'none' }}>
+
+      {/* Collapsible content with chain-of-thought line */}
+      <div
+        className="chat-thinking-collapsible"
+        style={{ display: isExpanded ? undefined : 'none' }}
+      >
         {children}
+
+        {/* Spinner at bottom while running */}
+        {isRunning && (
+          <div className="chat-thinking-spinner-item chat-thinking-tool-wrapper">
+            <span className="chat-thinking-icon">
+              <Codicon name="circle-filled" className="text-xs" />
+            </span>
+            <span className="chat-thinking-spinner-label">{spinnerLabel}</span>
+          </div>
+        )}
       </div>
     </div>
   );
@@ -385,6 +428,7 @@ const AssistantMessage: FC = () => {
         </span>
       </div>
       <div className="aui-assistant-message-content flex flex-col wrap-break-word px-4 text-foreground text-[13px] leading-[1.5em]">
+        <InlineWorkingProgress />
         <MessagePrimitive.Parts
           components={{
             Text: MarkdownText,

--- a/src/components/assistant-ui/thread.tsx
+++ b/src/components/assistant-ui/thread.tsx
@@ -188,16 +188,20 @@ const MessageError: FC = () => {
 const InlineWorkingProgress: FC = () => {
   const thinkingText = useThinkingText();
   const isRunning = useAuiState(s => s.thread.isRunning);
-  const hasTextContent = useAuiState(s => {
+  const hasContent = useAuiState(s => {
     const parts = s.message.parts;
-    return parts.some(p => p.type === 'text' && p.text.trim().length > 0);
+    return parts.some(
+      p =>
+        (p.type === 'text' && p.text.trim().length > 0) ||
+        p.type === 'tool-call'
+    );
   });
 
-  // Hide when: no thinking text, message has text content, or not running
-  if (!thinkingText || hasTextContent || !isRunning) return null;
+  // Hide when: no thinking text, message has any content (text or tools), or not running
+  if (!thinkingText || hasContent || !isRunning) return null;
 
   return (
-    <div className="progress-container shimmer-progress" style={{ order: -2 }}>
+    <div className="inline-working-progress progress-container shimmer-progress" style={{ order: -2 }}>
       <Codicon name="circle-filled" className="progress-status-icon shrink-0" />
       <span className="progress-step">{thinkingText}</span>
     </div>

--- a/src/components/assistant-ui/thread.tsx
+++ b/src/components/assistant-ui/thread.tsx
@@ -141,17 +141,17 @@ const Composer: FC<{ leftToolbar?: ReactNode; rightToolbar?: ReactNode }> = ({
         <div className="flex items-center gap-0.5">{leftToolbar}</div>
         <div className="flex items-center gap-0.5">
           {rightToolbar}
-          <AuiIf condition={s => !s.thread.isRunning}>
-            <ComposerPrimitive.Send asChild>
-              <TooltipIconButton
-                tooltip="Send"
-                variant="ghost"
-                className="aui-composer-send h-7 w-7 rounded-md transition-opacity"
-              >
-                <Codicon name="send" className="text-base" />
-              </TooltipIconButton>
-            </ComposerPrimitive.Send>
-          </AuiIf>
+          {/* Send button — always visible. When running, sending a new message
+              cancels the current response and redirects (VS Code "steer" behavior). */}
+          <ComposerPrimitive.Send asChild>
+            <TooltipIconButton
+              tooltip="Send"
+              variant="ghost"
+              className="aui-composer-send h-7 w-7 rounded-md transition-opacity"
+            >
+              <Codicon name="send" className="text-base" />
+            </TooltipIconButton>
+          </ComposerPrimitive.Send>
           <AuiIf condition={s => s.thread.isRunning}>
             <ComposerPrimitive.Cancel asChild>
               <TooltipIconButton

--- a/src/components/assistant-ui/thread.tsx
+++ b/src/components/assistant-ui/thread.tsx
@@ -92,34 +92,29 @@ const ThreadWelcome: FC = () => {
     <div className="aui-thread-welcome-root my-auto flex w-full grow flex-col px-4">
       <div className="aui-thread-welcome-center flex w-full grow flex-col items-center justify-center">
         <div className="aui-thread-welcome-message flex w-full flex-col items-center justify-center">
-          <div
-            className="mb-2 flex items-center justify-center rounded-full"
-            style={{
-              width: 28,
-              height: 28,
-              background: 'var(--vscode-chat-avatarBackground)',
-              color: 'var(--vscode-chat-avatarForeground)',
-            }}
-          >
-            <Codicon name="copilot" className="text-sm" />
+          <div style={{ marginBottom: 24 }}>
+            <Codicon
+              name="copilot"
+              className="text-[40px] text-[var(--vscode-descriptionForeground)]"
+            />
           </div>
-          <h1 className="aui-thread-welcome-message-inner fade-in slide-in-from-bottom-1 animate-in fill-mode-both font-semibold text-base duration-200">
+          <h1
+            className="aui-thread-welcome-message-inner fade-in slide-in-from-bottom-1 animate-in fill-mode-both font-semibold duration-200"
+            style={{ fontSize: 13 }}
+          >
             How can I help?
           </h1>
         </div>
 
-        <div className="mt-4 flex w-full flex-col">
+        <div className="chat-welcome-suggested-prompts mt-4">
+          <p className="chat-welcome-suggested-prompts-title">Try asking</p>
           {SUGGESTIONS.map((suggestion, idx) => (
             <ThreadPrimitive.Suggestion
               key={suggestion.prompt}
               {...suggestion}
-              className="fade-in slide-in-from-bottom-1 animate-in fill-mode-both flex items-center gap-2 rounded-[var(--vscode-cornerRadius-medium)] px-2 py-1.5 text-left text-[12px] transition-colors duration-150 hover:bg-[var(--vscode-list-hoverBackground)]"
-              style={{
-                animationDelay: `${100 + idx * 50}ms`,
-                color: 'var(--vscode-textLink-foreground)',
-              }}
+              className="chat-welcome-suggested-prompt fade-in animate-in fill-mode-both duration-150"
+              style={{ animationDelay: `${100 + idx * 50}ms` }}
             >
-              <Codicon name="sparkle" className="shrink-0 text-[11px]" />
               {suggestion.prompt}
             </ThreadPrimitive.Suggestion>
           ))}
@@ -410,23 +405,7 @@ const AssistantMessage: FC = () => {
       className="aui-assistant-message-root group/message fade-in slide-in-from-bottom-1 relative w-full animate-in py-2 duration-150"
       data-role="assistant"
     >
-      {/* Copilot avatar header */}
-      <div className="mb-1.5 flex items-center gap-2 px-4">
-        <div
-          className="flex items-center justify-center rounded-full"
-          style={{
-            width: 22,
-            height: 22,
-            background: 'var(--vscode-chat-avatarBackground)',
-            color: 'var(--vscode-chat-avatarForeground)',
-          }}
-        >
-          <Codicon name="copilot" className="text-[12px]" />
-        </div>
-        <span style={{ fontSize: 13, fontWeight: 600 }} className="text-foreground">
-          Copilot
-        </span>
-      </div>
+      {/* VS Code hides avatar + name for the default Copilot agent */}
       <div className="aui-assistant-message-content flex flex-col wrap-break-word px-4 text-foreground text-[13px] leading-[1.5em]">
         <InlineWorkingProgress />
         <MessagePrimitive.Parts
@@ -498,7 +477,7 @@ const UserMessage: FC = () => {
       className="aui-user-message-root fade-in slide-in-from-bottom-1 group/message relative flex w-full animate-in px-4 py-2 duration-150"
       data-role="user"
     >
-      <div className="aui-user-message-content wrap-break-word w-full text-foreground text-[13px] leading-[1.5em]">
+      <div className="aui-user-message-bubble wrap-break-word text-foreground text-[13px] leading-[1.5em]">
         <MessagePrimitive.Content />
       </div>
       <UserActionBar />

--- a/src/components/assistant-ui/tool-fallback.tsx
+++ b/src/components/assistant-ui/tool-fallback.tsx
@@ -1,315 +1,146 @@
-import { memo, useCallback, useRef, useState } from 'react';
+import { memo, useState, useCallback } from 'react';
 import {
-  useScrollLock,
   type ToolCallMessagePartStatus,
   type ToolCallMessagePartComponent,
 } from '@assistant-ui/react';
-import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible';
 import { Codicon } from '@/components/Codicon';
 import { cn } from '@/lib/utils';
 import { humanizeToolName } from '@/utils/humanizeToolName';
 import { toolResultSummary } from '@/utils/toolResultSummary';
-
-const ANIMATION_DURATION = 200;
-
-export type ToolFallbackRootProps = Omit<
-  React.ComponentProps<typeof Collapsible>,
-  'open' | 'onOpenChange'
-> & {
-  open?: boolean;
-  onOpenChange?: (open: boolean) => void;
-  defaultOpen?: boolean;
-};
-
-function ToolFallbackRoot({
-  className,
-  open: controlledOpen,
-  onOpenChange: controlledOnOpenChange,
-  defaultOpen = false,
-  children,
-  ...props
-}: ToolFallbackRootProps) {
-  const collapsibleRef = useRef<HTMLDivElement>(null);
-  const [uncontrolledOpen, setUncontrolledOpen] = useState(defaultOpen);
-  const lockScroll = useScrollLock(collapsibleRef, ANIMATION_DURATION);
-
-  const isControlled = controlledOpen !== undefined;
-  const isOpen = isControlled ? controlledOpen : uncontrolledOpen;
-
-  const handleOpenChange = useCallback(
-    (open: boolean) => {
-      if (!open) {
-        lockScroll();
-      }
-      if (!isControlled) {
-        setUncontrolledOpen(open);
-      }
-      controlledOnOpenChange?.(open);
-    },
-    [lockScroll, isControlled, controlledOnOpenChange]
-  );
-
-  return (
-    <Collapsible
-      ref={collapsibleRef}
-      data-slot="tool-fallback-root"
-      open={isOpen}
-      onOpenChange={handleOpenChange}
-      className={cn('aui-tool-fallback-root group/tool-fallback-root w-full py-2', className)}
-      style={
-        {
-          '--animation-duration': `${ANIMATION_DURATION}ms`,
-          border: '1px solid var(--vscode-widget-border)',
-          borderRadius: 'var(--vscode-cornerRadius-medium)',
-        } as React.CSSProperties
-      }
-      {...props}
-    >
-      {children}
-    </Collapsible>
-  );
-}
+import { getToolIcon } from '@/utils/toolIcon';
 
 type ToolStatus = ToolCallMessagePartStatus['type'];
 
-/** Maps tool status to codicon name */
-const statusCodiconMap: Record<ToolStatus, string> = {
-  running: 'loading~spin',
-  complete: 'check',
-  incomplete: 'error',
-  'requires-action': 'warning',
-};
+/**
+ * VS Code-style progress line for a tool invocation.
+ *
+ * Matches VS Code's `.progress-container` layout:
+ *   [tool-icon] [shimmer-text]          — while running
+ *   [check]     [muted past-tense text] — when complete
+ *
+ * No borders, no cards. Flat inline progress line.
+ */
+const ToolFallbackImpl: ToolCallMessagePartComponent = ({ toolName, argsText, result, status }) => {
+  const [isExpanded, setIsExpanded] = useState(false);
+  const toggle = useCallback(() => setIsExpanded(prev => !prev), []);
 
-function ToolFallbackTrigger({
-  toolName,
-  status,
-  result,
-  className,
-  ...props
-}: React.ComponentProps<typeof CollapsibleTrigger> & {
-  toolName: string;
-  status?: ToolCallMessagePartStatus;
-  result?: unknown;
-}) {
-  const statusType = status?.type ?? 'complete';
+  const statusType: ToolStatus = status?.type ?? 'complete';
   const isRunning = statusType === 'running';
   const isCancelled = status?.type === 'incomplete' && status.reason === 'cancelled';
+  const isError = statusType === 'incomplete' && !isCancelled;
 
-  const codiconName = statusCodiconMap[statusType];
   const friendlyName = humanizeToolName(toolName);
+  const toolIcon = getToolIcon(toolName);
   const summary = !isRunning && result !== undefined ? toolResultSummary(result) : null;
+  const hasDetails = !!(argsText || result !== undefined || (status?.type === 'incomplete' && status.error));
 
   return (
-    <CollapsibleTrigger
-      data-slot="tool-fallback-trigger"
-      className={cn(
-        'aui-tool-fallback-trigger group/trigger flex w-full items-center gap-2 px-3 text-sm transition-colors',
-        className
-      )}
-      {...props}
+    <div
+      className={cn('chat-tool-progress-wrapper', isCancelled && 'opacity-60')}
+      data-slot="tool-fallback-root"
     >
-      <Codicon
-        name={codiconName}
+      {/* Progress line: [icon] [text] [hover-chevron] */}
+      <button
+        type="button"
+        onClick={hasDetails ? toggle : undefined}
         className={cn(
-          'aui-tool-fallback-trigger-icon shrink-0 text-sm',
-          isCancelled && 'text-muted-foreground',
-          isRunning && 'codicon-modifier-spin'
+          'progress-container',
+          isRunning && 'shimmer-progress',
+          !hasDetails && 'pointer-events-none'
         )}
-      />
-      <span
-        data-slot="tool-fallback-trigger-label"
-        className={cn(
-          'aui-tool-fallback-trigger-label-wrapper relative inline-block text-left leading-none',
-          isCancelled && 'text-muted-foreground line-through'
-        )}
+        aria-expanded={hasDetails ? isExpanded : undefined}
+        data-slot="tool-fallback-trigger"
       >
-        <span className={cn(isRunning && 'chat-thinking-shimmer-text')}>
-          <b>{friendlyName}</b>
+        {/* Tool-type icon on the chain-of-thought line */}
+        <span className="chat-thinking-icon">
+          <Codicon name={toolIcon} className="text-xs" />
         </span>
-      </span>
-      {summary && (
-        <span className="ml-1 min-w-0 flex-1 truncate text-xs text-muted-foreground">
-          {summary}
+
+        {/* Status icon: hidden in shimmer mode, check when done */}
+        <Codicon
+          name={
+            isRunning
+              ? 'circle-filled'
+              : isError
+                ? 'error'
+                : isCancelled
+                  ? 'circle-slash'
+                  : 'check'
+          }
+          className={cn(
+            'progress-status-icon shrink-0',
+            isError && 'text-[var(--vscode-errorForeground)]',
+            isCancelled && 'text-muted-foreground'
+          )}
+        />
+
+        {/* Tool name + summary */}
+        <span
+          className={cn(
+            'progress-step',
+            isCancelled && 'line-through'
+          )}
+        >
+          {friendlyName}
         </span>
-      )}
-      <Codicon
-        name="chevron-down"
-        data-slot="tool-fallback-trigger-chevron"
-        className={cn(
-          'aui-tool-fallback-trigger-chevron ml-auto shrink-0 text-sm',
-          'transition-transform duration-200 ease-out',
-          'group-data-[state=closed]/trigger:-rotate-90',
-          'group-data-[state=open]/trigger:rotate-0'
+
+        {summary && (
+          <span className="progress-summary">{String(summary)}</span>
         )}
-      />
-    </CollapsibleTrigger>
-  );
-}
 
-function ToolFallbackContent({
-  className,
-  children,
-  ...props
-}: React.ComponentProps<typeof CollapsibleContent>) {
-  return (
-    <CollapsibleContent
-      data-slot="tool-fallback-content"
-      className={cn(
-        'aui-tool-fallback-content relative overflow-hidden text-sm outline-none',
-        'group/collapsible-content ease-out',
-        className
+        {/* Hover chevron (appears on hover, like VS Code) */}
+        {hasDetails && (
+          <Codicon
+            name={isExpanded ? 'chevron-down' : 'chevron-right'}
+            className="chat-collapsible-hover-chevron"
+          />
+        )}
+      </button>
+
+      {/* Expandable tool details */}
+      {isExpanded && hasDetails && (
+        <div className="tool-details-expanded">
+          {/* Error */}
+          {status?.type === 'incomplete' && !!status.error && (
+            <div className="tool-details-section">
+              <p
+                className="text-xs font-semibold"
+                style={{ color: 'var(--vscode-errorForeground)' }}
+              >
+                {isCancelled ? 'Cancelled:' : 'Error:'}
+              </p>
+              <p style={{ color: 'var(--vscode-errorForeground)' }}>
+                {typeof status.error === 'string'
+                  ? status.error
+                  : JSON.stringify(status.error as object)}
+              </p>
+            </div>
+          )}
+
+          {/* Input */}
+          {argsText && (
+            <div className="tool-details-section">
+              <p className="tool-details-label">Input</p>
+              <pre className="tool-details-code">{argsText}</pre>
+            </div>
+          )}
+
+          {/* Output */}
+          {result !== undefined && !isCancelled && (
+            <div className="tool-details-section">
+              <p className="tool-details-label">Output</p>
+              <pre className="tool-details-code">
+                {typeof result === 'string' ? result : JSON.stringify(result as object, null, 2)}
+              </pre>
+            </div>
+          )}
+        </div>
       )}
-      {...props}
-    >
-      <div
-        className="mt-2 flex flex-col gap-2 pt-2"
-        style={{ borderTop: '1px solid var(--vscode-widget-border)' }}
-      >
-        {children}
-      </div>
-    </CollapsibleContent>
-  );
-}
-
-function ToolFallbackArgs({
-  argsText,
-  className,
-  ...props
-}: React.ComponentProps<'div'> & {
-  argsText?: string;
-}) {
-  if (!argsText) return null;
-
-  return (
-    <div
-      data-slot="tool-fallback-args"
-      className={cn('aui-tool-fallback-args px-3', className)}
-      {...props}
-    >
-      <p className="mb-1 text-xs font-semibold text-muted-foreground">Input</p>
-      <pre
-        className="aui-tool-fallback-args-value whitespace-pre-wrap rounded-[var(--vscode-cornerRadius-medium)] p-2 text-xs"
-        style={{
-          fontFamily: 'var(--vscode-monospace-font)',
-          background: 'var(--vscode-editorWidget-background)',
-        }}
-      >
-        {argsText}
-      </pre>
     </div>
-  );
-}
-
-function ToolFallbackResult({
-  result,
-  className,
-  ...props
-}: React.ComponentProps<'div'> & {
-  result?: unknown;
-}) {
-  if (result === undefined) return null;
-
-  return (
-    <div
-      data-slot="tool-fallback-result"
-      className={cn('aui-tool-fallback-result px-3 pt-2', className)}
-      style={{ borderTop: '1px dashed var(--vscode-widget-border)' }}
-      {...props}
-    >
-      <p className="aui-tool-fallback-result-header mb-1 text-xs font-semibold text-muted-foreground">
-        Output
-      </p>
-      <pre
-        className="aui-tool-fallback-result-content whitespace-pre-wrap rounded-[var(--vscode-cornerRadius-medium)] p-2 text-xs"
-        style={{
-          fontFamily: 'var(--vscode-monospace-font)',
-          background: 'var(--vscode-editorWidget-background)',
-        }}
-      >
-        {typeof result === 'string' ? result : JSON.stringify(result, null, 2)}
-      </pre>
-    </div>
-  );
-}
-
-function ToolFallbackError({
-  status,
-  className,
-  ...props
-}: React.ComponentProps<'div'> & {
-  status?: ToolCallMessagePartStatus;
-}) {
-  if (status?.type !== 'incomplete') return null;
-
-  const error = status.error;
-  const errorText = error ? (typeof error === 'string' ? error : JSON.stringify(error)) : null;
-
-  if (!errorText) return null;
-
-  const isCancelled = status.reason === 'cancelled';
-  const headerText = isCancelled ? 'Cancelled reason:' : 'Error:';
-
-  return (
-    <div
-      data-slot="tool-fallback-error"
-      className={cn('aui-tool-fallback-error px-3', className)}
-      {...props}
-    >
-      <p
-        className="aui-tool-fallback-error-header font-semibold"
-        style={{ color: 'var(--vscode-errorForeground)' }}
-      >
-        {headerText}
-      </p>
-      <p
-        className="aui-tool-fallback-error-reason"
-        style={{ color: 'var(--vscode-errorForeground)' }}
-      >
-        {errorText}
-      </p>
-    </div>
-  );
-}
-
-const ToolFallbackImpl: ToolCallMessagePartComponent = ({ toolName, argsText, result, status }) => {
-  const isCancelled = status?.type === 'incomplete' && status.reason === 'cancelled';
-
-  return (
-    <ToolFallbackRoot className={cn(isCancelled && 'opacity-60')}>
-      <ToolFallbackTrigger toolName={toolName} status={status} result={result as unknown} />
-      <ToolFallbackContent>
-        <ToolFallbackError status={status} />
-        <ToolFallbackArgs argsText={argsText} className={cn(isCancelled && 'opacity-60')} />
-        {/* eslint-disable-next-line @typescript-eslint/no-unsafe-assignment */}
-        {!isCancelled && <ToolFallbackResult result={result} />}
-      </ToolFallbackContent>
-    </ToolFallbackRoot>
   );
 };
 
-const ToolFallback = memo(ToolFallbackImpl) as unknown as ToolCallMessagePartComponent & {
-  Root: typeof ToolFallbackRoot;
-  Trigger: typeof ToolFallbackTrigger;
-  Content: typeof ToolFallbackContent;
-  Args: typeof ToolFallbackArgs;
-  Result: typeof ToolFallbackResult;
-  Error: typeof ToolFallbackError;
-};
-
+const ToolFallback = memo(ToolFallbackImpl) as ToolCallMessagePartComponent;
 ToolFallback.displayName = 'ToolFallback';
-ToolFallback.Root = ToolFallbackRoot;
-ToolFallback.Trigger = ToolFallbackTrigger;
-ToolFallback.Content = ToolFallbackContent;
-ToolFallback.Args = ToolFallbackArgs;
-ToolFallback.Result = ToolFallbackResult;
-ToolFallback.Error = ToolFallbackError;
 
-export {
-  ToolFallback,
-  ToolFallbackRoot,
-  ToolFallbackTrigger,
-  ToolFallbackContent,
-  ToolFallbackArgs,
-  ToolFallbackResult,
-  ToolFallbackError,
-};
+export { ToolFallback };

--- a/src/hooks/useOfficeChat.ts
+++ b/src/hooks/useOfficeChat.ts
@@ -711,9 +711,6 @@ export function useOfficeChat(host: OfficeHostApp) {
           updateAssistant();
         } else if (event.type === 'tool.execution_complete') {
           const { toolCallId, result } = event.data;
-          // Don't clear thinkingText here — keep showing the tool name until
-          // text starts streaming or the response completes. In VS Code, the
-          // thinking label stays visible throughout the tool execution phase.
           const existing = toolParts.get(toolCallId);
           if (existing) {
             const resultText = result
@@ -724,6 +721,9 @@ export function useOfficeChat(host: OfficeHostApp) {
             toolParts.set(toolCallId, { ...existing, result: resultText });
             updateAssistant();
           }
+          // Reset thinking text to "Thinking…" so the shimmer reappears
+          // in the gap between this tool completing and the next action.
+          setThinkingText(DEFAULT_THINKING_TEXT);
         } else if (event.type === 'assistant.message') {
           // Update text content but DON'T clear thinking or mark complete here.
           // The SDK sends assistant.message BEFORE tool calls (model's initial

--- a/src/hooks/useOfficeChat.ts
+++ b/src/hooks/useOfficeChat.ts
@@ -867,9 +867,34 @@ export function useOfficeChat(host: OfficeHostApp) {
     onNew,
     onCancel: () => {
       cancelRef.current = true;
-      // Do not set isRunning=false here — the streaming loop's `finally` block
-      // handles it after the current iteration actually finishes. Setting it
-      // prematurely causes the UI to show "idle" while events are still processing.
+
+      // Immediately update UI: mark the running message as incomplete/cancelled
+      // and clear thinking text so the user gets instant feedback.
+      flushSync(() => {
+        setThinkingText(null);
+        setIsRunning(false);
+        setMessages(prev => {
+          const last = prev[prev.length - 1];
+          if (last?.role === 'assistant' && last.status?.type !== 'complete') {
+            return [
+              ...prev.slice(0, -1),
+              { ...last, status: { type: 'incomplete', reason: 'cancelled' } },
+            ];
+          }
+          return prev;
+        });
+      });
+
+      // Also destroy and recreate the session to actually stop the SDK query.
+      // Without this, the proxy/SDK keeps processing events until the response
+      // finishes naturally.
+      const session = sessionRef.current;
+      if (session) {
+        void session.destroy().catch(() => {/* ignore */});
+        sessionRef.current = null;
+        void initSessionRef.current();
+      }
+
       return Promise.resolve();
     },
     convertMessage: (msg: ThreadMessageLike) => msg,

--- a/src/services/ai/BASE_PROMPT.md
+++ b/src/services/ai/BASE_PROMPT.md
@@ -54,3 +54,9 @@ Rules:
 - Never emit both `choices` and `suggestions` in the same response.
 - Keep labels short and action-oriented.
 - Omit `suggestions` if the task is conversational, or if there are no obvious next steps.
+
+## Parallel data gathering
+
+When a task requires gathering data from multiple independent sources (web search, Power BI queries, MCP servers, file lookups), use **parallel tool calls** to collect data simultaneously rather than sequentially. This significantly speeds up research-heavy workflows like "fetch market data from the web and pull sales numbers from Power BI, then build a comparison chart."
+
+Only parallelize tools that are truly independent — don't parallelize calls that modify the same document (e.g., writing to cells in Excel should remain sequential).

--- a/src/services/ai/prompts/POWERPOINT_APP_PROMPT.md
+++ b/src/services/ai/prompts/POWERPOINT_APP_PROMPT.md
@@ -61,6 +61,10 @@ The `code` parameter receives three variables injected automatically at runtime:
 Content width = `W - 1` (0.5" margin each side). Safe area: x ≥ 0.5, y ≥ 0.5, x+w ≤ W-0.5, y+h ≤ H-0.5.
 Always add `shrinkText: true` to every `addText()` call.
 
+All positions (x, y, w, h) are in **inches**. Colors: 6-digit hex without # prefix (`"4472C4"`).
+
+### Text
+
 ```js
 // Title + subtitle
 slide.addText("Title", { x: 0.5, y: 0.5, w: W-1, h: 1, fontSize: 32, bold: true, color: "363636", shrinkText: true });
@@ -72,22 +76,23 @@ slide.addText([
   { text: "Point 2", options: { bullet: true } },
 ], { x: 0.5, y: 2.5, w: W-1, h: H-3, fontSize: 16, shrinkText: true });
 
-// 3-column layout — colW divides available width into 3 equal columns with 0.1" gaps
-const colW = (W - 1 - 0.2) / 3;  // 0.2" = 2 gaps × 0.1"
-const col0 = 0.5, col1 = col0 + colW + 0.1, col2 = col1 + colW + 0.1;
-const bodyY = 2.2, bodyH = H - bodyY - 0.5;
-slide.addText("Column 1", { x: col0, y: 1.5, w: colW, h: 0.5, fontSize: 16, bold: true, color: "4472C4", shrinkText: true });
-slide.addText("Body text here", { x: col0, y: bodyY, w: colW, h: bodyH, fontSize: 14, shrinkText: true });
-slide.addText("Column 2", { x: col1, y: 1.5, w: colW, h: 0.5, fontSize: 16, bold: true, color: "4472C4", shrinkText: true });
-slide.addText("Body text here", { x: col1, y: bodyY, w: colW, h: bodyH, fontSize: 14, shrinkText: true });
-slide.addText("Column 3", { x: col2, y: 1.5, w: colW, h: 0.5, fontSize: 16, bold: true, color: "4472C4", shrinkText: true });
-slide.addText("Body text here", { x: col2, y: bodyY, w: colW, h: bodyH, fontSize: 14, shrinkText: true });
+// Numbered bullets
+slide.addText([
+  { text: "First", options: { bullet: { type: "number" } } },
+  { text: "Second", options: { bullet: { type: "number" } } },
+], { x: 0.5, y: 2.5, w: W-1, h: H-3, fontSize: 16, shrinkText: true });
 
-// Table
-slide.addTable([["Header 1", "Header 2"], ["Row 1", "Data"]], { x: 0.5, y: 2, w: W-1, fontSize: 14 });
+// Text with hyperlink
+slide.addText([
+  { text: "Visit our website", options: { hyperlink: { url: "https://example.com", tooltip: "Example" } } },
+], { x: 0.5, y: 5, w: W-1, h: 0.5, fontSize: 14, shrinkText: true });
 
-// Shape
-slide.addShape("rect", { x: 1, y: 1, w: 3, h: 1, fill: { color: "4472C4" } });
+// Text inside a shape
+slide.addText("Inside a rounded rectangle", {
+  shape: "roundRect", x: 0.5, y: 2, w: W-1, h: 1.5,
+  fill: { color: "4472C4" }, color: "FFFFFF", fontSize: 18,
+  align: "center", valign: "middle", rectRadius: 0.2, shrinkText: true,
+});
 
 // Label + description — ALWAYS a SINGLE string with colon
 slide.addText([
@@ -95,7 +100,162 @@ slide.addText([
 ], { x: 0.5, y: 2, w: W-1, h: H-2.5, shrinkText: true });
 ```
 
-All positions (x, y, w, h) are in **inches**. Colors: 6-digit hex without # prefix (`"4472C4"`).
+Text options: `fontSize`, `fontFace`, `color`, `bold`, `italic`, `underline`, `align` (left/center/right), `valign` (top/middle/bottom), `lineSpacing`, `paraSpaceBefore`, `paraSpaceAfter`, `margin`, `fill: { color }`, `shadow: { type, color, blur, offset, angle }`, `outline: { size, color }`, `breakLine: true` (force line break in arrays).
+
+### Multi-Column Layout
+
+```js
+const colW = (W - 1 - 0.2) / 3;  // 0.2" = 2 gaps × 0.1"
+const col0 = 0.5, col1 = col0 + colW + 0.1, col2 = col1 + colW + 0.1;
+const bodyY = 2.2, bodyH = H - bodyY - 0.5;
+slide.addText("Column 1", { x: col0, y: 1.5, w: colW, h: 0.5, fontSize: 16, bold: true, color: "4472C4", shrinkText: true });
+slide.addText("Body text here", { x: col0, y: bodyY, w: colW, h: bodyH, fontSize: 14, shrinkText: true });
+```
+
+### Tables
+
+```js
+// Simple table
+slide.addTable([["Header 1", "Header 2"], ["Row 1", "Data"]], { x: 0.5, y: 2, w: W-1, fontSize: 14 });
+
+// Styled table with cell-level formatting
+slide.addTable([
+  [
+    { text: "Product", options: { bold: true, fill: { color: "4472C4" }, color: "FFFFFF", align: "center" } },
+    { text: "Revenue", options: { bold: true, fill: { color: "4472C4" }, color: "FFFFFF", align: "center" } },
+  ],
+  [
+    { text: "Widget A", options: { fill: { color: "F2F2F2" } } },
+    { text: "$1,200", options: { fill: { color: "F2F2F2" }, align: "right" } },
+  ],
+  ["Widget B", { text: "$3,400", options: { align: "right" } }],
+], {
+  x: 0.5, y: 2, w: W-1, fontSize: 13,
+  colW: [(W-1)*0.6, (W-1)*0.4],
+  border: { type: "solid", pt: 0.5, color: "CFCFCF" },
+  rowH: [0.4, 0.35, 0.35],
+});
+```
+
+Table options: `colW` (array of column widths or single uniform width), `rowH` (array or uniform), `border: { type, pt, color }` (type: "none"/"solid"/"dash"), `align`, `valign`, `fontFace`, `fontSize`, `color`, `fill`, `margin`, `colspan`, `rowspan`.
+
+### Charts
+
+```js
+// Bar chart
+slide.addChart("bar", [
+  { name: "Q1", labels: ["Jan","Feb","Mar"], values: [10, 20, 15] },
+  { name: "Q2", labels: ["Jan","Feb","Mar"], values: [25, 18, 30] },
+], {
+  x: 0.5, y: 2, w: W-1, h: H-3,
+  showTitle: true, title: "Quarterly Sales",
+  showValue: true, showLegend: true, legendPos: "b",
+  chartColors: ["4472C4", "ED7D31"],
+});
+
+// Line chart
+slide.addChart("line", [
+  { name: "Revenue", labels: ["2020","2021","2022","2023"], values: [100,150,200,280] },
+], {
+  x: 0.5, y: 2, w: W-1, h: H-3,
+  showTitle: true, title: "Revenue Trend",
+  showLegend: false, showValue: true,
+  lineDataSymbol: "circle", lineDataSymbolSize: 8,
+  chartColors: ["4472C4"],
+});
+
+// Pie chart
+slide.addChart("pie", [
+  { name: "Market Share", labels: ["Us","Competitor A","Competitor B","Other"], values: [45, 25, 20, 10] },
+], {
+  x: 1, y: 1.5, w: W-2, h: H-2.5,
+  showTitle: true, title: "Market Share",
+  showPercent: true, showLegend: true, legendPos: "b",
+  chartColors: ["4472C4", "ED7D31", "A5A5A5", "FFC000"],
+});
+
+// Doughnut chart
+slide.addChart("doughnut", [
+  { name: "Budget", labels: ["R&D","Marketing","Operations"], values: [40, 35, 25] },
+], {
+  x: 1, y: 1.5, w: W-2, h: H-2.5,
+  showTitle: true, title: "Budget Allocation",
+  showPercent: true, holeSize: 50,
+  chartColors: ["4472C4", "ED7D31", "70AD47"],
+});
+
+// Combo chart (bar + line)
+slide.addChart(
+  [
+    { type: "bar", data: [{ name: "Sales", labels: ["Q1","Q2","Q3","Q4"], values: [100,200,150,300] }], options: { chartColors: ["4472C4"] } },
+    { type: "line", data: [{ name: "Target", labels: ["Q1","Q2","Q3","Q4"], values: [150,150,150,150] }], options: { chartColors: ["ED7D31"] } },
+  ],
+  { x: 0.5, y: 2, w: W-1, h: H-3, showLegend: true, showTitle: true, title: "Sales vs Target" }
+);
+```
+
+Chart types: `"bar"`, `"bar3d"`, `"line"`, `"area"`, `"pie"`, `"doughnut"`, `"scatter"`, `"bubble"`, `"radar"`.
+
+Chart options: `showTitle`, `title`, `titleFontSize`, `showLegend`, `legendPos` (b/t/l/r/tr), `showValue`, `showPercent`, `showLabel`, `chartColors` (array of hex), `chartArea: { fill: { color } }`, `plotArea: { fill: { color } }`, `catAxisTitle`, `valAxisTitle`, `catAxisLabelRotate`, `valAxisLabelFormatCode` (e.g. `"$#,##0"`), `barDir` ("bar" for horizontal, default vertical), `barGapWidthPct`, `lineDataSymbol` ("circle"/"square"/"triangle"/"none"), `lineDataSymbolSize`, `lineSmooth: true`.
+
+### Images
+
+```js
+// Image from base64 data (use fetch_image_as_base64 tool to get the data URI first)
+slide.addImage({ data: "image/png;base64,iVBORw0KGgo...", x: 0.5, y: 2, w: 4, h: 3 });
+
+// Image with sizing (contain = fit within area preserving aspect ratio)
+slide.addImage({
+  data: imageDataUri,
+  x: 0.5, y: 2, w: W-1, h: H-3,
+  sizing: { type: "contain", w: W-1, h: H-3 },
+});
+
+// Rounded image
+slide.addImage({ data: imageDataUri, x: 1, y: 1.5, w: 3, h: 3, rounding: true });
+```
+
+Image options: `x`, `y`, `w`, `h`, `sizing: { type, w, h }` (type: "contain"/"cover"/"crop"), `rounding: true` (circle), `rotate` (degrees), `flipH`, `flipV`, `hyperlink: { url }`, `altText`, `transparency` (0-100).
+
+**Important**: Images cannot be loaded from URLs at runtime — use the `fetch_image_as_base64` tool first, then pass the returned data URI to `slide.addImage({ data: ... })`.
+
+### Shapes
+
+```js
+// Rectangle with fill
+slide.addShape("rect", { x: 0.5, y: 2, w: 3, h: 1.5, fill: { color: "4472C4" } });
+
+// Rounded rectangle
+slide.addShape("roundRect", { x: 0.5, y: 2, w: 3, h: 1.5, fill: { color: "70AD47" }, rectRadius: 0.2 });
+
+// Ellipse / circle
+slide.addShape("ellipse", { x: 5, y: 2, w: 2, h: 2, fill: { color: "ED7D31" } });
+
+// Line
+slide.addShape("line", { x: 0.5, y: 4, w: W-1, h: 0, line: { color: "CFCFCF", width: 1 } });
+
+// Shape with border
+slide.addShape("rect", {
+  x: 0.5, y: 2, w: 3, h: 1.5,
+  fill: { color: "FFFFFF" },
+  line: { color: "4472C4", width: 1.5 },
+  shadow: { type: "outer", color: "000000", blur: 6, offset: 3, angle: 45 },
+});
+```
+
+Common shape types: `"rect"`, `"roundRect"`, `"ellipse"`, `"triangle"`, `"diamond"`, `"hexagon"`, `"star5"`, `"heart"`, `"cloud"`, `"line"`, `"arrowRight"`, `"chevron"`.
+
+Shape options: `fill: { color }`, `line: { color, width, dashType }` (dashType: "solid"/"dash"/"lgDash"/"dot"), `rectRadius` (rounded corners 0-1), `rotate` (degrees), `shadow: { type, color, blur, offset, angle }`, `flipH`, `flipV`, `hyperlink: { url }`.
+
+### Slide Background
+
+```js
+// Solid color background
+slide.background = { color: "1A1A2E" };
+
+// Gradient background (not supported — use a full-slide shape instead)
+slide.addShape("rect", { x: 0, y: 0, w: W, h: H, fill: { color: "1A1A2E" } });
+```
 
 ### PptxGenJS Anti-Patterns (cause bugs)
 

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -431,3 +431,161 @@ button:hover .chat-collapsible-hover-chevron,
 .aui-md-pre:has(.language-choices) {
   display: none;
 }
+
+/* ── VS Code Question Carousel Card (Choices) ── */
+.chat-question-carousel-container {
+  margin: 8px 0;
+  border: 1px solid var(--vscode-chat-requestBorder);
+  border-radius: var(--vscode-cornerRadius-large);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+.chat-question-input-container {
+  display: flex;
+  flex-direction: column;
+  padding: 8px;
+}
+.chat-question-list {
+  display: flex;
+  flex-direction: column;
+  outline: none;
+  padding: 0;
+}
+.chat-question-list-item {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 6px 8px;
+  cursor: pointer;
+  border-radius: var(--vscode-cornerRadius-medium);
+  user-select: none;
+  border: none;
+  background: none;
+  font-family: inherit;
+  text-align: left;
+  color: var(--vscode-foreground);
+  font-size: var(--vscode-chat-font-size-body-s);
+  transition: background-color 0.1s;
+}
+.chat-question-list-item:hover {
+  background-color: var(--vscode-list-hoverBackground);
+}
+.chat-question-list-number {
+  font-size: var(--vscode-chat-font-size-body-s);
+  color: var(--vscode-descriptionForeground);
+  flex-shrink: 0;
+  min-width: 1ch;
+  text-align: right;
+}
+.chat-question-list-label {
+  flex: 1;
+  min-width: 0;
+  word-wrap: break-word;
+  overflow-wrap: break-word;
+  display: flex;
+  flex-direction: column;
+}
+.chat-question-list-label-title {
+  font-weight: 500;
+  line-height: 1.4;
+}
+.chat-question-list-label-desc {
+  font-weight: normal;
+  color: var(--vscode-descriptionForeground);
+  font-size: var(--vscode-chat-font-size-body-xs);
+}
+.chat-question-freeform {
+  margin: 0;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  padding: 4px 8px;
+  gap: 12px;
+}
+.chat-question-freeform-number {
+  font-size: var(--vscode-chat-font-size-body-s);
+  color: var(--vscode-descriptionForeground);
+  flex-shrink: 0;
+  min-width: 1ch;
+  text-align: right;
+}
+.chat-question-freeform-textarea {
+  width: 100%;
+  min-height: 24px;
+  max-height: 200px;
+  padding: 3px 8px;
+  border: 1px solid var(--vscode-input-border, var(--vscode-chat-requestBorder));
+  background-color: var(--vscode-input-background);
+  color: var(--vscode-input-foreground);
+  border-radius: 4px;
+  resize: none;
+  font-family: inherit;
+  font-size: var(--vscode-chat-font-size-body-s);
+  box-sizing: border-box;
+  overflow-y: hidden;
+  align-content: center;
+}
+.chat-question-freeform-textarea:focus {
+  outline: 1px solid var(--vscode-focusBorder);
+  border-color: var(--vscode-focusBorder);
+}
+.chat-question-freeform-textarea::placeholder {
+  color: var(--vscode-input-placeholderForeground);
+}
+
+/* ── User Message Bubbles (VS Code pattern) ── */
+.aui-user-message-root {
+  align-items: flex-end;
+}
+.aui-user-message-bubble {
+  background-color: var(--vscode-chat-requestBubbleBackground);
+  border-radius: var(--vscode-cornerRadius-xLarge);
+  padding: 8px 12px;
+  max-width: 90%;
+  margin-left: auto;
+  width: fit-content;
+  position: relative;
+}
+.aui-user-message-bubble:hover {
+  cursor: pointer;
+  background-color: var(--vscode-chat-requestBubbleHoverBackground);
+}
+
+/* ── Welcome Suggestion Pills (VS Code pattern) ── */
+.chat-welcome-suggested-prompts {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-start;
+  gap: 8px;
+  padding: 8px 0;
+}
+.chat-welcome-suggested-prompts-title {
+  width: 100%;
+  font-size: 12px;
+  color: var(--vscode-descriptionForeground);
+  margin: 0 0 4px 0;
+  text-align: left;
+}
+.chat-welcome-suggested-prompt {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  height: 20px;
+  padding: 0 6px;
+  border-radius: 4px;
+  background-color: var(--vscode-editorWidget-background);
+  cursor: pointer;
+  border: 1px solid var(--vscode-chat-requestBorder, var(--vscode-input-background, transparent));
+  width: fit-content;
+  margin: 0;
+  box-sizing: border-box;
+  flex: 0 0 auto;
+  font-family: inherit;
+  font-size: 12px;
+  color: var(--vscode-editorWidget-foreground, var(--vscode-foreground));
+  transition: background-color 0.1s;
+}
+.chat-welcome-suggested-prompt:hover {
+  background-color: var(--vscode-list-hoverBackground);
+}

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -141,84 +141,286 @@ summary:focus-visible,
   height: 0;
 }
 
-/* ── VS Code Chain-of-Thought Timeline ── */
-/* The assistant message content area is a flex column so the ToolGroup
-   wrapper (order: -1) renders visually above the text part (order: 0),
-   matching VS Code Copilot Chat's layout: tools above → text below.
-   The DOM order stays text-first to prevent React 18 tearing. */
+/* ── VS Code Chain-of-Thought & Tool Progress ──
+   Matches VS Code's .progress-container, .chat-thinking-box,
+   and chatThinkingContent.css patterns exactly. */
+
+/* Position context for tool groups and single tools */
 .aui-assistant-message-content {
   position: relative;
 }
 
-/* Tool group toggle button (visible when 2+ tools are grouped) */
-.aui-tool-group-trigger {
+/* ── Progress Container (each tool line) ── */
+/* Matches VS Code: display: flex; align-items: center; gap: 4px; margin: 0 0 6px 0; */
+.progress-container {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  margin: 0 0 6px 0;
+  font-size: 13px;
+  padding-top: 2px;
   cursor: pointer;
   background: none;
   border: none;
   font-family: inherit;
   color: var(--vscode-foreground);
-  padding-left: 4px;
+  width: 100%;
+  text-align: left;
 }
-.aui-tool-group-trigger:hover {
-  background: var(--vscode-toolbar-hoverBackground);
-  border-radius: var(--vscode-cornerRadius-medium);
-}
-
-/* Tool cards: remove individual borders, add left padding for timeline */
-[data-slot='tool-fallback-root'] {
-  border: none !important;
-  border-radius: 0 !important;
-  position: relative;
-  padding-left: 20px !important;
-  padding-top: 4px !important;
-  padding-bottom: 4px !important;
-  margin-bottom: 0 !important;
+.progress-container.pointer-events-none {
+  cursor: default;
 }
 
-/* Vertical chain-of-thought line on each tool card */
-[data-slot='tool-fallback-root']::before {
-  content: '';
+/* Status icon: 12px, hidden in shimmer mode */
+.progress-status-icon {
+  font-size: 12px;
+  color: var(--vscode-descriptionForeground);
+}
+.progress-status-icon::before {
+  font-size: 12px;
+}
+
+/* Shimmer progress: hide status icon, shimmer on text */
+.shimmer-progress .progress-status-icon {
+  display: none;
+}
+.shimmer-progress .progress-step {
+  background: linear-gradient(
+    90deg,
+    var(--vscode-descriptionForeground) 0%,
+    var(--vscode-descriptionForeground) 30%,
+    var(--vscode-chat-thinkingShimmer) 50%,
+    var(--vscode-descriptionForeground) 70%,
+    var(--vscode-descriptionForeground) 100%
+  );
+  background-size: 400% 100%;
+  background-clip: text;
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  animation: chat-thinking-shimmer 2s linear infinite;
+}
+
+/* Progress step text */
+.progress-step {
+  color: var(--vscode-descriptionForeground);
+  font-size: 0.923em; /* 12px when base is 13px */
+  margin: 0;
+  white-space: normal;
+}
+
+/* Progress summary (inline after tool name) */
+.progress-summary {
+  color: var(--vscode-descriptionForeground);
+  font-size: 0.846em; /* 11px */
+  margin-left: 4px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  min-width: 0;
+  flex: 1;
+}
+
+/* ── Hover Chevron (VS Code pattern: visible only on hover) ── */
+.chat-collapsible-hover-chevron {
+  font-size: 12px;
+  color: var(--vscode-descriptionForeground);
+  opacity: 0;
+  transition: opacity 0.1s ease-in-out;
+  margin-left: auto;
+  flex-shrink: 0;
+}
+.chat-collapsible-hover-chevron.codicon-chevron-down {
+  opacity: 1;
+}
+button:hover .chat-collapsible-hover-chevron,
+.progress-container:hover .chat-collapsible-hover-chevron {
+  opacity: 1;
+}
+
+/* ── Tool-Type Icons (on chain-of-thought line) ── */
+.chat-thinking-icon {
   position: absolute;
   left: 5px;
+  top: 9px;
+  width: 12px;
+  height: 12px;
+  font-size: 12px;
+  line-height: 12px;
+  text-align: center;
+  color: var(--vscode-descriptionForeground);
+  z-index: 1;
+}
+
+/* ── "Working" Collapsible Box ── */
+/* Matches VS Code's ChatThinkingContentPart / chat-thinking-box */
+.chat-thinking-box {
+  margin-bottom: 6px;
+}
+
+/* Header button */
+.chat-thinking-header {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  width: 100%;
+  padding: 4px 6px;
+  cursor: pointer;
+  background: none;
+  border: none;
+  font-family: inherit;
+  font-size: 0.923em; /* 12px */
+  line-height: 1.5em;
+  color: var(--vscode-descriptionForeground);
+  border-radius: var(--vscode-cornerRadius-medium);
+  text-align: left;
+}
+.chat-thinking-header:hover {
+  background: var(--vscode-toolbar-hoverBackground);
+  color: var(--vscode-foreground);
+}
+
+.chat-thinking-header-icon {
+  font-size: 12px;
+  flex-shrink: 0;
+}
+.chat-thinking-header-icon::before {
+  font-size: 12px;
+}
+
+/* Shimmer on "Working" title */
+.chat-thinking-title-shimmer {
+  background: linear-gradient(
+    90deg,
+    var(--vscode-descriptionForeground) 0%,
+    var(--vscode-descriptionForeground) 30%,
+    var(--vscode-chat-thinkingShimmer) 50%,
+    var(--vscode-descriptionForeground) 70%,
+    var(--vscode-descriptionForeground) 100%
+  );
+  background-size: 400% 100%;
+  background-clip: text;
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  animation: chat-thinking-shimmer 2s linear infinite;
+}
+
+.chat-thinking-title-done {
+  color: var(--vscode-descriptionForeground);
+}
+
+/* Collapsible content area with border */
+.chat-thinking-collapsible {
+  border: 1px solid var(--vscode-chat-requestBorder);
+  border-radius: var(--vscode-cornerRadius-medium);
+  margin-top: 4px;
+  position: relative;
+  overflow: hidden;
+}
+
+/* ── Chain-of-Thought Lines (inside Working box) ── */
+.chat-thinking-collapsible .chat-tool-progress-wrapper {
+  position: relative;
+  padding: 4px 12px 4px 28px;
+}
+.chat-thinking-collapsible .chat-tool-progress-wrapper::before {
+  content: '';
+  position: absolute;
+  left: 10.5px;
+  top: 0;
+  bottom: 0;
+  width: 1px;
+  border-radius: 0;
+  background-color: var(--vscode-chat-requestBorder);
+  mask-image: linear-gradient(to bottom, #000 0 5px, transparent 5px 25px, #000 24px 100%);
+}
+.chat-thinking-collapsible .chat-tool-progress-wrapper:first-child::before {
+  mask-image: linear-gradient(to bottom, transparent 0 25px, #000 25px 100%);
+}
+.chat-thinking-collapsible .chat-tool-progress-wrapper:last-child::before,
+.chat-thinking-collapsible .chat-thinking-spinner-item:last-child::before {
+  mask-image: linear-gradient(to bottom, #000 0 5px, transparent 5px 100%);
+}
+.chat-thinking-collapsible .chat-tool-progress-wrapper:only-child::before {
+  background: none;
+  mask-image: none;
+}
+
+/* Progress container inside Working box: reset margins, adapt to padding */
+.chat-thinking-collapsible .progress-container {
+  margin: 0;
+  padding-top: 0;
+}
+
+/* ── Spinner Item (inside Working box) ── */
+.chat-thinking-spinner-item {
+  position: relative;
+  padding: 6px 12px 6px 28px;
+  font-size: 0.923em;
+}
+.chat-thinking-spinner-item::before {
+  content: '';
+  position: absolute;
+  left: 10.5px;
   top: 0;
   bottom: 0;
   width: 1px;
   background-color: var(--vscode-chat-requestBorder);
+  mask-image: linear-gradient(to bottom, #000 0 5px, transparent 5px 25px, #000 24px 100%);
+}
+.chat-thinking-spinner-label {
+  background: linear-gradient(
+    90deg,
+    var(--vscode-descriptionForeground) 0%,
+    var(--vscode-descriptionForeground) 30%,
+    var(--vscode-chat-thinkingShimmer) 50%,
+    var(--vscode-descriptionForeground) 70%,
+    var(--vscode-descriptionForeground) 100%
+  );
+  background-size: 400% 100%;
+  background-clip: text;
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  animation: chat-thinking-shimmer 2s linear infinite;
+  color: var(--vscode-descriptionForeground);
 }
 
-/* Single tool card: hide vertical line (no chain to connect) */
-[data-slot='tool-fallback-root']:only-child::before {
+/* ── Single Tool (no Working box) ── */
+.chat-tool-single .chat-tool-progress-wrapper {
+  padding-left: 4px;
+}
+.chat-tool-single .chat-thinking-icon {
   display: none;
 }
 
-/* Tool status icon sits on top of the vertical line */
-.aui-tool-fallback-trigger-icon {
-  position: relative;
-  z-index: 1;
-  background: var(--vscode-editor-background);
-}
-
-/* Thinking indicator timeline styling */
-.aui-assistant-thinking-indicator {
-  position: relative;
-  padding-left: 20px !important;
-}
-.aui-assistant-thinking-indicator::before {
-  content: '';
-  position: absolute;
-  left: 5px;
-  top: 50%;
-  bottom: -100%;
-  width: 1px;
-  background-color: var(--vscode-chat-requestBorder);
-}
-
-/* Collapsed tool content: compact styling */
-[data-slot='tool-fallback-content'] > div {
-  border-top: 1px solid var(--vscode-chat-requestBorder);
+/* ── Expanded Tool Details ── */
+.tool-details-expanded {
   margin-top: 4px;
-  padding-top: 4px;
-  margin-left: 0;
+  padding: 6px 0;
+  border-top: 1px solid var(--vscode-chat-requestBorder);
+}
+.tool-details-section {
+  padding: 4px 6px;
+}
+.tool-details-section + .tool-details-section {
+  border-top: 1px dashed var(--vscode-widget-border);
+  margin-top: 4px;
+  padding-top: 8px;
+}
+.tool-details-label {
+  margin-bottom: 4px;
+  font-size: 0.846em;
+  font-weight: 600;
+  color: var(--vscode-descriptionForeground);
+}
+.tool-details-code {
+  white-space: pre-wrap;
+  border-radius: var(--vscode-cornerRadius-medium);
+  padding: 6px 8px;
+  font-family: var(--vscode-monospace-font);
+  font-size: 0.846em;
+  background: var(--vscode-editorWidget-background);
+  margin: 0;
+  overflow-x: auto;
 }
 
 /* Hide the raw code block that follows rendered choice/suggestion cards */

--- a/src/styles/vscode-theme.css
+++ b/src/styles/vscode-theme.css
@@ -54,6 +54,7 @@
   /* ── Chat-specific ── */
   --vscode-chat-requestBorder: #e0e0e0;
   --vscode-chat-requestBubbleBackground: #f4f4f480;
+  --vscode-chat-requestBubbleHoverBackground: #e8e8e880;
   --vscode-interactive-session-foreground: #3b3b3b;
   --vscode-chat-list-background: #ffffff;
   --vscode-chat-avatarBackground: #e5e5e5;
@@ -73,6 +74,7 @@
   --vscode-cornerRadius-small: 2px;
   --vscode-cornerRadius-medium: 4px;
   --vscode-cornerRadius-large: 8px;
+  --vscode-cornerRadius-xLarge: 12px;
 
   /* ── Chat typography (relative to 13px base) ── */
   --vscode-chat-font-size-body-xs: 0.846em;
@@ -136,6 +138,7 @@
   /* ── Chat-specific ── */
   --vscode-chat-requestBorder: #383838;
   --vscode-chat-requestBubbleBackground: #2c2c2c80;
+  --vscode-chat-requestBubbleHoverBackground: #36363680;
   --vscode-interactive-session-foreground: #cccccc;
   --vscode-chat-list-background: #1f1f1f;
   --vscode-chat-avatarBackground: #313131;

--- a/src/tools/powerpoint/index.ts
+++ b/src/tools/powerpoint/index.ts
@@ -423,13 +423,31 @@ PptxGenJS API reference:
         replaceSlideIndex?: number;
       };
 
+      // Read actual slide dimensions from the presentation.
+      // Default to standard 16:9 (13.33" × 7.5") if API unavailable.
+      const PTS_PER_INCH = 72;
+      let W = 13.33;
+      let H = 7.5;
+      try {
+        /* eslint-disable @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-explicit-any */
+        (context.presentation as any).load('slideWidth,slideHeight');
+        await context.sync();
+        const rawW = (context.presentation as any).slideWidth as number | undefined;
+        const rawH = (context.presentation as any).slideHeight as number | undefined;
+        /* eslint-enable @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-explicit-any */
+        if (typeof rawW === 'number' && rawW > 0) W = rawW / PTS_PER_INCH;
+        if (typeof rawH === 'number' && rawH > 0) H = rawH / PTS_PER_INCH;
+      } catch {
+        // slideWidth/slideHeight not available on this Office version — use defaults
+      }
+
       // Build the pptxgenjs slide (pure JS, no Office context needed)
       const pptx = new pptxgen();
       const slide = pptx.addSlide();
 
       /* eslint-disable @typescript-eslint/no-implied-eval, @typescript-eslint/no-unsafe-call */
-      const buildSlide = new Function('slide', code);
-      buildSlide(slide);
+      const buildSlide = new Function('slide', 'W', 'H', code);
+      buildSlide(slide, W, H);
       /* eslint-enable @typescript-eslint/no-implied-eval, @typescript-eslint/no-unsafe-call */
 
       const base64 = (await pptx.write({ outputType: 'base64' })) as string;

--- a/src/tools/powerpoint/index.ts
+++ b/src/tools/powerpoint/index.ts
@@ -441,8 +441,12 @@ PptxGenJS API reference:
         // slideWidth/slideHeight not available on this Office version — use defaults
       }
 
-      // Build the pptxgenjs slide (pure JS, no Office context needed)
+      // Build the pptxgenjs slide matching the target presentation dimensions.
+      // PptxGenJS defaults to 13.33"×7.5" (16:9). If the target is different
+      // (e.g. 10"×7.5" for 4:3), content positioned for 13.33" would overflow.
       const pptx = new pptxgen();
+      pptx.defineLayout({ name: 'CUSTOM', width: W, height: H });
+      pptx.layout = 'CUSTOM';
       const slide = pptx.addSlide();
 
       /* eslint-disable @typescript-eslint/no-implied-eval, @typescript-eslint/no-unsafe-call */

--- a/src/utils/toolIcon.ts
+++ b/src/utils/toolIcon.ts
@@ -1,0 +1,43 @@
+/**
+ * Maps a tool ID to a codicon name for the chain-of-thought line,
+ * matching VS Code's `getToolInvocationIcon()` in chatThinkingContentPart.ts.
+ */
+export function getToolIcon(toolId: string): string {
+  const lower = toolId.toLowerCase();
+
+  if (
+    lower.includes('search') ||
+    lower.includes('grep') ||
+    lower.includes('find') ||
+    lower.includes('list') ||
+    lower.includes('semantic') ||
+    lower.includes('changes') ||
+    lower.includes('codebase')
+  ) {
+    return 'search';
+  }
+
+  if (lower.includes('read') || lower.includes('get_file') || lower.includes('problems')) {
+    return 'book';
+  }
+
+  if (
+    lower.includes('edit') ||
+    lower.includes('create') ||
+    lower.includes('replace') ||
+    lower.includes('update') ||
+    lower.includes('set') ||
+    lower.includes('insert') ||
+    lower.includes('delete') ||
+    lower.includes('add') ||
+    lower.includes('remove')
+  ) {
+    return 'pencil';
+  }
+
+  if (lower.includes('terminal') || lower.includes('run')) {
+    return 'terminal';
+  }
+
+  return 'tools';
+}

--- a/tests-e2e-ppt/src/test-taskpane.ts
+++ b/tests-e2e-ppt/src/test-taskpane.ts
@@ -361,6 +361,17 @@ async function testPptTools(): Promise<void> {
       : `Expected add_slide_from_code with W/H to succeed, got: ${s.substring(0, 200)}`;
   });
 
+  // 10c. Overflow detection — verify get_slide_shapes can detect overflow
+  // Checks slide 0 (always exists). The tool reports "⚠️ OVERFLOW" for any out-of-bounds shape.
+  // If 10b's W/H injection was wrong, shapes would overflow and this would catch it.
+  await runTool(powerPointConfigs, 'get_slide_shapes', { slideIndex: 0 }, r => {
+    const s = safeString(r);
+    if (s.includes('OVERFLOW')) {
+      return `Slide 0 has overflowing shapes: ${s.substring(0, 300)}`;
+    }
+    return null;
+  });
+
   // 11. duplicate_slide
   await runTool(powerPointConfigs, 'duplicate_slide', { sourceIndex: 0 }, r => {
     const s = safeString(r);

--- a/tests-e2e-ppt/src/test-taskpane.ts
+++ b/tests-e2e-ppt/src/test-taskpane.ts
@@ -333,7 +333,7 @@ async function testPptTools(): Promise<void> {
     }
   );
 
-  // 10. add_slide_from_code
+  // 10. add_slide_from_code (hardcoded positions)
   const simpleSlideCode = [
     'slide.addText("E2E Test Slide", { x: 1, y: 1, w: 8, h: 1.5, fontSize: 36, bold: true });',
     'slide.addText("Created by e2e automated tests", { x: 1, y: 3, w: 8, h: 1, fontSize: 18 });',
@@ -344,6 +344,21 @@ async function testPptTools(): Promise<void> {
     return s.toLowerCase().includes('success') || s.includes('slide')
       ? null
       : `Expected success message from add_slide_from_code, got: ${s.substring(0, 100)}`;
+  });
+
+  // 10b. add_slide_from_code with W and H (tests that slide dimensions are injected)
+  const dynamicSlideCode = [
+    'if (typeof W !== "number" || W <= 0) throw new Error("W not injected or invalid: " + W);',
+    'if (typeof H !== "number" || H <= 0) throw new Error("H not injected or invalid: " + H);',
+    'slide.addText("Dynamic Layout Test", { x: 0.5, y: 0.5, w: W-1, h: 1, fontSize: 28, bold: true, shrinkText: true });',
+    'slide.addText("W=" + W.toFixed(2) + " H=" + H.toFixed(2), { x: 0.5, y: 2, w: W-1, h: H-3, fontSize: 16, shrinkText: true });',
+  ].join('\n');
+
+  await runTool(powerPointConfigs, 'add_slide_from_code', { code: dynamicSlideCode }, r => {
+    const s = safeString(r);
+    return s.toLowerCase().includes('success') || s.includes('slide')
+      ? null
+      : `Expected add_slide_from_code with W/H to succeed, got: ${s.substring(0, 200)}`;
   });
 
   // 11. duplicate_slide

--- a/tests-ui/chat/chat-thinking-indicator.spec.ts
+++ b/tests-ui/chat/chat-thinking-indicator.spec.ts
@@ -22,11 +22,11 @@ test.describe('Thinking indicator (live Copilot)', () => {
     await expect(page.getByText('Connection failed')).not.toBeVisible();
 
     // Capture all thinking indicator text values via MutationObserver
-    // Now the indicator is .progress-container.shimmer-progress inside the assistant message
+    // Now the indicator is .inline-working-progress inside the assistant message
     await page.evaluate(() => {
       (window as unknown as Record<string, string[]>).__thinkingTexts = [];
       const observer = new MutationObserver(() => {
-        const el = document.querySelector('.progress-container.shimmer-progress .progress-step');
+        const el = document.querySelector('.inline-working-progress .progress-step');
         if (el?.textContent) {
           const texts = (window as unknown as Record<string, string[]>).__thinkingTexts;
           const last = texts[texts.length - 1];
@@ -110,7 +110,7 @@ test.describe('Thinking indicator (live Copilot)', () => {
     await composer.press('Enter');
 
     // Wait for the shimmer progress indicator to appear inside the assistant message
-    const indicator = page.locator('.progress-container.shimmer-progress');
+    const indicator = page.locator('.inline-working-progress');
     await expect(indicator).toBeVisible({ timeout: AI_TIMEOUT });
 
     // The indicator must NOT be a descendant of the viewport footer
@@ -131,7 +131,7 @@ test.describe('Thinking indicator (live Copilot)', () => {
 
     // Geometric guard: indicator must render above the composer area
     const isAboveComposer = await page.evaluate(() => {
-      const indicatorEl = document.querySelector('.progress-container.shimmer-progress');
+      const indicatorEl = document.querySelector('.inline-working-progress');
       const composerEl = document.querySelector('.aui-composer-root');
       if (!indicatorEl || !composerEl) return false;
       const indicatorRect = indicatorEl.getBoundingClientRect();
@@ -143,7 +143,7 @@ test.describe('Thinking indicator (live Copilot)', () => {
     // The indicator must appear BELOW the last user message in DOM order
     const isAfterMessages = await page.evaluate(() => {
       const messages = document.querySelector('[data-role="user"]');
-      const ind = document.querySelector('.progress-container.shimmer-progress');
+      const ind = document.querySelector('.inline-working-progress');
       if (!messages || !ind) return false;
       return !!(messages.compareDocumentPosition(ind) & Node.DOCUMENT_POSITION_FOLLOWING);
     });

--- a/tests-ui/chat/chat-thinking-indicator.spec.ts
+++ b/tests-ui/chat/chat-thinking-indicator.spec.ts
@@ -18,17 +18,15 @@ test.describe('Thinking indicator (live Copilot)', () => {
     const composer = page.getByPlaceholder('Send a message...');
     await expect(composer).toBeVisible({ timeout: 5000 });
 
-    // Wait for the WebSocket session to be established before sending.
-    // The app shows "Connecting to Copilot..." during handshake; we wait for
-    // it to disappear so that sessionRef.current is populated.
     await expect(page.getByText('Connecting to Copilot...')).not.toBeVisible({ timeout: 15_000 });
     await expect(page.getByText('Connection failed')).not.toBeVisible();
 
     // Capture all thinking indicator text values via MutationObserver
+    // Now the indicator is .progress-container.shimmer-progress inside the assistant message
     await page.evaluate(() => {
       (window as unknown as Record<string, string[]>).__thinkingTexts = [];
       const observer = new MutationObserver(() => {
-        const el = document.querySelector('.aui-assistant-thinking-indicator span');
+        const el = document.querySelector('.progress-container.shimmer-progress .progress-step');
         if (el?.textContent) {
           const texts = (window as unknown as Record<string, string[]>).__thinkingTexts;
           const last = texts[texts.length - 1];
@@ -96,7 +94,7 @@ test.describe('Thinking indicator (live Copilot)', () => {
     }
   });
 
-  test('thinking indicator renders inline in message stream, not inside the sticky footer', async ({
+  test('thinking indicator renders inline in assistant message, not inside the sticky footer', async ({
     configuredTaskpane: page,
   }) => {
     test.setTimeout(AI_TIMEOUT + 30_000);
@@ -111,8 +109,8 @@ test.describe('Thinking indicator (live Copilot)', () => {
     );
     await composer.press('Enter');
 
-    // Wait for the thinking indicator to appear
-    const indicator = page.locator('.aui-assistant-thinking-indicator');
+    // Wait for the shimmer progress indicator to appear inside the assistant message
+    const indicator = page.locator('.progress-container.shimmer-progress');
     await expect(indicator).toBeVisible({ timeout: AI_TIMEOUT });
 
     // The indicator must NOT be a descendant of the viewport footer
@@ -133,7 +131,7 @@ test.describe('Thinking indicator (live Copilot)', () => {
 
     // Geometric guard: indicator must render above the composer area
     const isAboveComposer = await page.evaluate(() => {
-      const indicatorEl = document.querySelector('.aui-assistant-thinking-indicator');
+      const indicatorEl = document.querySelector('.progress-container.shimmer-progress');
       const composerEl = document.querySelector('.aui-composer-root');
       if (!indicatorEl || !composerEl) return false;
       const indicatorRect = indicatorEl.getBoundingClientRect();
@@ -142,10 +140,10 @@ test.describe('Thinking indicator (live Copilot)', () => {
     });
     expect(isAboveComposer).toBe(true);
 
-    // The indicator must appear BELOW the last message in DOM order
+    // The indicator must appear BELOW the last user message in DOM order
     const isAfterMessages = await page.evaluate(() => {
       const messages = document.querySelector('[data-role="user"]');
-      const ind = document.querySelector('.aui-assistant-thinking-indicator');
+      const ind = document.querySelector('.progress-container.shimmer-progress');
       if (!messages || !ind) return false;
       return !!(messages.compareDocumentPosition(ind) & Node.DOCUMENT_POSITION_FOLLOWING);
     });
@@ -156,7 +154,7 @@ test.describe('Thinking indicator (live Copilot)', () => {
       timeout: AI_TIMEOUT,
     });
 
-    // After completion, indicator must be gone
+    // After completion, shimmer indicator must be gone
     await expect(indicator).not.toBeVisible();
   });
 });

--- a/tests-ui/chat/chat-tool-card.spec.ts
+++ b/tests-ui/chat/chat-tool-card.spec.ts
@@ -69,8 +69,8 @@ test.describe('Tool card UX (live Copilot)', () => {
     const card = await waitForCompletedToolCard(page);
     const trigger = card.locator('[data-slot="tool-fallback-trigger"]');
 
-    // A non-empty summary span should appear between the name and the chevron
-    const summary = trigger.locator('span.text-muted-foreground');
+    // A non-empty summary span should appear (VS Code progress-summary class)
+    const summary = trigger.locator('.progress-summary');
     await expect(summary).toBeVisible({ timeout: 5_000 });
     const text = await summary.textContent();
     expect(text?.trim().length).toBeGreaterThan(0);
@@ -83,16 +83,14 @@ test.describe('Tool card UX (live Copilot)', () => {
 
     const card = await waitForCompletedToolCard(page);
 
-    // Open the card
+    // Open the card by clicking the progress line
     await card.locator('[data-slot="tool-fallback-trigger"]').click();
 
-    const args = card.locator('[data-slot="tool-fallback-args"]');
-    await expect(args).toBeVisible({ timeout: 3_000 });
+    const details = card.locator('.tool-details-expanded');
+    await expect(details).toBeVisible({ timeout: 3_000 });
 
     // Must have "Input" as section header
-    await expect(args).toContainText('Input');
-    // Must NOT use old "Result:" naming
-    await expect(args).not.toContainText('Result:');
+    await expect(details).toContainText('Input');
   });
 
   test('expanded card shows "Output" header (not "Result:" old label)', async ({
@@ -105,13 +103,13 @@ test.describe('Tool card UX (live Copilot)', () => {
     // Open the card
     await card.locator('[data-slot="tool-fallback-trigger"]').click();
 
-    const result = card.locator('[data-slot="tool-fallback-result"]');
-    await expect(result).toBeVisible({ timeout: 3_000 });
+    const details = card.locator('.tool-details-expanded');
+    await expect(details).toBeVisible({ timeout: 3_000 });
 
     // Must use the new "Output" header
-    await expect(result).toContainText('Output');
+    await expect(details).toContainText('Output');
     // Must NOT use old "Result:" naming
-    await expect(result).not.toContainText('Result:');
+    await expect(details).not.toContainText('Result:');
   });
 
   test('report_intent does not produce a tool card in the thread', async ({

--- a/tests/integration/thread-message-rendering.test.tsx
+++ b/tests/integration/thread-message-rendering.test.tsx
@@ -295,13 +295,13 @@ describe('Thread – AssistantMessage rendering', () => {
       await new Promise(r => setTimeout(r, 200));
     });
 
-    // After the stream completes, the thinking indicator should be gone
+    // After the stream completes, the shimmer thinking progress should be gone
     await waitFor(() => {
-      expect(document.querySelector('.aui-assistant-thinking-indicator')).not.toBeInTheDocument();
+      expect(document.querySelector('.progress-container.shimmer-progress')).not.toBeInTheDocument();
     });
   });
 
-  it('thinking indicator is rendered at the thread level, not inside individual messages', async () => {
+  it('thinking indicator is rendered inside the assistant message, not at thread level', async () => {
     const session = makeFakeSession([
       makeEvent('assistant.message', { messageId: 'msg1', content: 'Done' }),
       IDLE_EVENT,
@@ -323,9 +323,11 @@ describe('Thread – AssistantMessage rendering', () => {
       expect(document.querySelector('[data-role="assistant"]')).toBeInTheDocument();
     });
 
-    // The thinking indicator should NOT be inside any assistant message
+    // The thinking indicator is now rendered INSIDE the assistant message (as InlineWorkingProgress)
+    // After completion, it should not be visible
     const assistantMsg = document.querySelector('[data-role="assistant"]');
-    const indicatorInsideMsg = assistantMsg?.querySelector('.aui-assistant-thinking-indicator');
+    const indicatorInsideMsg = assistantMsg?.querySelector('.progress-container.shimmer-progress');
+    // After completion (text arrived), the shimmer progress should be gone
     expect(indicatorInsideMsg).toBeNull();
   });
 
@@ -508,8 +510,8 @@ describe('Thread – AssistantMessage rendering', () => {
       await new Promise(r => setTimeout(r, 150));
     });
 
-    // The thinking indicator should show "Thinking…" (not the tool name)
-    const indicator = document.querySelector('.aui-assistant-thinking-indicator');
+    // The thinking indicator should show "Thinking…" inside the assistant message
+    const indicator = document.querySelector('.progress-container.shimmer-progress');
     expect(indicator).toBeInTheDocument();
     expect(indicator!.textContent).toContain('Thinking…');
 
@@ -520,7 +522,7 @@ describe('Thread – AssistantMessage rendering', () => {
     });
 
     // Indicator should be gone after completion
-    expect(document.querySelector('.aui-assistant-thinking-indicator')).not.toBeInTheDocument();
+    expect(document.querySelector('.progress-container.shimmer-progress')).not.toBeInTheDocument();
   });
 
   it('thinking indicator shows report_intent text in the rendered DOM', async () => {
@@ -565,8 +567,8 @@ describe('Thread – AssistantMessage rendering', () => {
       await new Promise(r => setTimeout(r, 150));
     });
 
-    // The thinking indicator should show the intent text, not "Thinking…"
-    const indicator = document.querySelector('.aui-assistant-thinking-indicator');
+    // The thinking indicator should show the intent text inside the assistant message
+    const indicator = document.querySelector('.progress-container.shimmer-progress');
     expect(indicator).toBeInTheDocument();
     expect(indicator!.textContent).toContain('Analyzing your data');
 
@@ -575,7 +577,7 @@ describe('Thread – AssistantMessage rendering', () => {
       await new Promise(r => setTimeout(r, 200));
     });
 
-    expect(document.querySelector('.aui-assistant-thinking-indicator')).not.toBeInTheDocument();
+    expect(document.querySelector('.progress-container.shimmer-progress')).not.toBeInTheDocument();
   });
 });
 
@@ -622,12 +624,12 @@ describe('Tool-call visual ordering (VS Code layout: tools above text)', () => {
       expect(screen.getByText('Got it.')).toBeInTheDocument();
     });
 
-    // Tool card must be inside a .aui-tool-group wrapper
-    const toolGroup = document.querySelector('.aui-tool-group');
+    // Tool card must be inside a .chat-tool-single wrapper (single tool, no Working box)
+    const toolGroup = document.querySelector('.chat-tool-single');
     expect(toolGroup).toBeInTheDocument();
     expect(toolGroup!.querySelector('[data-slot="tool-fallback-root"]')).toBeInTheDocument();
 
-    // The ToolGroup wrapper must have order: -1 for CSS visual reordering
+    // The wrapper must have order: -1 for CSS visual reordering
     expect((toolGroup as HTMLElement).style.order).toBe('-1');
   });
 
@@ -690,14 +692,14 @@ describe('Tool-call visual ordering (VS Code layout: tools above text)', () => {
       expect(screen.getByText('Updated B1.')).toBeInTheDocument();
     });
 
-    // Verify both text and ToolGroup exist inside message content
+    // Verify both text and tool wrapper exist inside message content
     const content = document.querySelector('.aui-assistant-message-content');
-    const toolGroup = content!.querySelector('.aui-tool-group');
+    const toolGroup = content!.querySelector('.chat-tool-single');
     const toolCard = toolGroup!.querySelector('[data-slot="tool-fallback-root"]');
     expect(toolGroup).toBeInTheDocument();
     expect(toolCard).toBeInTheDocument();
 
-    // ToolGroup has order: -1 → visually above text (order: 0 default)
+    // Tool wrapper has order: -1 → visually above text (order: 0 default)
     expect((toolGroup as HTMLElement).style.order).toBe('-1');
   });
 
@@ -743,7 +745,7 @@ describe('Tool-call visual ordering (VS Code layout: tools above text)', () => {
       expect(screen.getByText('Both done.')).toBeInTheDocument();
     });
 
-    const toolGroups = document.querySelectorAll('.aui-tool-group');
+    const toolGroups = document.querySelectorAll('.chat-thinking-box');
     expect(toolGroups).toHaveLength(1);
 
     const toolCards = toolGroups[0]!.querySelectorAll('[data-slot="tool-fallback-root"]');
@@ -1000,7 +1002,7 @@ describe('Tool-call visual ordering (VS Code layout: tools above text)', () => {
     });
 
     // Tool cards must still be visible after completion
-    const toolGroup = document.querySelector('.aui-tool-group');
+    const toolGroup = document.querySelector('.chat-tool-single');
     expect(toolGroup).toBeInTheDocument();
 
     const toolCard = toolGroup!.querySelector('[data-slot="tool-fallback-root"]');
@@ -1010,8 +1012,8 @@ describe('Tool-call visual ordering (VS Code layout: tools above text)', () => {
     const checkIcon = toolCard!.querySelector('.codicon-check');
     expect(checkIcon).toBeInTheDocument();
 
-    // Thinking indicator must be gone
-    expect(document.querySelector('.aui-assistant-thinking-indicator')).not.toBeInTheDocument();
+    // Thinking indicator must be gone (no longer has old class — inline working progress hides when complete)
+    expect(document.querySelector('.progress-container.shimmer-progress')).not.toBeInTheDocument();
   });
 });
 

--- a/tests/integration/thread-message-rendering.test.tsx
+++ b/tests/integration/thread-message-rendering.test.tsx
@@ -297,7 +297,7 @@ describe('Thread – AssistantMessage rendering', () => {
 
     // After the stream completes, the shimmer thinking progress should be gone
     await waitFor(() => {
-      expect(document.querySelector('.progress-container.shimmer-progress')).not.toBeInTheDocument();
+      expect(document.querySelector('.inline-working-progress')).not.toBeInTheDocument();
     });
   });
 
@@ -326,7 +326,7 @@ describe('Thread – AssistantMessage rendering', () => {
     // The thinking indicator is now rendered INSIDE the assistant message (as InlineWorkingProgress)
     // After completion, it should not be visible
     const assistantMsg = document.querySelector('[data-role="assistant"]');
-    const indicatorInsideMsg = assistantMsg?.querySelector('.progress-container.shimmer-progress');
+    const indicatorInsideMsg = assistantMsg?.querySelector('.inline-working-progress');
     // After completion (text arrived), the shimmer progress should be gone
     expect(indicatorInsideMsg).toBeNull();
   });
@@ -510,10 +510,18 @@ describe('Thread – AssistantMessage rendering', () => {
       await new Promise(r => setTimeout(r, 150));
     });
 
-    // The thinking indicator should show "Thinking…" inside the assistant message
-    const indicator = document.querySelector('.progress-container.shimmer-progress');
-    expect(indicator).toBeInTheDocument();
-    expect(indicator!.textContent).toContain('Thinking…');
+    // The shimmer progress hides once a tool card appears (VS Code behavior)
+    // Tool cards handle their own shimmer on the tool name while running
+    const indicator = document.querySelector('.inline-working-progress');
+    const toolCard = document.querySelector('[data-slot="tool-fallback-root"]');
+
+    // Either: shimmer is gone (tool card appeared) or shimmer is visible (tool hasn't rendered yet)
+    // Once the tool card is in the DOM, shimmer must be gone
+    if (toolCard) {
+      expect(indicator).not.toBeInTheDocument();
+    }
+    // At minimum, a tool card should exist since tool.execution_start was emitted
+    expect(toolCard).toBeInTheDocument();
 
     // Release and finish
     await act(async () => {
@@ -522,7 +530,7 @@ describe('Thread – AssistantMessage rendering', () => {
     });
 
     // Indicator should be gone after completion
-    expect(document.querySelector('.progress-container.shimmer-progress')).not.toBeInTheDocument();
+    expect(document.querySelector('.inline-working-progress')).not.toBeInTheDocument();
   });
 
   it('thinking indicator shows report_intent text in the rendered DOM', async () => {
@@ -568,7 +576,7 @@ describe('Thread – AssistantMessage rendering', () => {
     });
 
     // The thinking indicator should show the intent text inside the assistant message
-    const indicator = document.querySelector('.progress-container.shimmer-progress');
+    const indicator = document.querySelector('.inline-working-progress');
     expect(indicator).toBeInTheDocument();
     expect(indicator!.textContent).toContain('Analyzing your data');
 
@@ -577,7 +585,7 @@ describe('Thread – AssistantMessage rendering', () => {
       await new Promise(r => setTimeout(r, 200));
     });
 
-    expect(document.querySelector('.progress-container.shimmer-progress')).not.toBeInTheDocument();
+    expect(document.querySelector('.inline-working-progress')).not.toBeInTheDocument();
   });
 });
 
@@ -1013,7 +1021,7 @@ describe('Tool-call visual ordering (VS Code layout: tools above text)', () => {
     expect(checkIcon).toBeInTheDocument();
 
     // Thinking indicator must be gone (no longer has old class — inline working progress hides when complete)
-    expect(document.querySelector('.progress-container.shimmer-progress')).not.toBeInTheDocument();
+    expect(document.querySelector('.inline-working-progress')).not.toBeInTheDocument();
   });
 });
 

--- a/tests/integration/thread-message-rendering.test.tsx
+++ b/tests/integration/thread-message-rendering.test.tsx
@@ -1058,9 +1058,9 @@ describe('ChoiceCards', () => {
     expect(screen.getByText('Excel')).toBeInTheDocument();
     expect(screen.getByText('PDF')).toBeInTheDocument();
 
-    // Number badges 1, 2, 3 are present
+    // Number badges 1, 2, 3 are present (now using VS Code carousel class names)
     const wrapper = document.querySelector('.aui-choices-wrapper')!;
-    const badges = wrapper.querySelectorAll('span.text-right');
+    const badges = wrapper.querySelectorAll('.chat-question-list-number');
     expect(badges[0]?.textContent?.trim()).toBe('1');
     expect(badges[1]?.textContent?.trim()).toBe('2');
     expect(badges[2]?.textContent?.trim()).toBe('3');
@@ -1071,8 +1071,8 @@ describe('ChoiceCards', () => {
     expect(textarea?.placeholder).toBe('Enter custom answer');
 
     // Freeform row is numbered n+1 (4)
-    const allBadges = wrapper.querySelectorAll('span.text-right');
-    expect(allBadges[3]?.textContent?.trim()).toBe('4');
+    const freeformNumber = wrapper.querySelector('.chat-question-freeform-number');
+    expect(freeformNumber?.textContent?.trim()).toBe('4');
   });
 
   it('clicking a choice appends the label as a user message', async () => {


### PR DESCRIPTION
## Changes

### VS Code Copilot Chat UI matching
- Tool cards → flat progress lines with shimmer
- Working collapsible box with chain-of-thought line
- Thinking indicator inside assistant message
- Choices → VS Code question carousel card
- User messages → right-aligned chat bubbles
- Welcome suggestions → pill chips
- Hide Copilot avatar for default agent
- Fix inter-step thinking gap

### Stop button + Steer
- Stop immediately cancels (destroys session)
- Send always visible — redirect mid-response

### PowerPoint fixes
- Inject W/H into add_slide_from_code
- Set PptxGenJS layout to match presentation
- Full PptxGenJS API reference (charts, images, tables, shapes)

### Tests: 755 integration, 42 Playwright, 15 PPT E2E — all green