### PR TITLE
fix: use absolute localhost:3000 URL for all API fetch calls

### DIFF
--- a/src/components/McpManagerDialog.tsx
+++ b/src/components/McpManagerDialog.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { Codicon } from '@/components/Codicon';
 import { useSettingsStore } from '@/stores/settingsStore';
 import { useMcpStatusStore } from '@/stores';
+import { getLocalApiBase } from '@/lib/api';
 import type { McpServerConfig, McpServerStatus } from '@/types';
 import { McpLogViewer } from './McpLogViewer';
 
@@ -23,7 +24,7 @@ const STATUS_LABELS: Record<McpServerStatus | 'disabled', string> = {
 
 async function fetchMcpServers(): Promise<McpServerConfig[]> {
   try {
-    const res = await fetch('/api/mcp-servers');
+    const res = await fetch(`${getLocalApiBase()}/api/mcp-servers`);
     if (!res.ok) return [];
     const data = (await res.json()) as { servers: McpServerConfig[] };
     return data.servers ?? [];

--- a/src/components/McpPicker.tsx
+++ b/src/components/McpPicker.tsx
@@ -10,6 +10,7 @@ import * as Popover from '@radix-ui/react-popover';
 import { Codicon } from '@/components/Codicon';
 import { cn } from '@/lib/utils';
 import { useSettingsStore } from '@/stores/settingsStore';
+import { getLocalApiBase } from '@/lib/api';
 import type { McpServerConfig } from '@/types/mcp';
 
 interface McpPickerProps {
@@ -18,7 +19,7 @@ interface McpPickerProps {
 
 async function fetchAllMcpServers(): Promise<McpServerConfig[]> {
   try {
-    const res = await fetch('/api/mcp-servers');
+    const res = await fetch(`${getLocalApiBase()}/api/mcp-servers`);
     if (!res.ok) return [];
     const data = (await res.json()) as { servers: McpServerConfig[] };
     return data.servers ?? [];

--- a/src/components/PermissionManagerDialog.tsx
+++ b/src/components/PermissionManagerDialog.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useMemo, useState } from 'react';
 import { Codicon } from '@/components/Codicon';
 import { usePermissionStore } from '@/stores';
+import { getLocalApiBase } from '@/lib/api';
 
 interface BrowseResponse {
   path: string;
@@ -33,7 +34,7 @@ export const PermissionManagerPanel: React.FC = () => {
     setBrowseLoading(true);
     try {
       const query = pathValue ? `?path=${encodeURIComponent(pathValue)}` : '';
-      const response = await fetch(`/api/browse${query}`);
+      const response = await fetch(`${getLocalApiBase()}/api/browse${query}`);
       const data = (await response.json()) as BrowseResponse;
       if (data.error) return;
       setBrowsePath(data.path);
@@ -54,7 +55,7 @@ export const PermissionManagerPanel: React.FC = () => {
     }
     void (async () => {
       try {
-        const response = await fetch('/api/env');
+        const response = await fetch(`${getLocalApiBase()}/api/env`);
         const data = (await response.json()) as { cwd?: string; home?: string };
         void loadDir(data.cwd ?? data.home);
       } catch {

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,0 +1,16 @@
+/**
+ * Returns the base URL for the local proxy API server.
+ *
+ * The API server always runs on localhost:3000 — even when the taskpane HTML
+ * is served from a remote origin (e.g. GitHub Pages). All fetch('/api/...')
+ * calls must use this base so they reach the local server, not the CDN.
+ */
+export function getLocalApiBase(): string {
+  if (typeof window === 'undefined') return 'https://localhost:3000';
+  const { hostname, protocol, host } = window.location;
+  // Non-localhost origin (GitHub Pages, staging) → always target localhost:3000
+  if (hostname !== 'localhost' && hostname !== '127.0.0.1') {
+    return 'https://localhost:3000';
+  }
+  return `${protocol}//${host}`;
+}

--- a/src/services/plugins/pluginService.ts
+++ b/src/services/plugins/pluginService.ts
@@ -11,8 +11,9 @@ import type {
   PluginComponents,
   PluginActionResult,
 } from '@/types/plugin';
+import { getLocalApiBase } from '@/lib/api';
 
-const API_BASE = '/api/plugins';
+const API_BASE = `${getLocalApiBase()}/api/plugins`;
 
 async function fetchJson<T>(url: string, init?: RequestInit): Promise<T> {
   const res = await fetch(url, init);
@@ -39,16 +40,16 @@ export async function getInstalledPlugins(): Promise<InstalledPlugin[]> {
 
 /** Get all registered marketplaces. */
 export async function getMarketplaces(): Promise<RegisteredMarketplace[]> {
-  const data = await fetchJson<{ marketplaces: RegisteredMarketplace[] }>(`${API_BASE}/marketplaces`);
+  const data = await fetchJson<{ marketplaces: RegisteredMarketplace[] }>(
+    `${API_BASE}/marketplaces`
+  );
   return data.marketplaces;
 }
 
 /** Browse plugins in a marketplace. Returns plugins with install status. */
-export async function browseMarketplace(
-  marketplace: string,
-): Promise<BrowsePlugin[]> {
+export async function browseMarketplace(marketplace: string): Promise<BrowsePlugin[]> {
   const data = await fetchJson<{ marketplace: string; plugins: BrowsePlugin[] }>(
-    `${API_BASE}/browse/${encodeURIComponent(marketplace)}`,
+    `${API_BASE}/browse/${encodeURIComponent(marketplace)}`
   );
   return data.plugins;
 }
@@ -60,59 +61,45 @@ export async function getPluginDetails(name: string): Promise<{
   components: PluginComponents;
 }> {
   // API returns flat {...plugin, manifest, components} — restructure for the UI
-  const data = await fetchJson<InstalledPlugin & { manifest: PluginManifest | null; components: PluginComponents }>(
-    `${API_BASE}/${encodeURIComponent(name)}/details`,
-  );
+  const data = await fetchJson<
+    InstalledPlugin & { manifest: PluginManifest | null; components: PluginComponents }
+  >(`${API_BASE}/${encodeURIComponent(name)}/details`);
   const { manifest, components, ...plugin } = data;
   return { plugin: plugin as InstalledPlugin, manifest, components };
 }
 
 /** Install a plugin from a marketplace, repo, or local path. */
-export async function installPlugin(
-  spec: string,
-): Promise<PluginActionResult> {
+export async function installPlugin(spec: string): Promise<PluginActionResult> {
   return postJson<PluginActionResult>(`${API_BASE}/install`, { spec });
 }
 
 /** Uninstall a plugin. */
-export async function uninstallPlugin(
-  name: string,
-): Promise<PluginActionResult> {
+export async function uninstallPlugin(name: string): Promise<PluginActionResult> {
   return postJson<PluginActionResult>(`${API_BASE}/uninstall`, { name });
 }
 
 /** Enable a disabled plugin. */
-export async function enablePlugin(
-  name: string,
-): Promise<PluginActionResult> {
+export async function enablePlugin(name: string): Promise<PluginActionResult> {
   return postJson<PluginActionResult>(`${API_BASE}/enable`, { name });
 }
 
 /** Disable a plugin without uninstalling it. */
-export async function disablePlugin(
-  name: string,
-): Promise<PluginActionResult> {
+export async function disablePlugin(name: string): Promise<PluginActionResult> {
   return postJson<PluginActionResult>(`${API_BASE}/disable`, { name });
 }
 
 /** Update a plugin to the latest version. */
-export async function updatePlugin(
-  name: string,
-): Promise<PluginActionResult> {
+export async function updatePlugin(name: string): Promise<PluginActionResult> {
   return postJson<PluginActionResult>(`${API_BASE}/update`, { name });
 }
 
 /** Register a new marketplace. */
-export async function addMarketplace(
-  spec: string,
-): Promise<PluginActionResult> {
+export async function addMarketplace(spec: string): Promise<PluginActionResult> {
   return postJson<PluginActionResult>(`${API_BASE}/marketplace/add`, { spec });
 }
 
 /** Remove a registered marketplace. */
-export async function removeMarketplace(
-  name: string,
-): Promise<PluginActionResult> {
+export async function removeMarketplace(name: string): Promise<PluginActionResult> {
   return postJson<PluginActionResult>(`${API_BASE}/marketplace/remove`, {
     name,
   });


### PR DESCRIPTION
## Problem
When the taskpane is served from GitHub Pages, relative \/api/*\ fetch calls resolve against \sbroenne.github.io\ and return 404. The local proxy always runs on \localhost:3000\.

## Fix
Added \src/lib/api.ts\ with \getLocalApiBase()\ — returns \https://localhost:3000\ for non-localhost origins, mirrors the existing \getWsUrl()\ pattern.

Updated all fetch call sites: \pluginService.ts\, \McpPicker.tsx\, \McpManagerDialog.tsx\, \PermissionManagerDialog.tsx\.

## Tests
772/772 integration tests passing (excl. flaky live sentinel test).