### PR TITLE
feat: surface task_complete summary as visible text after tool use

### DIFF
--- a/src/components/chat/AssistantMessage.tsx
+++ b/src/components/chat/AssistantMessage.tsx
@@ -58,11 +58,31 @@ export const AssistantMessage: FC<AssistantMessageProps> = ({
   const hasText = textParts.some(p => p.text.trim().length > 0);
   const hasTools = content.some(p => p.type === 'tool-call');
 
-  // Full message text for copy button
-  const fullText = textParts.map(p => p.text).join('');
-
   const isMessageRunning = status?.type === 'running';
   const isError = status?.type === 'incomplete' && status.reason === 'error';
+
+  // When the agent ends with task_complete (no text response follows), surface
+  // the summary as readable text — matching VS Code where the model always writes
+  // a text response after tool use.
+  const taskCompleteSummary = (() => {
+    if (hasText || isMessageRunning) return null;
+    const part = content.find(
+      (p): p is ToolCallPart => p.type === 'tool-call' && p.toolName === 'task_complete'
+    );
+    if (!part?.argsText) return null;
+    try {
+      const args = JSON.parse(part.argsText) as Record<string, unknown>;
+      const s = args.summary;
+      return typeof s === 'string' && s.trim() ? s.trim() : null;
+    } catch {
+      return null;
+    }
+  })();
+
+  // Full message text for copy button (include task_complete summary when present)
+  const fullText = taskCompleteSummary
+    ? textParts.map(p => p.text).join('') || taskCompleteSummary
+    : textParts.map(p => p.text).join('');
 
   // Show inline "Thinking…" shimmer ONLY before any tools or text appear.
   // Once tools exist, the Working box takes over all thinking indication
@@ -105,6 +125,9 @@ export const AssistantMessage: FC<AssistantMessageProps> = ({
           if (!text && !(isLast && isRunning)) return null;
           return <MarkdownContent key={i} text={text} />;
         })}
+
+        {/* task_complete summary — shown when the agent ends with task_complete but no text */}
+        {taskCompleteSummary && <MarkdownContent text={taskCompleteSummary} />}
 
         {/* Error indicator */}
         {isError && status.error && (

--- a/src/components/chat/ToolGroup.tsx
+++ b/src/components/chat/ToolGroup.tsx
@@ -106,11 +106,13 @@ export const ToolGroup: FC<ToolGroupProps> = ({
   // and we have thinking text to display. This is the inter-step "Thinking…" indicator.
   const showSpinner = isRunning && !hasRunningTool && !!thinkingText;
   const spinnerLabel = thinkingText ?? 'Thinking…';
+  // task_complete is a completion marker — exclude from the "N steps" count
+  const workStepCount = parts.filter(p => p.toolName !== 'task_complete').length;
 
   return (
     <WorkingCollapsible
       isRunning={isRunning}
-      toolCount={parts.length}
+      toolCount={workStepCount}
       showSpinner={showSpinner}
       spinnerLabel={spinnerLabel}
     >

--- a/src/utils/humanizeToolName.ts
+++ b/src/utils/humanizeToolName.ts
@@ -7,8 +7,10 @@
  *   create_table          → "Create table"
  *   add_conditional_format → "Add conditional format"
  *   list_named_ranges     → "List named ranges"
+ *   task_complete         → "Task completed"
  */
 export function humanizeToolName(toolName: string): string {
+  if (toolName === 'task_complete') return 'Task completed';
   const words = toolName.replace(/_/g, ' ').trim();
   if (!words) return toolName;
   return words.charAt(0).toUpperCase() + words.slice(1);

--- a/src/utils/toolIcon.ts
+++ b/src/utils/toolIcon.ts
@@ -5,6 +5,8 @@
 export function getToolIcon(toolId: string): string {
   const lower = toolId.toLowerCase();
 
+  if (lower === 'task_complete') return 'pass';
+
   if (
     lower.includes('search') ||
     lower.includes('grep') ||


### PR DESCRIPTION
When the agent ends a turn with task_complete (no text response),
the summary was buried inside an expandable tool card. Users saw
only 'Finished with N steps' with no indication of what was done.

Changes:
- AssistantMessage: extract task_complete summary from argsText and
  render it as MarkdownContent below the tool group when no text
  response exists — mirrors VS Code where the model always writes a
  text response after tool use
- ToolGroup/WorkingCollapsible: exclude task_complete from the step
  count so the header shows 'Finished with N steps' for actual work
  steps only
- humanizeToolName: task_complete -> 'Task completed'
- toolIcon: task_complete -> 'pass' codicon (checkmark)

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
