### PR TITLE
feat: add Copilot avatar header to each assistant message (VS Code parity)

### DIFF
--- a/src/components/chat/AssistantMessage.tsx
+++ b/src/components/chat/AssistantMessage.tsx
@@ -96,6 +96,25 @@ export const AssistantMessage: FC<AssistantMessageProps> = ({
       className="aui-assistant-message-root group/message fade-in slide-in-from-bottom-1 relative w-full animate-in py-2 duration-150"
       data-role="assistant"
     >
+      {/* VS Code-style message header: Copilot avatar + "Copilot" label */}
+      <div className="flex items-center gap-2 px-4 pb-1.5">
+        <div
+          className="flex h-[22px] w-[22px] shrink-0 items-center justify-center rounded-full"
+          style={{
+            background: 'var(--vscode-chat-avatarBackground)',
+            color: 'var(--vscode-chat-avatarForeground)',
+          }}
+        >
+          <Codicon name="copilot" className="text-[13px]" />
+        </div>
+        <span
+          className="text-[13px] font-semibold leading-none"
+          style={{ color: 'var(--vscode-foreground)' }}
+        >
+          Copilot
+        </span>
+      </div>
+
       <div className="aui-assistant-message-content flex flex-col wrap-break-word px-4 text-foreground text-[13px] leading-[1.5em]">
         {/* Inline working progress */}
         {showThinking && (


### PR DESCRIPTION
Each assistant turn now starts with the VS Code-style Copilot avatar
circle + 'Copilot' label row, matching VS Code Copilot Chat exactly.

This is the key visual separator that was missing: without it, adjacent
assistant messages blurred together and the new 'Working' box for turn 2
appeared to belong to turn 1's message area.

Structure matches VS Code ChatMessageHeaderPart:
- 22x22 filled circle using --vscode-chat-avatarBackground
- Copilot codicon in --vscode-chat-avatarForeground
- 'Copilot' label in --vscode-foreground, 13px semibold
- Header is outside the flex-col content container so CSS order: -1
  on ToolGroup can never push the header below content

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
