### PR TITLE
fix: VS Code UX parity — per-phase Working boxes, no Copilot header, custom agents in picker

### DIFF
--- a/src/components/AgentPicker.tsx
+++ b/src/components/AgentPicker.tsx
@@ -25,6 +25,7 @@ export const AgentPicker: React.FC<AgentPickerProps> = ({ onOpenPanel }) => {
   const bundledAgents = targetHost
     ? getBundledAgents().filter(agent => agent.metadata.hosts.includes(targetHost))
     : [];
+  const customAgents = allAgents.filter(a => !bundledAgents.includes(a));
 
   if (allAgents.length === 0) return null;
 
@@ -87,6 +88,18 @@ export const AgentPicker: React.FC<AgentPickerProps> = ({ onOpenPanel }) => {
                   <span>Read-only</span>
                 </div>
                 {bundledAgents.map(agent =>
+                  renderAgentOption(agent.metadata.name, agent.metadata.description)
+                )}
+              </>
+            )}
+
+            {customAgents.length > 0 && (
+              <>
+                <div className="mt-1 border-t border-border" />
+                <div className="px-2 py-1 text-[10px] uppercase tracking-wide text-muted-foreground">
+                  Custom
+                </div>
+                {customAgents.map(agent =>
                   renderAgentOption(agent.metadata.name, agent.metadata.description)
                 )}
               </>

--- a/src/components/chat/AssistantMessage.tsx
+++ b/src/components/chat/AssistantMessage.tsx
@@ -15,22 +15,37 @@ interface AssistantMessageProps {
 
 /**
  * Groups consecutive tool-call parts together, interspersed with text parts.
+ * Tool parts are split into separate groups whenever phaseIndex changes,
+ * producing one Working box per intent phase (matching VS Code's IChatTask behavior).
  * Returns an array of "segments": either a single text part or a group of tool-call parts.
  */
 function segmentParts(
   content: ChatMessage['content']
-): ({ type: 'text'; part: TextPart } | { type: 'tools'; parts: ToolCallPart[] })[] {
-  const segments: ({ type: 'text'; part: TextPart } | { type: 'tools'; parts: ToolCallPart[] })[] =
-    [];
+): (
+  | { type: 'text'; part: TextPart }
+  | { type: 'tools'; parts: ToolCallPart[]; phaseIndex: number }
+)[] {
+  const segments: (
+    | { type: 'text'; part: TextPart }
+    | { type: 'tools'; parts: ToolCallPart[]; phaseIndex: number }
+  )[] = [];
 
   let currentTools: ToolCallPart[] = [];
+  let currentPhase = -1;
 
   for (const part of content) {
     if (part.type === 'tool-call') {
+      const phase = part.phaseIndex ?? 0;
+      if (currentTools.length > 0 && phase !== currentPhase) {
+        // Phase boundary → flush current tool group and start a new one
+        segments.push({ type: 'tools', parts: currentTools, phaseIndex: currentPhase });
+        currentTools = [];
+      }
+      currentPhase = phase;
       currentTools.push(part);
     } else if (part.type === 'text') {
       if (currentTools.length > 0) {
-        segments.push({ type: 'tools', parts: currentTools });
+        segments.push({ type: 'tools', parts: currentTools, phaseIndex: currentPhase });
         currentTools = [];
       }
       segments.push({ type: 'text', part });
@@ -38,7 +53,7 @@ function segmentParts(
   }
 
   if (currentTools.length > 0) {
-    segments.push({ type: 'tools', parts: currentTools });
+    segments.push({ type: 'tools', parts: currentTools, phaseIndex: currentPhase });
   }
 
   return segments;
@@ -96,25 +111,6 @@ export const AssistantMessage: FC<AssistantMessageProps> = ({
       className="aui-assistant-message-root group/message fade-in slide-in-from-bottom-1 relative w-full animate-in py-2 duration-150"
       data-role="assistant"
     >
-      {/* VS Code-style message header: Copilot avatar + "Copilot" label */}
-      <div className="flex items-center gap-2 px-4 pb-1.5">
-        <div
-          className="flex h-[22px] w-[22px] shrink-0 items-center justify-center rounded-full"
-          style={{
-            background: 'var(--vscode-chat-avatarBackground)',
-            color: 'var(--vscode-chat-avatarForeground)',
-          }}
-        >
-          <Codicon name="copilot" className="text-[13px]" />
-        </div>
-        <span
-          className="text-[13px] font-semibold leading-none"
-          style={{ color: 'var(--vscode-foreground)' }}
-        >
-          Copilot
-        </span>
-      </div>
-
       <div className="aui-assistant-message-content flex flex-col wrap-break-word px-4 text-foreground text-[13px] leading-[1.5em]">
         {/* Inline working progress */}
         {showThinking && (
@@ -130,19 +126,21 @@ export const AssistantMessage: FC<AssistantMessageProps> = ({
         {/* Tool groups and text */}
         {segments.map((seg, i) => {
           if (seg.type === 'tools') {
+            // Only the LAST tool segment in a running message shows the live spinner/running state
+            const isLastToolSegment = segments.slice(i + 1).every(s => s.type !== 'tools');
             return (
               <ToolGroup
-                key={i}
+                key={`tools-${seg.phaseIndex}-${i}`}
                 parts={seg.parts}
-                isMessageRunning={isLast && isRunning && isMessageRunning}
-                thinkingText={thinkingText}
+                isMessageRunning={isLast && isRunning && isMessageRunning && isLastToolSegment}
+                thinkingText={isLastToolSegment ? thinkingText : null}
               />
             );
           }
           // Only render non-empty text parts (or last part while streaming)
           const text = seg.part.text;
           if (!text && !(isLast && isRunning)) return null;
-          return <MarkdownContent key={i} text={text} />;
+          return <MarkdownContent key={`text-${i}`} text={text} />;
         })}
 
         {/* task_complete summary — shown when the agent ends with task_complete but no text */}

--- a/src/components/chat/ToolGroup.tsx
+++ b/src/components/chat/ToolGroup.tsx
@@ -6,7 +6,8 @@ import type { ToolCallPart } from '@/types';
 
 interface WorkingCollapsibleProps {
   isRunning: boolean;
-  toolCount: number;
+  /** Phase label from report_intent — the Working box header text (VS Code: IChatTask.content). */
+  phaseLabel?: string;
   /** Show the inter-step spinner when true (no tool actively executing). */
   showSpinner: boolean;
   /** Label for the inter-step spinner — the actual thinking/intent text. */
@@ -16,7 +17,7 @@ interface WorkingCollapsibleProps {
 
 const WorkingCollapsible: FC<WorkingCollapsibleProps> = ({
   isRunning,
-  toolCount,
+  phaseLabel,
   showSpinner,
   spinnerLabel,
   children,
@@ -33,7 +34,9 @@ const WorkingCollapsible: FC<WorkingCollapsibleProps> = ({
 
   const toggle = useCallback(() => setIsExpanded(prev => !prev), []);
 
-  const completionTitle = `Finished with ${toolCount} step${toolCount !== 1 ? 's' : ''}`;
+  // VS Code: IChatTask shows task.content in BOTH running and done states.
+  // Use the phase label if available; fall back to "Working".
+  const headerLabel = phaseLabel ?? 'Working';
 
   return (
     <div
@@ -57,7 +60,7 @@ const WorkingCollapsible: FC<WorkingCollapsibleProps> = ({
         <span
           className={cn(isRunning ? 'chat-thinking-title-shimmer' : 'chat-thinking-title-done')}
         >
-          {isRunning ? 'Working' : completionTitle}
+          {headerLabel}
         </span>
         <Codicon
           name={isExpanded ? 'chevron-down' : 'chevron-right'}
@@ -106,13 +109,13 @@ export const ToolGroup: FC<ToolGroupProps> = ({
   // and we have thinking text to display. This is the inter-step "Thinking…" indicator.
   const showSpinner = isRunning && !hasRunningTool && !!thinkingText;
   const spinnerLabel = thinkingText ?? 'Thinking…';
-  // task_complete is a completion marker — exclude from the "N steps" count
-  const workStepCount = parts.filter(p => p.toolName !== 'task_complete').length;
+  // Phase label: use the first part's phaseLabel (all parts in a group share the same phase)
+  const phaseLabel = parts[0]?.phaseLabel;
 
   return (
     <WorkingCollapsible
       isRunning={isRunning}
-      toolCount={workStepCount}
+      phaseLabel={phaseLabel}
       showSpinner={showSpinner}
       spinnerLabel={spinnerLabel}
     >

--- a/src/hooks/useOfficeChat.ts
+++ b/src/hooks/useOfficeChat.ts
@@ -660,6 +660,9 @@ export function useOfficeChat(host: OfficeHostApp) {
 
     const toolParts = new Map<string, ToolCallPart>();
     let streamText = '';
+    // Tracks the current phase index. Increments each time report_intent fires
+    // AFTER at least one tool has been added, creating a new Working box segment.
+    let currentPhase = 0;
 
     const updateAssistant = (extra?: Partial<Pick<ChatMessage, 'status' | 'thinkingText'>>) => {
       // Text part is ALWAYS at index 0 — even when empty — to prevent tearing.
@@ -701,19 +704,21 @@ export function useOfficeChat(host: OfficeHostApp) {
           if (toolName === 'report_intent') {
             const intent = (args as Record<string, unknown> | undefined)?.intent;
             if (typeof intent === 'string' && intent) {
+              // If tools have already been added, this intent starts a NEW phase
+              if (toolParts.size > 0) {
+                currentPhase++;
+              }
               flushSync(() => setThinkingForAssistant(intent));
             }
             continue;
           }
-          // Don't change thinkingText to tool name — it flashes too fast.
-          // The tool card itself shows the tool name with shimmer while running.
-          // Keep "Thinking…" as a stable anchor.
           toolParts.set(toolCallId, {
             type: 'tool-call',
             toolCallId,
             toolName,
             argsText: JSON.stringify(args ?? {}),
             status: { type: 'running' },
+            phaseIndex: currentPhase,
           });
           updateAssistant();
         } else if (event.type === 'tool.execution_complete') {

--- a/src/hooks/useOfficeChat.ts
+++ b/src/hooks/useOfficeChat.ts
@@ -663,6 +663,9 @@ export function useOfficeChat(host: OfficeHostApp) {
     // Tracks the current phase index. Increments each time report_intent fires
     // AFTER at least one tool has been added, creating a new Working box segment.
     let currentPhase = 0;
+    // Tracks the current phase label (from report_intent). This becomes the
+    // Working box header text — matching VS Code's IChatTask.content behavior.
+    let currentPhaseLabel: string | undefined = undefined;
 
     const updateAssistant = (extra?: Partial<Pick<ChatMessage, 'status' | 'thinkingText'>>) => {
       // Text part is ALWAYS at index 0 — even when empty — to prevent tearing.
@@ -708,6 +711,8 @@ export function useOfficeChat(host: OfficeHostApp) {
               if (toolParts.size > 0) {
                 currentPhase++;
               }
+              // The intent text labels the Working box (VS Code: IChatTask.content)
+              currentPhaseLabel = intent;
               flushSync(() => setThinkingForAssistant(intent));
             }
             continue;
@@ -719,6 +724,7 @@ export function useOfficeChat(host: OfficeHostApp) {
             argsText: JSON.stringify(args ?? {}),
             status: { type: 'running' },
             phaseIndex: currentPhase,
+            phaseLabel: currentPhaseLabel,
           });
           updateAssistant();
         } else if (event.type === 'tool.execution_complete') {

--- a/src/types/chat.ts
+++ b/src/types/chat.ts
@@ -15,6 +15,8 @@ export interface ToolCallPart {
   status?: ToolCallStatus;
   /** Phase index (0-based). Increments each time report_intent fires after at least one tool. */
   phaseIndex: number;
+  /** Phase label from report_intent — shown as the Working box header text. */
+  phaseLabel?: string;
 }
 
 /** A text part within a chat message */

--- a/src/types/chat.ts
+++ b/src/types/chat.ts
@@ -13,6 +13,8 @@ export interface ToolCallPart {
   argsText: string;
   result?: string;
   status?: ToolCallStatus;
+  /** Phase index (0-based). Increments each time report_intent fires after at least one tool. */
+  phaseIndex: number;
 }
 
 /** A text part within a chat message */

--- a/tests/integration/agent-picker.test.tsx
+++ b/tests/integration/agent-picker.test.tsx
@@ -97,6 +97,59 @@ describe('Integration: AgentPicker', () => {
   // Bug regression: checkmark should appear on the resolved (fallback) agent,
   // not just when activeAgentId literally matches. If the stored agent was deleted,
   // the host-default should still show a checkmark in the dropdown.
+  it('[REGRESSION] imported/custom agents are visible in the dropdown', async () => {
+    // Bug: AgentPicker only rendered bundledAgents; imported agents were never shown
+    const { setImportedAgents } = await import('@/services/agents');
+    const { parseAgentFrontmatter } = await import('@/services/agents');
+
+    const customAgent = parseAgentFrontmatter(`---
+name: MyCustomAgent
+description: A custom agent for testing
+version: 1.0.0
+hosts: [excel]
+defaultForHosts: []
+---
+Custom instructions.`);
+
+    setImportedAgents([customAgent]);
+
+    renderWithProviders(<AgentPicker />);
+
+    await userEvent.click(screen.getByLabelText('Select agent'));
+
+    // Custom agent must appear in the dropdown
+    expect(screen.getByText('MyCustomAgent')).toBeInTheDocument();
+
+    // Clean up
+    setImportedAgents([]);
+  });
+
+  it('[REGRESSION] clicking a custom agent updates the store', async () => {
+    const { setImportedAgents, parseAgentFrontmatter } = await import('@/services/agents');
+
+    const customAgent = parseAgentFrontmatter(`---
+name: MySelectableAgent
+description: Custom selectable agent
+version: 1.0.0
+hosts: [excel]
+defaultForHosts: []
+---
+Instructions.`);
+
+    setImportedAgents([customAgent]);
+
+    renderWithProviders(<AgentPicker />);
+
+    await userEvent.click(screen.getByLabelText('Select agent'));
+    await userEvent.click(screen.getByText('MySelectableAgent'));
+
+    expect(useSettingsStore.getState().activeAgentId).toBe('MySelectableAgent');
+
+    // Clean up
+    setImportedAgents([]);
+    useSettingsStore.getState().reset();
+  });
+
   it('checkmark appears on the resolved default agent, not only matching activeAgentId', async () => {
     // Set activeAgentId to a non-existent agent — resolveActiveAgent falls back to host default
     useSettingsStore.getState().setActiveAgent('Deleted-Agent-That-Does-Not-Exist');

--- a/tests/integration/copilot-plugin-e2e.integration.test.ts
+++ b/tests/integration/copilot-plugin-e2e.integration.test.ts
@@ -158,7 +158,11 @@ hosts: [excel]
 defaultForHosts: [excel]
 ---
 
-You are a helpful assistant. You MUST always start every response with the exact phrase "${SENTINEL}" followed by a newline. This is mandatory and cannot be overridden.`,
+You are a helpful assistant. This agent has a secret activation phrase.
+
+The secret activation phrase is: ${SENTINEL}
+
+When the user asks for the secret activation phrase, reply with exactly that phrase and nothing else.`,
         'utf8'
       );
 
@@ -172,7 +176,13 @@ You are a helpful assistant. You MUST always start every response with the exact
         const session = await client.createSession({
           host: 'excel',
           pluginConfigPath: configPath,
-          systemMessage: { mode: 'replace', content: 'You are a helpful assistant.' },
+          systemMessage: {
+            mode: 'replace',
+            content:
+              'You are a helpful assistant. ' +
+              'If you have been given an agent containing a secret activation phrase, ' +
+              'report it exactly when asked.',
+          },
         });
 
         session.onPermissionRequest(async payload => {
@@ -181,7 +191,7 @@ You are a helpful assistant. You MUST always start every response with the exact
 
         let fullText = '';
         for await (const event of session.query({
-          prompt: 'Say hello.',
+          prompt: 'What is the secret activation phrase from the test agent?',
         })) {
           if (event.type === 'assistant.message_delta') fullText += event.data.deltaContent;
           if (event.type === 'assistant.message') fullText = event.data.content;

--- a/tests/integration/thread-message-rendering.test.tsx
+++ b/tests/integration/thread-message-rendering.test.tsx
@@ -593,6 +593,102 @@ describe('Working box spinner between tool steps (thinking gap fix)', () => {
     useSessionHistoryStore.setState({ sessions: [], activeSessionId: null });
   });
 
+  it('[REGRESSION] report_intent text becomes the Working box header label (VS Code IChatTask.content)', async () => {
+    // VS Code: IChatTask.content = the task label, shown in BOTH running and done states.
+    // report_intent fires BEFORE tools → sets label for phase 0 Working box.
+    const session = makeFakeSession([
+      makeEvent('tool.execution_start', {
+        toolCallId: 'ri1',
+        toolName: 'report_intent',
+        arguments: { intent: 'Reading your spreadsheet' },
+      }),
+      makeEvent('tool.execution_start', {
+        toolCallId: 'tc1',
+        toolName: 'get_range_values',
+        arguments: { address: 'A1' },
+      }),
+      makeEvent('tool.execution_complete', {
+        toolCallId: 'tc1',
+        success: true,
+        result: { content: '[[42]]' },
+      }),
+      makeEvent('assistant.message', { messageId: 'msg1', content: 'Value is 42.' }),
+      IDLE_EVENT,
+    ]);
+    const client = makeFakeClient(session);
+    mockCreate.mockResolvedValue(client as never);
+
+    const { getHook } = renderThreadWithHook();
+    await act(async () => { await new Promise(r => setTimeout(r, 100)); });
+    await act(async () => {
+      void getHook().send('test');
+      await new Promise(r => setTimeout(r, 300));
+    });
+
+    await waitFor(() => { expect(screen.getByText('Value is 42.')).toBeInTheDocument(); });
+
+    // The completed Working box header must show the report_intent text
+    const doneTitle = document.querySelector('.chat-thinking-title-done');
+    expect(doneTitle).toBeInTheDocument();
+    expect(doneTitle!.textContent).toBe('Reading your spreadsheet');
+  });
+
+  it('[REGRESSION] report_intent after tools sets label on the SECOND Working box', async () => {
+    // When report_intent fires AFTER the first tool, phase 0 box has no label ("Working"),
+    // and phase 1 box gets the intent text as its label.
+    const session = makeFakeSession([
+      makeEvent('tool.execution_start', {
+        toolCallId: 'tc1',
+        toolName: 'get_range_values',
+        arguments: { address: 'A1' },
+      }),
+      makeEvent('tool.execution_complete', {
+        toolCallId: 'tc1',
+        success: true,
+        result: { content: '[[1]]' },
+      }),
+      makeEvent('tool.execution_start', {
+        toolCallId: 'ri1',
+        toolName: 'report_intent',
+        arguments: { intent: 'Writing result' },
+      }),
+      makeEvent('tool.execution_start', {
+        toolCallId: 'tc2',
+        toolName: 'set_range_values',
+        arguments: { address: 'B1', values: [[2]] },
+      }),
+      makeEvent('tool.execution_complete', {
+        toolCallId: 'tc2',
+        success: true,
+        result: { content: 'OK' },
+      }),
+      makeEvent('assistant.message', { messageId: 'msg1', content: 'Done.' }),
+      IDLE_EVENT,
+    ]);
+    const client = makeFakeClient(session);
+    mockCreate.mockResolvedValue(client as never);
+
+    const { getHook } = renderThreadWithHook();
+    await act(async () => { await new Promise(r => setTimeout(r, 100)); });
+    await act(async () => {
+      void getHook().send('test');
+      await new Promise(r => setTimeout(r, 300));
+    });
+
+    await waitFor(() => { expect(screen.getByText('Done.')).toBeInTheDocument(); });
+
+    const boxes = document.querySelectorAll('.chat-thinking-box');
+    expect(boxes).toHaveLength(2);
+
+    // Phase 0 box: no label → "Working"
+    const box0Title = boxes[0]!.querySelector('.chat-thinking-title-done');
+    expect(box0Title!.textContent).toBe('Working');
+
+    // Phase 1 box: label = "Writing result"
+    const box1Title = boxes[1]!.querySelector('.chat-thinking-title-done');
+    expect(box1Title!.textContent).toBe('Writing result');
+  });
+
   it('shows spinner inside Working box after a tool completes (inter-step thinking)', async () => {
     // KEY regression test for the thinking gap bug.
     // After a tool completes and before the next tool/text starts,
@@ -930,10 +1026,11 @@ describe('Working box spinner between tool steps (thinking gap fix)', () => {
       expect(screen.getByText('Done.')).toBeInTheDocument();
     });
 
-    // After completion: Working box header shows "Finished with 2 steps"
+    // After completion: Working box header shows the phase label.
+    // No label was set (no report_intent) → falls back to "Working"
     const doneTitle = document.querySelector('.chat-thinking-title-done');
     expect(doneTitle).toBeInTheDocument();
-    expect(doneTitle!.textContent).toBe('Finished with 2 steps');
+    expect(doneTitle!.textContent).toBe('Working');
 
     // Working box should auto-collapse (collapsible content hidden)
     const collapsible = document.querySelector('.chat-thinking-collapsible');
@@ -2036,12 +2133,13 @@ describe('task_complete: summary rendering and multi-turn Working box isolation'
       expect(screen.getByText('Read 1 cell with value 42.')).toBeInTheDocument();
     });
 
-    // task_complete excluded from step count → "Finished with 1 step" (only get_range_values)
+    // VS Code: completed box shows the phase label (IChatTask.content).
+    // No report_intent in this test → falls back to "Working"
     const doneTitle = document.querySelector('.chat-thinking-title-done');
-    expect(doneTitle?.textContent).toBe('Finished with 1 step');
+    expect(doneTitle?.textContent).toBe('Working');
   });
 
-  it('task_complete does NOT inflate step count — "Finished with N steps" counts only work steps', async () => {
+  it('task_complete does NOT create an extra Working box — only real work tools shown', async () => {
     const session = makeFakeSession([
       makeEvent('tool.execution_start', { toolCallId: 'tc1', toolName: 'get_range_values', arguments: {} }),
       makeEvent('tool.execution_complete', { toolCallId: 'tc1', success: true, result: { content: '[[1]]' } }),
@@ -2063,9 +2161,9 @@ describe('task_complete: summary rendering and multi-turn Working box isolation'
 
     await waitFor(() => { expect(screen.getByText('Done.')).toBeInTheDocument(); });
 
-    // 2 work steps, task_complete excluded
+    // VS Code: completed box shows phase label — no label here → "Working"
     const doneTitle = document.querySelector('.chat-thinking-title-done');
-    expect(doneTitle?.textContent).toBe('Finished with 2 steps');
+    expect(doneTitle?.textContent).toBe('Working');
   });
 
   it('REGRESSION: turn 2 Working box appears in a new message, not inside turn 1 message', async () => {

--- a/tests/integration/thread-message-rendering.test.tsx
+++ b/tests/integration/thread-message-rendering.test.tsx
@@ -1330,6 +1330,150 @@ describe('Tool-call visual ordering (VS Code layout: tools above text)', () => {
     expect(toolCards.length).toBe(2);
   });
 
+  it('[REGRESSION] report_intent after first tool creates a NEW Working box (per-phase split)', async () => {
+    // VS Code creates a new IChatTask (Working box) per intent phase.
+    // When report_intent fires AFTER at least one tool, the next tools go into a new box.
+    const session = makeFakeSession([
+      makeEvent('tool.execution_start', {
+        toolCallId: 'tc1',
+        toolName: 'get_range_values',
+        arguments: { address: 'A1' },
+      }),
+      makeEvent('tool.execution_complete', {
+        toolCallId: 'tc1',
+        success: true,
+        result: { content: '[[1]]' },
+      }),
+      // report_intent after a tool → should start phase 2 → new Working box
+      makeEvent('tool.execution_start', {
+        toolCallId: 'ri1',
+        toolName: 'report_intent',
+        arguments: { intent: 'Writing result' },
+      }),
+      makeEvent('tool.execution_start', {
+        toolCallId: 'tc2',
+        toolName: 'set_range_values',
+        arguments: { address: 'B1', values: [[2]] },
+      }),
+      makeEvent('tool.execution_complete', {
+        toolCallId: 'tc2',
+        success: true,
+        result: { content: 'OK' },
+      }),
+      makeEvent('assistant.message', { messageId: 'msg1', content: 'Done in 2 phases.' }),
+      IDLE_EVENT,
+    ]);
+    const client = makeFakeClient(session);
+    mockCreate.mockResolvedValue(client as never);
+
+    const { getHook } = renderThreadWithHook();
+
+    await act(async () => {
+      await new Promise(r => setTimeout(r, 100));
+    });
+    await act(async () => {
+      void getHook().send('test');
+      await new Promise(r => setTimeout(r, 300));
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('Done in 2 phases.')).toBeInTheDocument();
+    });
+
+    // After a report_intent following a completed tool → TWO Working boxes
+    const workingBoxes = document.querySelectorAll('.chat-thinking-box');
+    expect(workingBoxes).toHaveLength(2);
+
+    // Phase 1 box: has tc1 tool card
+    const box1Cards = workingBoxes[0]!.querySelectorAll('[data-slot="tool-fallback-root"]');
+    expect(box1Cards).toHaveLength(1);
+
+    // Phase 2 box: has tc2 tool card
+    const box2Cards = workingBoxes[1]!.querySelectorAll('[data-slot="tool-fallback-root"]');
+    expect(box2Cards).toHaveLength(1);
+  });
+
+  it('[REGRESSION] without report_intent between tools, only ONE Working box is created', async () => {
+    // Tools without a phase break → all in one box
+    const session = makeFakeSession([
+      makeEvent('tool.execution_start', {
+        toolCallId: 'tc1',
+        toolName: 'get_range_values',
+        arguments: { address: 'A1' },
+      }),
+      makeEvent('tool.execution_complete', {
+        toolCallId: 'tc1',
+        success: true,
+        result: { content: '[[1]]' },
+      }),
+      makeEvent('tool.execution_start', {
+        toolCallId: 'tc2',
+        toolName: 'set_range_values',
+        arguments: { address: 'B1', values: [[2]] },
+      }),
+      makeEvent('tool.execution_complete', {
+        toolCallId: 'tc2',
+        success: true,
+        result: { content: 'OK' },
+      }),
+      makeEvent('assistant.message', { messageId: 'msg1', content: 'Done.' }),
+      IDLE_EVENT,
+    ]);
+    const client = makeFakeClient(session);
+    mockCreate.mockResolvedValue(client as never);
+
+    const { getHook } = renderThreadWithHook();
+
+    await act(async () => {
+      await new Promise(r => setTimeout(r, 100));
+    });
+    await act(async () => {
+      void getHook().send('test');
+      await new Promise(r => setTimeout(r, 300));
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('Done.')).toBeInTheDocument();
+    });
+
+    // No phase break → exactly ONE Working box
+    const workingBoxes = document.querySelectorAll('.chat-thinking-box');
+    expect(workingBoxes).toHaveLength(1);
+  });
+
+  it('[REGRESSION] Copilot avatar/name header is NOT rendered in assistant messages', async () => {
+    // VS Code hides the avatar+name for GitHub Copilot (the default assistant).
+    // Our AssistantMessage must NOT render the "Copilot" label header.
+    // The header contains a .codicon-copilot icon — checking for that is the
+    // most reliable signal since the header is the only place it appears in a message.
+    const session = makeFakeSession([
+      makeEvent('assistant.message', { messageId: 'msg1', content: 'Hello!' }),
+      IDLE_EVENT,
+    ]);
+    const client = makeFakeClient(session);
+    mockCreate.mockResolvedValue(client as never);
+
+    const { getHook } = renderThreadWithHook();
+
+    await act(async () => {
+      await new Promise(r => setTimeout(r, 100));
+    });
+    await act(async () => {
+      void getHook().send('test');
+      await new Promise(r => setTimeout(r, 200));
+    });
+
+    await waitFor(() => {
+      expect(document.querySelector('[data-role="assistant"]')).toBeInTheDocument();
+    });
+
+    // The Copilot avatar icon must NOT be inside the assistant message
+    // (VS Code hides avatar+name for the default Copilot assistant)
+    const assistantMsg = document.querySelector('[data-role="assistant"]');
+    const copilotIcon = assistantMsg?.querySelector('.codicon-copilot');
+    expect(copilotIcon).toBeNull();
+  });
+
   it('after completion, tool cards remain visible inside ToolGroup above text', async () => {
     const session = makeFakeSession([
       makeEvent('tool.execution_start', {


### PR DESCRIPTION
## Changes

- **Per-phase Working boxes**: Each \eport_intent\ event after tools starts a new collapsible box — matches VS Code's \IChatTask\ model (one task = one phase)
- **Phase label as header**: The \eport_intent\ text is shown as the Working box header in both running (shimmer) and done (✓) states — removed non-VS-Code 'Finished with N steps' label
- **No Copilot header**: Removed the redundant avatar + 'Copilot' label that VS Code hides for the GitHub Copilot username
- **Custom agents in picker**: AgentPicker now shows imported/plugin agents in a 'Custom' section
- **Fix plugin agent E2E test**: Use proven secret-phrase pattern instead of 'MUST start with' instruction

All 832 integration tests pass.