### PR TITLE
fix: pass registeredKey to marketplace remove, protect OCA marketplace

### DIFF
--- a/src/components/plugins/PluginHub.tsx
+++ b/src/components/plugins/PluginHub.tsx
@@ -610,7 +610,7 @@ const PluginHub: React.FC<PluginHubProps> = ({ open, onClose }) => {
 
             {marketplaces.map(m => (
               <div
-                key={m.name}
+                key={m.slug ?? m.name}
                 className="flex items-center justify-between gap-2 rounded-md border px-2 py-1.5"
                 style={{
                   borderColor: 'var(--vscode-panel-border, var(--vscode-widget-border))',
@@ -619,7 +619,7 @@ const PluginHub: React.FC<PluginHubProps> = ({ open, onClose }) => {
                 <div className="min-w-0 flex-1">
                   <div className="flex items-center gap-1.5">
                     <span className="truncate text-[12px] font-medium">{m.name}</span>
-                    {m.isBuiltIn && (
+                    {(m.isBuiltIn || m.isOwn) && (
                       <Codicon
                         name="lock"
                         className="shrink-0 text-[11px] text-muted-foreground"
@@ -632,9 +632,9 @@ const PluginHub: React.FC<PluginHubProps> = ({ open, onClose }) => {
                     {m.pluginCount != null ? ` · ${m.pluginCount} plugins` : ''}
                   </p>
                 </div>
-                {!m.isBuiltIn && (
+                {!m.isBuiltIn && !m.isOwn && m.registeredKey && (
                   <button
-                    onClick={() => void handleRemoveMarketplace(m.name)}
+                    onClick={() => void handleRemoveMarketplace(m.registeredKey!)}
                     className="inline-flex h-6 w-6 shrink-0 items-center justify-center rounded text-muted-foreground hover:bg-accent hover:text-[var(--vscode-errorForeground)]"
                     title="Remove marketplace"
                     disabled={loading}

--- a/src/server-prod.mjs
+++ b/src/server-prod.mjs
@@ -302,6 +302,17 @@ export async function createServer() {
     try {
       const builtInSlugs = ['copilot-plugins', 'awesome-copilot'];
       const cacheDir = path.join(os.homedir(), '.copilot', 'marketplace-cache');
+      const config = readCopilotConfig();
+      const configMarketplaces = config.marketplaces || {};
+
+      const dirToKey = new Map();
+      for (const [key, value] of Object.entries(configMarketplaces)) {
+        const repo = value?.source?.repo;
+        if (!repo) continue;
+        dirToKey.set(repo.replace('/', '-'), key);
+        dirToKey.set(repo.replace('/', '--'), key);
+      }
+
       const marketplaces = [];
 
       if (fs.existsSync(cacheDir)) {
@@ -311,6 +322,8 @@ export async function createServer() {
           const dirPath = path.join(cacheDir, entry.name);
           const manifest = findMarketplaceManifest(dirPath);
           const isBuiltIn = builtInSlugs.some(slug => entry.name.includes(slug));
+          const registeredKey = dirToKey.get(entry.name) ?? null;
+          const isOwn = registeredKey === OCA_MARKETPLACE_NAME;
           marketplaces.push({
             slug: entry.name,
             name: manifest?.name || entry.name,
@@ -318,6 +331,8 @@ export async function createServer() {
             description: manifest?.description || null,
             pluginCount: Array.isArray(manifest?.plugins) ? manifest.plugins.length : 0,
             isBuiltIn,
+            registeredKey,
+            isOwn,
           });
         }
       }
@@ -460,6 +475,10 @@ export async function createServer() {
     try {
       const { name } = req.body;
       if (!name || typeof name !== 'string') { res.status(400).json({ error: 'Missing required field: name' }); return; }
+      if (name === OCA_MARKETPLACE_NAME) {
+        res.status(403).json({ success: false, message: 'Cannot remove the office-coding-agent marketplace' });
+        return;
+      }
       const result = runCopilotCommand(`marketplace remove ${name}`);
       res.status(result.success ? 200 : 500).json(result);
     } catch (error) {

--- a/src/server.mjs
+++ b/src/server.mjs
@@ -341,6 +341,20 @@ async function createServer() {
     try {
       const builtInSlugs = ['copilot-plugins', 'awesome-copilot'];
       const cacheDir = path.join(os.homedir(), '.copilot', 'marketplace-cache');
+      const config = readCopilotConfig();
+      const configMarketplaces = config.marketplaces || {};
+
+      // Build a map: cache dir name → registered config key.
+      // The CLI converts "owner/repo" to a dir name by replacing "/" with "-" or "--".
+      // We try both forms so we can match regardless of which the CLI chose.
+      const dirToKey = new Map();
+      for (const [key, value] of Object.entries(configMarketplaces)) {
+        const repo = value?.source?.repo;
+        if (!repo) continue;
+        dirToKey.set(repo.replace('/', '-'), key);
+        dirToKey.set(repo.replace('/', '--'), key);
+      }
+
       const marketplaces = [];
 
       if (fs.existsSync(cacheDir)) {
@@ -350,6 +364,8 @@ async function createServer() {
           const dirPath = path.join(cacheDir, entry.name);
           const manifest = findMarketplaceManifest(dirPath);
           const isBuiltIn = builtInSlugs.some(slug => entry.name.includes(slug));
+          const registeredKey = dirToKey.get(entry.name) ?? null;
+          const isOwn = registeredKey === OCA_MARKETPLACE_NAME;
           marketplaces.push({
             slug: entry.name,
             name: manifest?.name || entry.name,
@@ -357,6 +373,8 @@ async function createServer() {
             description: manifest?.description || null,
             pluginCount: Array.isArray(manifest?.plugins) ? manifest.plugins.length : 0,
             isBuiltIn,
+            registeredKey,
+            isOwn,
           });
         }
       }
@@ -529,12 +547,16 @@ async function createServer() {
     }
   });
 
-  // POST /api/plugins/marketplace/remove — remove a marketplace by name
+  // POST /api/plugins/marketplace/remove — remove a marketplace by registered config key
   apiRouter.post('/plugins/marketplace/remove', (req, res) => {
     try {
       const { name } = req.body;
       if (!name || typeof name !== 'string') {
         res.status(400).json({ error: 'Missing required field: name' });
+        return;
+      }
+      if (name === OCA_MARKETPLACE_NAME) {
+        res.status(403).json({ success: false, message: 'Cannot remove the office-coding-agent marketplace' });
         return;
       }
       const result = runCopilotCommand(`marketplace remove ${name}`);

--- a/src/types/plugin.ts
+++ b/src/types/plugin.ts
@@ -82,9 +82,7 @@ export interface PluginComponents {
  * Plugin source in marketplace.json — can be a relative path string,
  * or an object with source type + repo + path for external repos.
  */
-export type PluginSource =
-  | string
-  | { source: string; repo?: string; path?: string };
+export type PluginSource = string | { source: string; repo?: string; path?: string };
 
 /**
  * Marketplace plugin entry — from marketplace.json → plugins[].
@@ -138,10 +136,15 @@ export interface PluginMarketplace {
  * Registered marketplace info (from CLI or config).
  */
 export interface RegisteredMarketplace {
+  slug: string; // cache directory name, e.g. "sbroenne-office-coding-agent-plugins"
   name: string;
   source: string; // e.g. "github/copilot-plugins" or local path
   isBuiltIn: boolean; // true for copilot-plugins and awesome-copilot
   pluginCount?: number;
+  /** The key in ~/.copilot/config.json marketplaces — required for removal. Null if not registered. */
+  registeredKey: string | null;
+  /** True if this is the office-coding-agent's own marketplace (cannot be removed). */
+  isOwn: boolean;
 }
 
 /**


### PR DESCRIPTION
- GET /api/plugins/marketplaces now cross-references cache dirs against
  config.json to resolve the registered key for each marketplace.
  Tries both '-' and '--' as owner/repo separators since the CLI uses
  either form depending on whether the owner name contains special chars.
- Returns registeredKey (config key) and isOwn (OCA marketplace) per entry.
- POST /api/plugins/marketplace/remove: use registeredKey (not display name),
  refuse with 403 if name === OCA_MARKETPLACE_NAME.
- Frontend: delete button only shows when registeredKey is set and !isOwn.
  OCA marketplace and entries with no config key show a lock icon instead.
- Added slug and registeredKey/isOwn to RegisteredMarketplace type.
- Synced both server.mjs and server-prod.mjs.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
