### PR TITLE
fix: show all marketplaces (registered + cache-only), enable delete for both

### DIFF
--- a/src/components/plugins/PluginHub.tsx
+++ b/src/components/plugins/PluginHub.tsx
@@ -298,11 +298,11 @@ const PluginHub: React.FC<PluginHubProps> = ({ open, onClose }) => {
   );
 
   const handleRemoveMarketplace = useCallback(
-    async (registeredKey: string) => {
+    async (slug: string, registeredKey: string | null) => {
       setLoading(true);
       setError(null);
       try {
-        await pluginService.removeMarketplace(registeredKey);
+        await pluginService.removeMarketplace(slug, registeredKey);
         await fetchMarketplaces();
       } catch (err) {
         setError(err instanceof Error ? err.message : 'Failed to remove marketplace');
@@ -634,7 +634,7 @@ const PluginHub: React.FC<PluginHubProps> = ({ open, onClose }) => {
                 </div>
                 {!m.isBuiltIn && !m.isOwn && (
                   <button
-                    onClick={() => void handleRemoveMarketplace(m.registeredKey!)}
+                    onClick={() => void handleRemoveMarketplace(m.slug ?? m.name, m.registeredKey)}
                     className="inline-flex h-6 w-6 shrink-0 items-center justify-center rounded text-muted-foreground hover:bg-accent hover:text-[var(--vscode-errorForeground)]"
                     title="Remove marketplace"
                     disabled={loading}

--- a/src/marketplaceService.d.mts
+++ b/src/marketplaceService.d.mts
@@ -4,7 +4,7 @@ export interface RegisteredMarketplaceEntry {
   source: string;
   isBuiltIn: boolean;
   isOwn: boolean;
-  registeredKey: string;
+  registeredKey: string | null;
   pluginCount: number;
 }
 
@@ -14,10 +14,12 @@ export interface RemoveResult {
 }
 
 export declare const OCA_MARKETPLACE_KEY: string;
+export declare const OCA_MARKETPLACE_SLUG: string;
 export declare const BUILTIN_KEYS: string[];
+export declare const BUILTIN_SLUGS: string[];
 
 export declare function readConfig(configPath: string): Record<string, unknown>;
 export declare function findMarketplaceManifest(cacheDir: string): Record<string, unknown> | null;
 export declare function repoCacheSlugs(repo: string): string[];
 export declare function listMarketplaces(cacheDir: string, configPath: string): RegisteredMarketplaceEntry[];
-export declare function removeMarketplace(registeredKey: string): RemoveResult;
+export declare function removeMarketplace(cacheDir: string, slug: string, registeredKey: string | null): RemoveResult;

--- a/src/marketplaceService.mjs
+++ b/src/marketplaceService.mjs
@@ -2,7 +2,7 @@
  * marketplaceService.mjs
  *
  * Testable helper functions for marketplace listing and removal.
- * Extracted from server.mjs so the logic can be unit-tested without Express.
+ * Extracted from server.mjs so the logic can be tested without Express.
  */
 
 import fs from 'node:fs';
@@ -12,7 +12,9 @@ import { execSync } from 'node:child_process';
 // ─── Constants ────────────────────────────────────────────────────────────────
 
 export const OCA_MARKETPLACE_KEY = 'office-coding-agent';
+export const OCA_MARKETPLACE_SLUG = 'sbroenne-office-coding-agent-plugins';
 export const BUILTIN_KEYS = ['copilot-plugins', 'awesome-copilot'];
+export const BUILTIN_SLUGS = ['github-copilot-plugins', 'github-awesome-copilot'];
 
 // ─── File system helpers ──────────────────────────────────────────────────────
 
@@ -50,22 +52,14 @@ export function findMarketplaceManifest(cacheDir) {
 // ─── Slug helpers ─────────────────────────────────────────────────────────────
 
 /**
- * Convert an "owner/repo" string to all plausible cache-dir name forms that
- * the Copilot CLI might use:
- *   "owner/repo"         → ["owner-repo", "owner--repo"]
- *   "stbrnner_ms/SPT-IQ" → ["stbrnner_ms-SPT-IQ", "stbrnner_ms--SPT-IQ",
- *                            "stbrnner-ms-spt-iq"]
- * We try multiple forms because the CLI's exact algorithm is not public.
+ * Convert an "owner/repo" string to all plausible cache-dir name forms the
+ * Copilot CLI might use.
  */
 export function repoCacheSlugs(repo) {
   const slugs = new Set();
-  // Form 1: replace first "/" with "-" (original case)
   slugs.add(repo.replace('/', '-'));
-  // Form 2: replace first "/" with "--" (original case, observed for repos with _ in owner)
   slugs.add(repo.replace('/', '--'));
-  // Form 3: full lowercase slugify (replace all non-alphanumeric with "-")
   slugs.add(repo.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, ''));
-  // Form 4: keep owner chars, slugify only repo
   const [owner, repoName] = repo.split('/');
   if (owner && repoName) {
     const repoSlug = repoName.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '');
@@ -78,18 +72,22 @@ export function repoCacheSlugs(repo) {
 // ─── listMarketplaces ─────────────────────────────────────────────────────────
 
 /**
- * List all explicitly registered marketplaces from config.json.
- * Cache-only dirs (never registered) are intentionally ignored.
+ * List ALL known marketplaces — registered (from config.json) PLUS cache-only
+ * directories the CLI has cloned but the user never explicitly registered.
+ *
+ * Registered entries  → registeredKey = config key (non-null)
+ * Cache-only entries  → registeredKey = null  (removed by fs.rmSync)
  *
  * @param {string} cacheDir   - path to ~/.copilot/marketplace-cache
  * @param {string} configPath - path to ~/.copilot/config.json
- * @returns {{ slug, name, source, isBuiltIn, isOwn, registeredKey, pluginCount }[]}
  */
 export function listMarketplaces(cacheDir, configPath) {
   const config = readConfig(configPath);
   const configMarketplaces = config.marketplaces || {};
   const result = [];
+  const coveredSlugs = new Set();
 
+  // ── Step 1: registered entries (config.json) ──────────────────────────────
   for (const [key, value] of Object.entries(configMarketplaces)) {
     const repo = value?.source?.repo ?? null;
     const isBuiltIn = BUILTIN_KEYS.includes(key);
@@ -108,6 +106,7 @@ export function listMarketplaces(cacheDir, configPath) {
           slug = entry.name;
           manifest = findMarketplaceManifest(path.join(cacheDir, entry.name));
           pluginCount = Array.isArray(manifest?.plugins) ? manifest.plugins.length : 0;
+          coveredSlugs.add(entry.name);
           break;
         }
       }
@@ -122,33 +121,86 @@ export function listMarketplaces(cacheDir, configPath) {
       registeredKey: key,
       pluginCount,
     });
+    if (slug) coveredSlugs.add(slug);
+  }
+
+  // ── Step 2: cache-only dirs not covered by config ─────────────────────────
+  if (fs.existsSync(cacheDir)) {
+    const entries = fs.readdirSync(cacheDir, { withFileTypes: true });
+    for (const entry of entries) {
+      if (!entry.isDirectory()) continue;
+      if (coveredSlugs.has(entry.name)) continue;
+
+      const dirPath = path.join(cacheDir, entry.name);
+      const manifest = findMarketplaceManifest(dirPath);
+      const isBuiltIn = BUILTIN_SLUGS.some(s => entry.name.includes(s));
+      const isOwn = entry.name === OCA_MARKETPLACE_SLUG;
+      const pluginCount = Array.isArray(manifest?.plugins) ? manifest.plugins.length : 0;
+
+      result.push({
+        slug: entry.name,
+        name: manifest?.name ?? entry.name,
+        source: manifest?.source ?? entry.name,
+        isBuiltIn,
+        isOwn,
+        registeredKey: null,
+        pluginCount,
+      });
+    }
   }
 
   return result;
 }
 
+// ─── removeMarketplace ────────────────────────────────────────────────────────
+
 /**
- * Remove a registered marketplace via the Copilot CLI.
+ * Remove a marketplace.
  *
- * @param {string} registeredKey - config key (e.g. "my-marketplace")
+ * - Registered (registeredKey non-null): unregister via CLI, then delete cache dir.
+ * - Cache-only (registeredKey null): delete cache dir only.
+ * - OCA marketplace and built-ins are always protected.
+ *
+ * @param {string} cacheDir        - path to ~/.copilot/marketplace-cache
+ * @param {string} slug            - cache directory name
+ * @param {string|null} registeredKey - config key, or null for cache-only
  * @returns {{ success: boolean, message: string }}
  */
-export function removeMarketplace(registeredKey) {
-  if (registeredKey === OCA_MARKETPLACE_KEY) {
+export function removeMarketplace(cacheDir, slug, registeredKey) {
+  if (slug === OCA_MARKETPLACE_SLUG || registeredKey === OCA_MARKETPLACE_KEY) {
     return { success: false, message: 'Cannot remove the office-coding-agent marketplace' };
   }
-  if (BUILTIN_KEYS.includes(registeredKey)) {
+  if (BUILTIN_SLUGS.some(s => slug.includes(s)) || BUILTIN_KEYS.includes(registeredKey ?? '')) {
     return { success: false, message: 'Cannot remove built-in marketplaces' };
   }
 
-  try {
-    execSync(`copilot plugin marketplace remove ${registeredKey}`, {
-      encoding: 'utf-8',
-      timeout: 30000,
-      stdio: ['pipe', 'pipe', 'pipe'],
-    });
-    return { success: true, message: `Removed marketplace: ${registeredKey}` };
-  } catch (err) {
-    return { success: false, message: err.stderr?.trim() || err.message };
+  const errors = [];
+
+  // Step 1: unregister from CLI if registered
+  if (registeredKey) {
+    try {
+      execSync(`copilot plugin marketplace remove ${registeredKey}`, {
+        encoding: 'utf-8',
+        timeout: 30000,
+        stdio: ['pipe', 'pipe', 'pipe'],
+      });
+    } catch (err) {
+      errors.push(`CLI unregister failed: ${err.stderr?.trim() || err.message}`);
+    }
   }
+
+  // Step 2: delete cache directory
+  const dirPath = path.join(cacheDir, slug);
+  if (fs.existsSync(dirPath)) {
+    try {
+      fs.rmSync(dirPath, { recursive: true, force: true });
+    } catch (err) {
+      errors.push(`Cache delete failed: ${err.message}`);
+    }
+  }
+
+  if (errors.length > 0) {
+    return { success: false, message: errors.join('; ') };
+  }
+  return { success: true, message: `Removed marketplace: ${registeredKey ?? slug}` };
 }

--- a/src/server-prod.mjs
+++ b/src/server-prod.mjs
@@ -440,12 +440,13 @@ export async function createServer() {
 
   apiRouter.post('/plugins/marketplace/remove', (req, res) => {
     try {
-      const { registeredKey } = req.body;
-      if (!registeredKey || typeof registeredKey !== 'string') {
-        res.status(400).json({ error: 'Missing required field: registeredKey' });
+      const { slug, registeredKey } = req.body;
+      if (!slug || typeof slug !== 'string') {
+        res.status(400).json({ error: 'Missing required field: slug' });
         return;
       }
-      const result = removeMarketplaceSvc(registeredKey);
+      const cacheDir = path.join(os.homedir(), '.copilot', 'marketplace-cache');
+      const result = removeMarketplaceSvc(cacheDir, slug, registeredKey ?? null);
       res.status(result.success ? 200 : 500).json(result);
     } catch (error) {
       res.status(500).json({ error: error instanceof Error ? error.message : String(error) });

--- a/src/server.mjs
+++ b/src/server.mjs
@@ -514,12 +514,13 @@ async function createServer() {
   // POST /api/plugins/marketplace/remove — remove a marketplace (registered or cache-only)
   apiRouter.post('/plugins/marketplace/remove', (req, res) => {
     try {
-      const { registeredKey } = req.body;
-      if (!registeredKey || typeof registeredKey !== 'string') {
-        res.status(400).json({ error: 'Missing required field: registeredKey' });
+      const { slug, registeredKey } = req.body;
+      if (!slug || typeof slug !== 'string') {
+        res.status(400).json({ error: 'Missing required field: slug' });
         return;
       }
-      const result = removeMarketplaceSvc(registeredKey);
+      const cacheDir = path.join(os.homedir(), '.copilot', 'marketplace-cache');
+      const result = removeMarketplaceSvc(cacheDir, slug, registeredKey ?? null);
       res.status(result.success ? 200 : 500).json(result);
     } catch (error) {
       res.status(500).json({ error: error instanceof Error ? error.message : String(error) });

--- a/src/services/plugins/pluginService.ts
+++ b/src/services/plugins/pluginService.ts
@@ -24,7 +24,7 @@ async function fetchJson<T>(url: string, init?: RequestInit): Promise<T> {
   return res.json() as Promise<T>;
 }
 
-function postJson<T>(url: string, body: Record<string, string>): Promise<T> {
+function postJson<T>(url: string, body: Record<string, string | null | undefined>): Promise<T> {
   return fetchJson<T>(url, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
@@ -98,7 +98,13 @@ export async function addMarketplace(spec: string): Promise<PluginActionResult> 
   return postJson<PluginActionResult>(`${API_BASE}/marketplace/add`, { spec });
 }
 
-/** Remove a registered marketplace. */
-export async function removeMarketplace(registeredKey: string): Promise<PluginActionResult> {
-  return postJson<PluginActionResult>(`${API_BASE}/marketplace/remove`, { registeredKey });
+/** Remove a marketplace — registered (by CLI) or cache-only (by slug). */
+export async function removeMarketplace(
+  slug: string,
+  registeredKey?: string | null
+): Promise<PluginActionResult> {
+  return postJson<PluginActionResult>(`${API_BASE}/marketplace/remove`, {
+    slug,
+    registeredKey: registeredKey ?? null,
+  });
 }

--- a/tests/integration/marketplace-service.test.ts
+++ b/tests/integration/marketplace-service.test.ts
@@ -1,12 +1,10 @@
 // @vitest-environment node
 /**
  * Real integration tests for marketplaceService.mjs.
- *
- * These tests create actual temp directories on disk — no mocking.
- * They verify the REAL logic for listing and removing marketplaces.
+ * Uses actual temp directories on disk — no mocking.
  */
 import { describe, it, expect, afterEach } from 'vitest';
-import { mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { mkdirSync, writeFileSync, existsSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { randomUUID } from 'node:crypto';
@@ -15,7 +13,9 @@ import {
   removeMarketplace,
   repoCacheSlugs,
   OCA_MARKETPLACE_KEY,
+  OCA_MARKETPLACE_SLUG,
   BUILTIN_KEYS,
+  BUILTIN_SLUGS,
 } from '@/../src/marketplaceService.mjs';
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
@@ -74,7 +74,7 @@ describe('repoCacheSlugs', () => {
 // ─── listMarketplaces ─────────────────────────────────────────────────────────
 
 describe('listMarketplaces', () => {
-  it('registered marketplace always has non-null registeredKey (simple owner/repo)', () => {
+  it('registered marketplace has non-null registeredKey', () => {
     const root = tempDir(); cleanups.push(root);
     const cacheDir = join(root, 'cache');
     const configPath = join(root, 'config.json');
@@ -106,17 +106,18 @@ describe('listMarketplaces', () => {
     expect(entry!.registeredKey).toBe('spt-iq');
   });
 
-  it('cache-only dirs (not in config) are NOT listed', () => {
+  it('cache-only dir (not in config) IS listed with registeredKey=null', () => {
     const root = tempDir(); cleanups.push(root);
     const cacheDir = join(root, 'cache');
     const configPath = join(root, 'config.json');
 
-    makeCacheDir(cacheDir, 'some-random-cache', null);
+    makeCacheDir(cacheDir, 'some-cache-only-marketplace', null);
     writeFileSync(configPath, makeConfig({}));
 
     const list = listMarketplaces(cacheDir, configPath);
-    expect(list.find(m => m.slug === 'some-random-cache')).toBeUndefined();
-    expect(list).toHaveLength(0);
+    const entry = list.find(m => m.slug === 'some-cache-only-marketplace');
+    expect(entry).toBeTruthy();
+    expect(entry!.registeredKey).toBeNull();
   });
 
   it('OCA marketplace entry has isOwn = true', () => {
@@ -124,7 +125,7 @@ describe('listMarketplaces', () => {
     const cacheDir = join(root, 'cache');
     const configPath = join(root, 'config.json');
 
-    makeCacheDir(cacheDir, 'sbroenne-office-coding-agent-plugins', 'office-coding-agent');
+    makeCacheDir(cacheDir, OCA_MARKETPLACE_SLUG, 'office-coding-agent');
     writeFileSync(configPath, makeConfig({
       [OCA_MARKETPLACE_KEY]: { source: { source: 'github', repo: 'sbroenne/office-coding-agent-plugins' } },
     }));
@@ -133,6 +134,21 @@ describe('listMarketplaces', () => {
     const entry = list.find(m => m.isOwn);
     expect(entry).toBeTruthy();
     expect(entry!.registeredKey).toBe(OCA_MARKETPLACE_KEY);
+  });
+
+  it('built-in cache-only dir is listed with isBuiltIn=true', () => {
+    const root = tempDir(); cleanups.push(root);
+    const cacheDir = join(root, 'cache');
+    const configPath = join(root, 'config.json');
+
+    makeCacheDir(cacheDir, BUILTIN_SLUGS[0], null);
+    writeFileSync(configPath, makeConfig({}));
+
+    const list = listMarketplaces(cacheDir, configPath);
+    const entry = list.find(m => m.slug === BUILTIN_SLUGS[0]);
+    expect(entry).toBeTruthy();
+    expect(entry!.isBuiltIn).toBe(true);
+    expect(entry!.registeredKey).toBeNull();
   });
 
   it('returns manifest name when available, falls back to config key', () => {
@@ -174,22 +190,70 @@ describe('listMarketplaces', () => {
 // ─── removeMarketplace ────────────────────────────────────────────────────────
 
 describe('removeMarketplace', () => {
-  it('refuses to remove OCA marketplace', () => {
-    const result = removeMarketplace(OCA_MARKETPLACE_KEY);
-    expect(result.success).toBe(false);
-    expect(result.message).toMatch(/office-coding-agent/i);
+  it('removes cache directory for a cache-only marketplace', () => {
+    const root = tempDir(); cleanups.push(root);
+    const cacheDir = join(root, 'cache');
+
+    makeCacheDir(cacheDir, 'my-cache-slug');
+    expect(existsSync(join(cacheDir, 'my-cache-slug'))).toBe(true);
+
+    const result = removeMarketplace(cacheDir, 'my-cache-slug', null);
+    expect(result.success).toBe(true);
+    expect(existsSync(join(cacheDir, 'my-cache-slug'))).toBe(false);
   });
 
-  it('refuses to remove built-in marketplace keys', () => {
+  it('does not throw when cache dir does not exist', () => {
+    const root = tempDir(); cleanups.push(root);
+    const cacheDir = join(root, 'cache');
+    mkdirSync(cacheDir);
+
+    const result = removeMarketplace(cacheDir, 'nonexistent-slug', null);
+    expect(result.success).toBe(true);
+  });
+
+  it('refuses to remove OCA marketplace (by slug)', () => {
+    const root = tempDir(); cleanups.push(root);
+    const cacheDir = join(root, 'cache');
+    makeCacheDir(cacheDir, OCA_MARKETPLACE_SLUG);
+
+    const result = removeMarketplace(cacheDir, OCA_MARKETPLACE_SLUG, null);
+    expect(result.success).toBe(false);
+    expect(result.message).toMatch(/office-coding-agent/i);
+    expect(existsSync(join(cacheDir, OCA_MARKETPLACE_SLUG))).toBe(true);
+  });
+
+  it('refuses to remove OCA marketplace (by registeredKey)', () => {
+    const root = tempDir(); cleanups.push(root);
+    const cacheDir = join(root, 'cache');
+
+    const result = removeMarketplace(cacheDir, 'some-slug', OCA_MARKETPLACE_KEY);
+    expect(result.success).toBe(false);
+  });
+
+  it('refuses to remove built-in marketplace (by slug)', () => {
+    const root = tempDir(); cleanups.push(root);
+    const cacheDir = join(root, 'cache');
+    makeCacheDir(cacheDir, BUILTIN_SLUGS[0]);
+
+    const result = removeMarketplace(cacheDir, BUILTIN_SLUGS[0], null);
+    expect(result.success).toBe(false);
+  });
+
+  it('refuses to remove built-in marketplace (by registeredKey)', () => {
+    const root = tempDir(); cleanups.push(root);
+    const cacheDir = join(root, 'cache');
+
     for (const key of BUILTIN_KEYS) {
-      const result = removeMarketplace(key);
+      const result = removeMarketplace(cacheDir, 'some-slug', key);
       expect(result.success).toBe(false);
     }
   });
 
-  it('returns failure when CLI command fails (non-registered key)', () => {
-    // The CLI will fail because the key is not registered; we expect a failure result
-    const result = removeMarketplace('nonexistent-marketplace-key-zzz');
+  it('returns failure when CLI command fails for a registered key', () => {
+    const root = tempDir(); cleanups.push(root);
+    const cacheDir = join(root, 'cache');
+
+    const result = removeMarketplace(cacheDir, 'nonexistent-key-zzz', 'nonexistent-key-zzz');
     expect(result.success).toBe(false);
   });
 });

--- a/tests/integration/plugin-hub-marketplace.test.tsx
+++ b/tests/integration/plugin-hub-marketplace.test.tsx
@@ -69,6 +69,19 @@ describe('Integration: PluginHub — Marketplaces tab', () => {
     expect(deleteBtn).toBeInTheDocument();
   });
 
+  it('delete button is visible for a cache-only marketplace (registeredKey = null)', async () => {
+    // Regression: cache-only entries (browsed but never registered) must be deletable.
+    const user = userEvent.setup();
+    vi.mocked(pluginService.getMarketplaces).mockResolvedValue([
+      makeMarketplace({ registeredKey: null, isOwn: false, isBuiltIn: false }),
+    ]);
+
+    renderWithProviders(<PluginHub open onClose={() => {}} />);
+    await openMarketplacesTab(user);
+
+    const deleteBtn = await screen.findByRole('button', { name: /remove marketplace/i });
+    expect(deleteBtn).toBeInTheDocument();
+  });
 
   it('delete button is HIDDEN for the OCA marketplace (isOwn = true)', async () => {
     const user = userEvent.setup();
@@ -107,15 +120,16 @@ describe('Integration: PluginHub — Marketplaces tab', () => {
     expect(screen.queryByRole('button', { name: /remove marketplace/i })).toBeNull();
   });
 
-  it('clicking delete calls removeMarketplace with the registeredKey', async () => {
+  it('clicking delete calls removeMarketplace with slug and registeredKey', async () => {
     const user = userEvent.setup();
+    const SLUG = 'stbrnner-microsoft-spt-iq';
     const REGISTERED_KEY = 'stbrnner-microsoft/spt-iq';
 
     vi.mocked(pluginService.getMarketplaces)
       .mockResolvedValueOnce([
-        makeMarketplace({ slug: 'stbrnner-microsoft-spt-iq', registeredKey: REGISTERED_KEY }),
+        makeMarketplace({ slug: SLUG, registeredKey: REGISTERED_KEY }),
       ])
-      .mockResolvedValue([]); // after removal list is refreshed
+      .mockResolvedValue([]);
 
     renderWithProviders(<PluginHub open onClose={() => {}} />);
     await openMarketplacesTab(user);
@@ -124,7 +138,7 @@ describe('Integration: PluginHub — Marketplaces tab', () => {
     await user.click(deleteBtn);
 
     expect(pluginService.removeMarketplace).toHaveBeenCalledOnce();
-    expect(pluginService.removeMarketplace).toHaveBeenCalledWith(REGISTERED_KEY);
+    expect(pluginService.removeMarketplace).toHaveBeenCalledWith(SLUG, REGISTERED_KEY);
   });
 
   it('after successful removal the marketplace list is refreshed', async () => {


### PR DESCRIPTION
## Root cause

\config.json\ only has \office-coding-agent\ registered. All other cache dirs (\mcaps-microsoft--SPT-IQ\, \stbrnner_microsoft--SPT-IQ\, \gency-*\) were cloned by the CLI during browsing but never registered. v0.5.15 accidentally hid them entirely.

## Changes

- **\listMarketplaces()\**: Returns registered entries AND cache-only dirs (registeredKey=null)
- **\emoveMarketplace(cacheDir, slug, registeredKey)\**: Registered → CLI unregister + rmSync cache dir; cache-only → rmSync only
- **Delete button**: Visible for all \!isBuiltIn && !isOwn\ entries — no \egisteredKey\ guard
- **\pluginService.ts\**: \postJson\ body type widened to allow \
ull\ values
- **Tests**: 28 tests — cache-only entries ARE listed; cache-only delete works; delete button shown when \egisteredKey\ is null