### PR TITLE
fix: only show registered marketplaces, simplify remove to CLI-only

### DIFF
--- a/src/components/plugins/PluginHub.tsx
+++ b/src/components/plugins/PluginHub.tsx
@@ -298,11 +298,11 @@ const PluginHub: React.FC<PluginHubProps> = ({ open, onClose }) => {
   );
 
   const handleRemoveMarketplace = useCallback(
-    async (name: string) => {
+    async (registeredKey: string) => {
       setLoading(true);
       setError(null);
       try {
-        await pluginService.removeMarketplace(name);
+        await pluginService.removeMarketplace(registeredKey);
         await fetchMarketplaces();
       } catch (err) {
         setError(err instanceof Error ? err.message : 'Failed to remove marketplace');
@@ -632,7 +632,7 @@ const PluginHub: React.FC<PluginHubProps> = ({ open, onClose }) => {
                     {m.pluginCount != null ? ` · ${m.pluginCount} plugins` : ''}
                   </p>
                 </div>
-                {!m.isBuiltIn && !m.isOwn && m.registeredKey && (
+                {!m.isBuiltIn && !m.isOwn && (
                   <button
                     onClick={() => void handleRemoveMarketplace(m.registeredKey!)}
                     className="inline-flex h-6 w-6 shrink-0 items-center justify-center rounded text-muted-foreground hover:bg-accent hover:text-[var(--vscode-errorForeground)]"

--- a/src/marketplaceService.d.mts
+++ b/src/marketplaceService.d.mts
@@ -1,0 +1,23 @@
+export interface RegisteredMarketplaceEntry {
+  slug: string;
+  name: string;
+  source: string;
+  isBuiltIn: boolean;
+  isOwn: boolean;
+  registeredKey: string;
+  pluginCount: number;
+}
+
+export interface RemoveResult {
+  success: boolean;
+  message: string;
+}
+
+export declare const OCA_MARKETPLACE_KEY: string;
+export declare const BUILTIN_KEYS: string[];
+
+export declare function readConfig(configPath: string): Record<string, unknown>;
+export declare function findMarketplaceManifest(cacheDir: string): Record<string, unknown> | null;
+export declare function repoCacheSlugs(repo: string): string[];
+export declare function listMarketplaces(cacheDir: string, configPath: string): RegisteredMarketplaceEntry[];
+export declare function removeMarketplace(registeredKey: string): RemoveResult;

--- a/src/marketplaceService.mjs
+++ b/src/marketplaceService.mjs
@@ -1,0 +1,154 @@
+/**
+ * marketplaceService.mjs
+ *
+ * Testable helper functions for marketplace listing and removal.
+ * Extracted from server.mjs so the logic can be unit-tested without Express.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { execSync } from 'node:child_process';
+
+// ─── Constants ────────────────────────────────────────────────────────────────
+
+export const OCA_MARKETPLACE_KEY = 'office-coding-agent';
+export const BUILTIN_KEYS = ['copilot-plugins', 'awesome-copilot'];
+
+// ─── File system helpers ──────────────────────────────────────────────────────
+
+export function readConfig(configPath) {
+  if (!fs.existsSync(configPath)) return {};
+  try {
+    return JSON.parse(fs.readFileSync(configPath, 'utf-8'));
+  } catch {
+    return {};
+  }
+}
+
+/**
+ * Find the marketplace.json manifest inside a cache directory.
+ * The CLI clones the GitHub repo so the manifest may live in various locations.
+ */
+export function findMarketplaceManifest(cacheDir) {
+  const candidates = [
+    path.join(cacheDir, '.claude-plugin', 'marketplace.json'),
+    path.join(cacheDir, '.github', 'plugin', 'marketplace.json'),
+    path.join(cacheDir, 'marketplace.json'),
+  ];
+  for (const p of candidates) {
+    if (fs.existsSync(p)) {
+      try {
+        return JSON.parse(fs.readFileSync(p, 'utf-8'));
+      } catch {
+        continue;
+      }
+    }
+  }
+  return null;
+}
+
+// ─── Slug helpers ─────────────────────────────────────────────────────────────
+
+/**
+ * Convert an "owner/repo" string to all plausible cache-dir name forms that
+ * the Copilot CLI might use:
+ *   "owner/repo"         → ["owner-repo", "owner--repo"]
+ *   "stbrnner_ms/SPT-IQ" → ["stbrnner_ms-SPT-IQ", "stbrnner_ms--SPT-IQ",
+ *                            "stbrnner-ms-spt-iq"]
+ * We try multiple forms because the CLI's exact algorithm is not public.
+ */
+export function repoCacheSlugs(repo) {
+  const slugs = new Set();
+  // Form 1: replace first "/" with "-" (original case)
+  slugs.add(repo.replace('/', '-'));
+  // Form 2: replace first "/" with "--" (original case, observed for repos with _ in owner)
+  slugs.add(repo.replace('/', '--'));
+  // Form 3: full lowercase slugify (replace all non-alphanumeric with "-")
+  slugs.add(repo.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, ''));
+  // Form 4: keep owner chars, slugify only repo
+  const [owner, repoName] = repo.split('/');
+  if (owner && repoName) {
+    const repoSlug = repoName.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '');
+    slugs.add(`${owner}-${repoSlug}`);
+    slugs.add(`${owner}--${repoSlug}`);
+  }
+  return [...slugs];
+}
+
+// ─── listMarketplaces ─────────────────────────────────────────────────────────
+
+/**
+ * List all explicitly registered marketplaces from config.json.
+ * Cache-only dirs (never registered) are intentionally ignored.
+ *
+ * @param {string} cacheDir   - path to ~/.copilot/marketplace-cache
+ * @param {string} configPath - path to ~/.copilot/config.json
+ * @returns {{ slug, name, source, isBuiltIn, isOwn, registeredKey, pluginCount }[]}
+ */
+export function listMarketplaces(cacheDir, configPath) {
+  const config = readConfig(configPath);
+  const configMarketplaces = config.marketplaces || {};
+  const result = [];
+
+  for (const [key, value] of Object.entries(configMarketplaces)) {
+    const repo = value?.source?.repo ?? null;
+    const isBuiltIn = BUILTIN_KEYS.includes(key);
+    const isOwn = key === OCA_MARKETPLACE_KEY;
+
+    let slug = null;
+    let manifest = null;
+    let pluginCount = 0;
+
+    if (fs.existsSync(cacheDir) && repo) {
+      const candidateSlugs = repoCacheSlugs(repo);
+      const entries = fs.readdirSync(cacheDir, { withFileTypes: true });
+      for (const entry of entries) {
+        if (!entry.isDirectory()) continue;
+        if (candidateSlugs.includes(entry.name) || entry.name === key) {
+          slug = entry.name;
+          manifest = findMarketplaceManifest(path.join(cacheDir, entry.name));
+          pluginCount = Array.isArray(manifest?.plugins) ? manifest.plugins.length : 0;
+          break;
+        }
+      }
+    }
+
+    result.push({
+      slug: slug ?? key,
+      name: manifest?.name ?? key,
+      source: repo ?? key,
+      isBuiltIn,
+      isOwn,
+      registeredKey: key,
+      pluginCount,
+    });
+  }
+
+  return result;
+}
+
+/**
+ * Remove a registered marketplace via the Copilot CLI.
+ *
+ * @param {string} registeredKey - config key (e.g. "my-marketplace")
+ * @returns {{ success: boolean, message: string }}
+ */
+export function removeMarketplace(registeredKey) {
+  if (registeredKey === OCA_MARKETPLACE_KEY) {
+    return { success: false, message: 'Cannot remove the office-coding-agent marketplace' };
+  }
+  if (BUILTIN_KEYS.includes(registeredKey)) {
+    return { success: false, message: 'Cannot remove built-in marketplaces' };
+  }
+
+  try {
+    execSync(`copilot plugin marketplace remove ${registeredKey}`, {
+      encoding: 'utf-8',
+      timeout: 30000,
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+    return { success: true, message: `Removed marketplace: ${registeredKey}` };
+  } catch (err) {
+    return { success: false, message: err.stderr?.trim() || err.message };
+  }
+}

--- a/src/server-prod.mjs
+++ b/src/server-prod.mjs
@@ -9,6 +9,7 @@ import { fileURLToPath } from 'node:url';
 import { resolve } from 'node:path';
 import { execSync } from 'node:child_process';
 import { setupCopilotProxy, checkCopilotHealth } from './copilotProxy.mjs';
+import { listMarketplaces, removeMarketplace as removeMarketplaceSvc } from './marketplaceService.mjs';
 
 // ─── Copilot Plugin Helpers ────────────────────────────────────────────────
 
@@ -300,43 +301,9 @@ export async function createServer() {
 
   apiRouter.get('/plugins/marketplaces', (_req, res) => {
     try {
-      const builtInSlugs = ['copilot-plugins', 'awesome-copilot'];
       const cacheDir = path.join(os.homedir(), '.copilot', 'marketplace-cache');
-      const config = readCopilotConfig();
-      const configMarketplaces = config.marketplaces || {};
-
-      const dirToKey = new Map();
-      for (const [key, value] of Object.entries(configMarketplaces)) {
-        const repo = value?.source?.repo;
-        if (!repo) continue;
-        dirToKey.set(repo.replace('/', '-'), key);
-        dirToKey.set(repo.replace('/', '--'), key);
-      }
-
-      const marketplaces = [];
-
-      if (fs.existsSync(cacheDir)) {
-        const entries = fs.readdirSync(cacheDir, { withFileTypes: true });
-        for (const entry of entries) {
-          if (!entry.isDirectory()) continue;
-          const dirPath = path.join(cacheDir, entry.name);
-          const manifest = findMarketplaceManifest(dirPath);
-          const isBuiltIn = builtInSlugs.some(slug => entry.name.includes(slug));
-          const registeredKey = dirToKey.get(entry.name) ?? null;
-          const isOwn = registeredKey === OCA_MARKETPLACE_NAME;
-          marketplaces.push({
-            slug: entry.name,
-            name: manifest?.name || entry.name,
-            owner: manifest?.owner || null,
-            description: manifest?.description || null,
-            pluginCount: Array.isArray(manifest?.plugins) ? manifest.plugins.length : 0,
-            isBuiltIn,
-            registeredKey,
-            isOwn,
-          });
-        }
-      }
-
+      const configPath = path.join(os.homedir(), '.copilot', 'config.json');
+      const marketplaces = listMarketplaces(cacheDir, configPath);
       res.json({ marketplaces });
     } catch (error) {
       res.status(500).json({ error: error instanceof Error ? error.message : String(error) });
@@ -473,13 +440,12 @@ export async function createServer() {
 
   apiRouter.post('/plugins/marketplace/remove', (req, res) => {
     try {
-      const { name } = req.body;
-      if (!name || typeof name !== 'string') { res.status(400).json({ error: 'Missing required field: name' }); return; }
-      if (name === OCA_MARKETPLACE_NAME) {
-        res.status(403).json({ success: false, message: 'Cannot remove the office-coding-agent marketplace' });
+      const { registeredKey } = req.body;
+      if (!registeredKey || typeof registeredKey !== 'string') {
+        res.status(400).json({ error: 'Missing required field: registeredKey' });
         return;
       }
-      const result = runCopilotCommand(`marketplace remove ${name}`);
+      const result = removeMarketplaceSvc(registeredKey);
       res.status(result.success ? 200 : 500).json(result);
     } catch (error) {
       res.status(500).json({ error: error instanceof Error ? error.message : String(error) });

--- a/src/server.mjs
+++ b/src/server.mjs
@@ -20,6 +20,7 @@ import net from 'node:net';
 import { fileURLToPath } from 'node:url';
 import { execSync } from 'node:child_process';
 import { setupCopilotProxy, checkCopilotHealth } from './copilotProxy.mjs';
+import { listMarketplaces, removeMarketplace as removeMarketplaceSvc } from './marketplaceService.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const PORT = 3000;
@@ -339,46 +340,9 @@ async function createServer() {
   // GET /api/plugins/marketplaces — list available plugin marketplaces
   apiRouter.get('/plugins/marketplaces', (_req, res) => {
     try {
-      const builtInSlugs = ['copilot-plugins', 'awesome-copilot'];
       const cacheDir = path.join(os.homedir(), '.copilot', 'marketplace-cache');
-      const config = readCopilotConfig();
-      const configMarketplaces = config.marketplaces || {};
-
-      // Build a map: cache dir name → registered config key.
-      // The CLI converts "owner/repo" to a dir name by replacing "/" with "-" or "--".
-      // We try both forms so we can match regardless of which the CLI chose.
-      const dirToKey = new Map();
-      for (const [key, value] of Object.entries(configMarketplaces)) {
-        const repo = value?.source?.repo;
-        if (!repo) continue;
-        dirToKey.set(repo.replace('/', '-'), key);
-        dirToKey.set(repo.replace('/', '--'), key);
-      }
-
-      const marketplaces = [];
-
-      if (fs.existsSync(cacheDir)) {
-        const entries = fs.readdirSync(cacheDir, { withFileTypes: true });
-        for (const entry of entries) {
-          if (!entry.isDirectory()) continue;
-          const dirPath = path.join(cacheDir, entry.name);
-          const manifest = findMarketplaceManifest(dirPath);
-          const isBuiltIn = builtInSlugs.some(slug => entry.name.includes(slug));
-          const registeredKey = dirToKey.get(entry.name) ?? null;
-          const isOwn = registeredKey === OCA_MARKETPLACE_NAME;
-          marketplaces.push({
-            slug: entry.name,
-            name: manifest?.name || entry.name,
-            owner: manifest?.owner || null,
-            description: manifest?.description || null,
-            pluginCount: Array.isArray(manifest?.plugins) ? manifest.plugins.length : 0,
-            isBuiltIn,
-            registeredKey,
-            isOwn,
-          });
-        }
-      }
-
+      const configPath = path.join(os.homedir(), '.copilot', 'config.json');
+      const marketplaces = listMarketplaces(cacheDir, configPath);
       res.json({ marketplaces });
     } catch (error) {
       res.status(500).json({ error: error instanceof Error ? error.message : String(error) });
@@ -547,19 +511,15 @@ async function createServer() {
     }
   });
 
-  // POST /api/plugins/marketplace/remove — remove a marketplace by registered config key
+  // POST /api/plugins/marketplace/remove — remove a marketplace (registered or cache-only)
   apiRouter.post('/plugins/marketplace/remove', (req, res) => {
     try {
-      const { name } = req.body;
-      if (!name || typeof name !== 'string') {
-        res.status(400).json({ error: 'Missing required field: name' });
+      const { registeredKey } = req.body;
+      if (!registeredKey || typeof registeredKey !== 'string') {
+        res.status(400).json({ error: 'Missing required field: registeredKey' });
         return;
       }
-      if (name === OCA_MARKETPLACE_NAME) {
-        res.status(403).json({ success: false, message: 'Cannot remove the office-coding-agent marketplace' });
-        return;
-      }
-      const result = runCopilotCommand(`marketplace remove ${name}`);
+      const result = removeMarketplaceSvc(registeredKey);
       res.status(result.success ? 200 : 500).json(result);
     } catch (error) {
       res.status(500).json({ error: error instanceof Error ? error.message : String(error) });

--- a/src/services/plugins/pluginService.ts
+++ b/src/services/plugins/pluginService.ts
@@ -99,8 +99,6 @@ export async function addMarketplace(spec: string): Promise<PluginActionResult> 
 }
 
 /** Remove a registered marketplace. */
-export async function removeMarketplace(name: string): Promise<PluginActionResult> {
-  return postJson<PluginActionResult>(`${API_BASE}/marketplace/remove`, {
-    name,
-  });
+export async function removeMarketplace(registeredKey: string): Promise<PluginActionResult> {
+  return postJson<PluginActionResult>(`${API_BASE}/marketplace/remove`, { registeredKey });
 }

--- a/tests/integration/marketplace-service.test.ts
+++ b/tests/integration/marketplace-service.test.ts
@@ -1,0 +1,195 @@
+// @vitest-environment node
+/**
+ * Real integration tests for marketplaceService.mjs.
+ *
+ * These tests create actual temp directories on disk — no mocking.
+ * They verify the REAL logic for listing and removing marketplaces.
+ */
+import { describe, it, expect, afterEach } from 'vitest';
+import { mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { randomUUID } from 'node:crypto';
+import {
+  listMarketplaces,
+  removeMarketplace,
+  repoCacheSlugs,
+  OCA_MARKETPLACE_KEY,
+  BUILTIN_KEYS,
+} from '@/../src/marketplaceService.mjs';
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function tempDir(): string {
+  const dir = join(tmpdir(), `oca-mkt-test-${randomUUID()}`);
+  mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+function makeConfig(marketplaces: Record<string, unknown>): string {
+  return JSON.stringify({ marketplaces });
+}
+
+function makeCacheDir(baseDir: string, slug: string, manifestName: string | null = null): string {
+  const dir = join(baseDir, slug);
+  mkdirSync(dir, { recursive: true });
+  if (manifestName !== null) {
+    const pluginDir = join(dir, '.claude-plugin');
+    mkdirSync(pluginDir, { recursive: true });
+    writeFileSync(
+      join(pluginDir, 'marketplace.json'),
+      JSON.stringify({ name: manifestName, plugins: [] })
+    );
+  }
+  return dir;
+}
+
+const cleanups: string[] = [];
+afterEach(() => {
+  for (const dir of cleanups.splice(0)) {
+    try { rmSync(dir, { recursive: true, force: true }); } catch { /* ignore */ }
+  }
+});
+
+// ─── repoCacheSlugs ───────────────────────────────────────────────────────────
+
+describe('repoCacheSlugs', () => {
+  it('produces owner-repo form', () => {
+    expect(repoCacheSlugs('owner/repo')).toContain('owner-repo');
+  });
+
+  it('produces owner--repo form', () => {
+    expect(repoCacheSlugs('owner/repo')).toContain('owner--repo');
+  });
+
+  it('produces fully slugified form for names with special chars', () => {
+    expect(repoCacheSlugs('stbrnner_microsoft/SPT-IQ')).toContain('stbrnner-microsoft-spt-iq');
+  });
+
+  it('produces double-dash form observed in real CLI output', () => {
+    expect(repoCacheSlugs('stbrnner_microsoft/SPT-IQ')).toContain('stbrnner_microsoft--SPT-IQ');
+  });
+});
+
+// ─── listMarketplaces ─────────────────────────────────────────────────────────
+
+describe('listMarketplaces', () => {
+  it('registered marketplace always has non-null registeredKey (simple owner/repo)', () => {
+    const root = tempDir(); cleanups.push(root);
+    const cacheDir = join(root, 'cache');
+    const configPath = join(root, 'config.json');
+
+    makeCacheDir(cacheDir, 'sbroenne-my-plugins', 'My Plugins');
+    writeFileSync(configPath, makeConfig({
+      'my-plugins': { source: { source: 'github', repo: 'sbroenne/my-plugins' } },
+    }));
+
+    const list = listMarketplaces(cacheDir, configPath);
+    const entry = list.find(m => m.slug === 'sbroenne-my-plugins');
+    expect(entry).toBeTruthy();
+    expect(entry!.registeredKey).toBe('my-plugins');
+  });
+
+  it('registered marketplace with double-dash cache slug gets correct registeredKey', () => {
+    const root = tempDir(); cleanups.push(root);
+    const cacheDir = join(root, 'cache');
+    const configPath = join(root, 'config.json');
+
+    makeCacheDir(cacheDir, 'stbrnner_microsoft--SPT-IQ', 'SPT-IQ');
+    writeFileSync(configPath, makeConfig({
+      'spt-iq': { source: { source: 'github', repo: 'stbrnner_microsoft/SPT-IQ' } },
+    }));
+
+    const list = listMarketplaces(cacheDir, configPath);
+    const entry = list.find(m => m.slug === 'stbrnner_microsoft--SPT-IQ');
+    expect(entry).toBeTruthy();
+    expect(entry!.registeredKey).toBe('spt-iq');
+  });
+
+  it('cache-only dirs (not in config) are NOT listed', () => {
+    const root = tempDir(); cleanups.push(root);
+    const cacheDir = join(root, 'cache');
+    const configPath = join(root, 'config.json');
+
+    makeCacheDir(cacheDir, 'some-random-cache', null);
+    writeFileSync(configPath, makeConfig({}));
+
+    const list = listMarketplaces(cacheDir, configPath);
+    expect(list.find(m => m.slug === 'some-random-cache')).toBeUndefined();
+    expect(list).toHaveLength(0);
+  });
+
+  it('OCA marketplace entry has isOwn = true', () => {
+    const root = tempDir(); cleanups.push(root);
+    const cacheDir = join(root, 'cache');
+    const configPath = join(root, 'config.json');
+
+    makeCacheDir(cacheDir, 'sbroenne-office-coding-agent-plugins', 'office-coding-agent');
+    writeFileSync(configPath, makeConfig({
+      [OCA_MARKETPLACE_KEY]: { source: { source: 'github', repo: 'sbroenne/office-coding-agent-plugins' } },
+    }));
+
+    const list = listMarketplaces(cacheDir, configPath);
+    const entry = list.find(m => m.isOwn);
+    expect(entry).toBeTruthy();
+    expect(entry!.registeredKey).toBe(OCA_MARKETPLACE_KEY);
+  });
+
+  it('returns manifest name when available, falls back to config key', () => {
+    const root = tempDir(); cleanups.push(root);
+    const cacheDir = join(root, 'cache');
+    const configPath = join(root, 'config.json');
+
+    makeCacheDir(cacheDir, 'owner-repo', 'Pretty Name From Manifest');
+    writeFileSync(configPath, makeConfig({
+      'owner-repo': { source: { source: 'github', repo: 'owner/repo' } },
+    }));
+
+    const list = listMarketplaces(cacheDir, configPath);
+    expect(list[0].name).toBe('Pretty Name From Manifest');
+  });
+
+  it('shows registered entry even when cache dir does not exist', () => {
+    const root = tempDir(); cleanups.push(root);
+    const cacheDir = join(root, 'cache');
+    const configPath = join(root, 'config.json');
+
+    writeFileSync(configPath, makeConfig({
+      'no-cache-market': { source: { source: 'github', repo: 'owner/no-cache' } },
+    }));
+
+    const list = listMarketplaces(cacheDir, configPath);
+    const entry = list.find(m => m.registeredKey === 'no-cache-market');
+    expect(entry).toBeTruthy();
+    expect(entry!.registeredKey).toBe('no-cache-market');
+  });
+
+  it('returns empty list when config and cache both missing', () => {
+    const root = tempDir(); cleanups.push(root);
+    const list = listMarketplaces(join(root, 'cache'), join(root, 'config.json'));
+    expect(list).toEqual([]);
+  });
+});
+
+// ─── removeMarketplace ────────────────────────────────────────────────────────
+
+describe('removeMarketplace', () => {
+  it('refuses to remove OCA marketplace', () => {
+    const result = removeMarketplace(OCA_MARKETPLACE_KEY);
+    expect(result.success).toBe(false);
+    expect(result.message).toMatch(/office-coding-agent/i);
+  });
+
+  it('refuses to remove built-in marketplace keys', () => {
+    for (const key of BUILTIN_KEYS) {
+      const result = removeMarketplace(key);
+      expect(result.success).toBe(false);
+    }
+  });
+
+  it('returns failure when CLI command fails (non-registered key)', () => {
+    // The CLI will fail because the key is not registered; we expect a failure result
+    const result = removeMarketplace('nonexistent-marketplace-key-zzz');
+    expect(result.success).toBe(false);
+  });
+});

--- a/tests/integration/plugin-hub-marketplace.test.tsx
+++ b/tests/integration/plugin-hub-marketplace.test.tsx
@@ -2,11 +2,10 @@
  * Regression tests: PluginHub — Marketplace tab (delete & edit).
  *
  * These tests document the expected behaviour for the Marketplaces tab:
- * - Delete button is visible for custom marketplaces that have a registeredKey
+ * - Delete button is visible for custom marketplaces (all listed entries have a registeredKey)
  * - Delete button is hidden for the OCA marketplace (isOwn = true)
  * - Delete button is hidden for built-in marketplaces (isBuiltIn = true)
- * - Delete button is hidden when registeredKey is null (CLI mapping failure)
- * - Clicking delete calls removeMarketplace with the registeredKey (not slug)
+ * - Clicking delete calls removeMarketplace with the registeredKey
  * - Lock icon is shown for protected marketplaces
  * - After a successful removal the list is refreshed
  */
@@ -70,20 +69,6 @@ describe('Integration: PluginHub — Marketplaces tab', () => {
     expect(deleteBtn).toBeInTheDocument();
   });
 
-  it('delete button is HIDDEN when registeredKey is null (CLI slug mismatch bug)', async () => {
-    // Regression: when the server cannot map the cache dir to a config key, registeredKey is null.
-    // The delete button must not show (there is nothing safe to pass to the CLI).
-    const user = userEvent.setup();
-    vi.mocked(pluginService.getMarketplaces).mockResolvedValue([
-      makeMarketplace({ registeredKey: null, isOwn: false, isBuiltIn: false }),
-    ]);
-
-    renderWithProviders(<PluginHub open onClose={() => {}} />);
-    await openMarketplacesTab(user);
-
-    await screen.findByText('My Plugins');
-    expect(screen.queryByRole('button', { name: /remove marketplace/i })).toBeNull();
-  });
 
   it('delete button is HIDDEN for the OCA marketplace (isOwn = true)', async () => {
     const user = userEvent.setup();


### PR DESCRIPTION
## Summary

Cache-only marketplace directories (cloned by the CLI as a side-effect of browsing/installing, but never explicitly registered) are now ignored. Only marketplaces the user explicitly added via \copilot plugin marketplace add\ are shown.

### Changes
- **\listMarketplaces()\**: Only returns entries from \config.json\ (registered). Cache-only dirs are intentionally ignored — they're CLI implementation details, not user-configured marketplaces.
- **\emoveMarketplace()\**: Simplified to a single CLI command (\copilot plugin marketplace remove <key>\). No more dual-path \s.rmSync\ fallback for cache-only entries.
- **\server.mjs\ / \server-prod.mjs\**: Routes updated to match new signatures.
- **\pluginService.ts\ / \PluginHub.tsx\**: Delete button is now visible for all non-protected entries (all listed entries always have a \egisteredKey\). Removed the \m.registeredKey\ guard that was hiding the button.
- Added \marketplaceService.d.mts\ for TypeScript types.
- Removed stale 'registeredKey is null' regression test; added test verifying cache-only dirs are NOT listed.

### Why cache-only entries were confusing
The CLI downloads marketplace repos to \~/.copilot/marketplace-cache/\ as a side-effect of browsing, but doesn't register them in \config.json\. Showing these entries was misleading because they weren't something the user consciously added, and trying to delete them via \copilot plugin marketplace remove\ would fail since they're not registered.

## Tests
- 22 marketplace tests pass (14 service + 8 UI)