### PR TITLE
fix: robust plan extraction from planner text output

### DIFF
--- a/src/services/ai/prompts/PLANNER_PROMPT.md
+++ b/src/services/ai/prompts/PLANNER_PROMPT.md
@@ -26,5 +26,20 @@ Given the user's request, create a detailed plan for each slide. Consider:
 
 1. Analyze the user's request
 2. Plan each slide with: title, layout type, and content description
-3. Call the `submit_plan` tool with your plan
+3. **You MUST call the `submit_plan` tool** with your complete plan — this is the ONLY way to submit it
 4. Keep content descriptions concise but specific enough for a slide creator to execute
+5. Do NOT output the plan as text or JSON in your response — always use the `submit_plan` tool
+
+## Example
+
+For a request like "Create a 3-slide overview of cloud computing", you would call `submit_plan` with:
+
+```
+submit_plan({
+  "slides": [
+    { "index": 0, "title": "Cloud Computing", "layout": "title-dark", "content": "Title slide with subtitle: An Overview of Modern Cloud Infrastructure" },
+    { "index": 1, "title": "Key Benefits", "layout": "three-column-cards", "content": "Three cards: 1) Scalability — scale up/down on demand 2) Cost Efficiency — pay only for what you use 3) Reliability — built-in redundancy and failover" },
+    { "index": 2, "title": "Getting Started", "layout": "bullet-list", "content": "Steps: Choose a provider (AWS/Azure/GCP), Start with managed services, Migrate incrementally, Monitor and optimize costs" }
+  ]
+})
+```

--- a/src/tools/planner/index.ts
+++ b/src/tools/planner/index.ts
@@ -94,26 +94,156 @@ export function extractPlanFromEvents(
 }
 
 /**
- * Last-resort: parse a JSON slide plan from the planner's text output.
- * The model sometimes outputs the plan as a JSON code block instead of calling the tool.
+ * Try to coerce a parsed JSON value into a DeckPlan.
+ * Accepts `{ slides: [...] }` or a bare array of slide objects.
+ */
+function coerceToPlan(value: unknown): DeckPlan | null {
+  if (value && typeof value === 'object') {
+    // { slides: [...] }
+    const obj = value as Record<string, unknown>;
+    if (Array.isArray(obj.slides) && obj.slides.length > 0) {
+      return obj as unknown as DeckPlan;
+    }
+    // { plan: { slides: [...] } }
+    if (obj.plan && typeof obj.plan === 'object') {
+      const inner = obj.plan as Record<string, unknown>;
+      if (Array.isArray(inner.slides) && inner.slides.length > 0) {
+        return inner as unknown as DeckPlan;
+      }
+    }
+  }
+  // Bare array of slide objects
+  if (Array.isArray(value) && value.length > 0) {
+    const first = value[0] as Record<string, unknown>;
+    if (typeof first.title === 'string' && typeof first.layout === 'string') {
+      const slides = (value as Record<string, unknown>[]).map((s, i) => ({
+        index: typeof s.index === 'number' ? s.index : i,
+        title: typeof s.title === 'string' ? s.title : '',
+        layout: typeof s.layout === 'string' ? s.layout : '',
+        content: typeof s.content === 'string' ? s.content : '',
+      }));
+      return { slides };
+    }
+  }
+  return null;
+}
+
+/**
+ * Extract the outermost JSON value (object or array) from a string.
+ * Uses bracket counting instead of lazy regex to correctly handle nested braces.
+ */
+function extractOutermostJson(text: string): string | null {
+  const startIdx = text.search(/[{[]/);
+  if (startIdx === -1) return null;
+
+  const openChar = text[startIdx];
+  const closeChar = openChar === '{' ? '}' : ']';
+  let depth = 0;
+  let inString = false;
+  let escape = false;
+
+  for (let i = startIdx; i < text.length; i++) {
+    const ch = text[i];
+    if (escape) {
+      escape = false;
+      continue;
+    }
+    if (ch === '\\' && inString) {
+      escape = true;
+      continue;
+    }
+    if (ch === '"') {
+      inString = !inString;
+      continue;
+    }
+    if (inString) continue;
+    if (ch === openChar) depth++;
+    if (ch === closeChar) depth--;
+    if (depth === 0) {
+      return text.slice(startIdx, i + 1);
+    }
+  }
+  return null;
+}
+
+/**
+ * Parse a structured markdown plan into a DeckPlan.
+ * Handles numbered lists like:
+ *   1. **Title** — Layout: title-dark. Content description...
+ *   ### Slide 1: Title\n- Layout: title-dark\n- Content: ...
+ */
+function parseMarkdownPlan(text: string): DeckPlan | null {
+  const slides: SlidePlan[] = [];
+
+  // Pattern 1: "### Slide N: Title" blocks with "- Layout:" and "- Content:" lines
+  const blockPattern =
+    /###\s*Slide\s+(\d+)[:\s]*([^\n]+)\n(?:[\s\S]*?-\s*\*{0,2}Layout\*{0,2}[:\s]+([^\n]+)\n)?(?:[\s\S]*?-\s*\*{0,2}Content\*{0,2}[:\s]+([^\n]+))?/gi;
+  let match: RegExpExecArray | null;
+  while ((match = blockPattern.exec(text)) !== null) {
+    slides.push({
+      index: slides.length,
+      title: match[2].trim().replace(/\*{1,2}/g, ''),
+      layout: (match[3] ?? 'bullet-list').trim().replace(/\*{1,2}/g, ''),
+      content: (match[4] ?? match[2]).trim().replace(/\*{1,2}/g, ''),
+    });
+  }
+  if (slides.length > 0) return { slides };
+
+  // Pattern 2: Numbered list "N. **Title** — Layout: X. Content..."
+  const linePattern =
+    /^\s*\d+\.\s*\*{0,2}([^*\n]+?)\*{0,2}\s*[—–-]\s*(?:Layout:\s*(\S+))?[.,]?\s*(.*)/gm;
+  while ((match = linePattern.exec(text)) !== null) {
+    slides.push({
+      index: slides.length,
+      title: match[1].trim(),
+      layout: (match[2] ?? 'bullet-list').trim(),
+      content: (match[3] ?? match[1]).trim(),
+    });
+  }
+  if (slides.length >= 2) return { slides };
+
+  return null;
+}
+
+/**
+ * Last-resort: parse a slide plan from the planner's text output.
+ * The model sometimes outputs the plan as text instead of calling the tool.
+ *
+ * Tries in order:
+ * 1. JSON object/array in a code block (```json ... ```)
+ * 2. Raw JSON object/array in the text
+ * 3. Structured markdown (### Slide N or numbered lists)
  */
 export function parsePlanFromText(text: string): DeckPlan | null {
-  // Try to find JSON in a code block first
-  const codeBlockMatch = /```(?:json)?\s*(\{[\s\S]*?\})\s*```/.exec(text);
-  const candidates = codeBlockMatch ? [codeBlockMatch[1]] : [];
+  const candidates: string[] = [];
 
-  // Also try the entire text as JSON (model may output raw JSON)
+  // 1. Extract JSON from fenced code blocks (all occurrences)
+  const codeBlockRegex = /```(?:json)?\s*([\s\S]*?)```/g;
+  let cbMatch: RegExpExecArray | null;
+  while ((cbMatch = codeBlockRegex.exec(text)) !== null) {
+    const inner = cbMatch[1].trim();
+    if (inner.startsWith('{') || inner.startsWith('[')) {
+      candidates.push(inner);
+    }
+  }
+
+  // 2. Try extracting outermost JSON from the full text
+  const outerJson = extractOutermostJson(text);
+  if (outerJson) candidates.push(outerJson);
+
+  // 3. Try the entire text as-is
   candidates.push(text.trim());
 
   for (const candidate of candidates) {
     try {
-      const parsed = JSON.parse(candidate) as Record<string, unknown>;
-      if (Array.isArray(parsed.slides) && parsed.slides.length > 0) {
-        return parsed as unknown as DeckPlan;
-      }
+      const parsed: unknown = JSON.parse(candidate);
+      const plan = coerceToPlan(parsed);
+      if (plan) return plan;
     } catch {
       // Not valid JSON — continue
     }
   }
-  return null;
+
+  // 4. Try structured markdown parsing
+  return parseMarkdownPlan(text);
 }


### PR DESCRIPTION
## Problem
The deck orchestrator failed with **'Planner did not produce a valid slide plan'** when the LLM output its plan as text instead of calling \submit_plan\.

## Root Cause
All 3 plan extraction methods failed when the model didn't call the tool:
1. \getLastPlan()\ — tool handler never ran
2. \xtractPlanFromEvents()\ — no \	ool.execution_start\ event
3. \parsePlanFromText()\ — lazy regex mis-matched nested JSON; only handled \{slides:[…]}\

## Fix
- **\parsePlanFromText\**: bracket-counting JSON extractor (replaces lazy regex); handles bare arrays and \{plan:{slides:…}}\ wrappers; structured markdown parsing as final fallback
- **\coerceToPlan\**: normalizes diverse JSON shapes into \DeckPlan\
- **\PLANNER_PROMPT\**: explicit 'you MUST call submit_plan' + example + 'do NOT output as text' guardrail

## Tests
- 757 integration tests pass
- Typecheck clean