### PR TITLE
fix: AgentPicker reactivity and deduplication for plugin agents

### DIFF
--- a/src/components/AgentPicker.tsx
+++ b/src/components/AgentPicker.tsx
@@ -15,6 +15,8 @@ export const AgentPicker: React.FC<AgentPickerProps> = ({ onOpenPanel }) => {
   const [open, setOpen] = useState(false);
   const activeAgentId = useSettingsStore(s => s.activeAgentId);
   const setActiveAgent = useSettingsStore(s => s.setActiveAgent);
+  // Subscribe to pluginAgents so the picker re-renders when the proxy sends plugin.agents
+  useSettingsStore(s => s.pluginAgents);
 
   const host = detectOfficeHost();
   const targetHost =
@@ -25,7 +27,10 @@ export const AgentPicker: React.FC<AgentPickerProps> = ({ onOpenPanel }) => {
   const bundledAgents = targetHost
     ? getBundledAgents().filter(agent => agent.metadata.hosts.includes(targetHost))
     : [];
-  const customAgents = allAgents.filter(a => !bundledAgents.includes(a));
+  // Use name-based deduplication: a plugin agent with the same name as a bundled agent
+  // should NOT appear as a separate Custom entry.
+  const bundledAgentNames = new Set(bundledAgents.map(a => a.metadata.name));
+  const customAgents = allAgents.filter(a => !bundledAgentNames.has(a.metadata.name));
 
   if (allAgents.length === 0) return null;
 

--- a/src/hooks/useOfficeChat.ts
+++ b/src/hooks/useOfficeChat.ts
@@ -5,12 +5,7 @@ import type { PermissionRequestPayload } from '@/lib/websocket-client';
 import { createWebSocketClient } from '@/lib/websocket-client';
 import { getToolsForHost } from '@/tools';
 import { getImportedSkills, skillToMarkdown } from '@/services/skills';
-import {
-  resolveActiveAgent,
-  getAgents,
-  setImportedAgents,
-  SUPPORTED_AGENT_HOSTS,
-} from '@/services/agents';
+import { resolveActiveAgent, getAgents, SUPPORTED_AGENT_HOSTS } from '@/services/agents';
 import { toSdkMcpServers } from '@/services/mcp';
 import { useSettingsStore } from '@/stores';
 import { useSessionHistoryStore } from '@/stores';
@@ -249,7 +244,8 @@ export function useOfficeChat(host: OfficeHostApp) {
           },
           instructions: agent.prompt,
         }));
-        setImportedAgents(agentConfigs);
+        // Update the store — this syncs agentService AND triggers AgentPicker re-render
+        useSettingsStore.getState().setPluginAgents(agentConfigs);
       });
 
       const resolvedAgent = resolveActiveAgent(activeAgentIdRef.current, host);

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -19,6 +19,13 @@ interface SettingsState extends UserSettings {
   // ─── Agent management ───
   setActiveAgent: (agentId: string) => void;
   getActiveAgent: () => string;
+  /**
+   * Plugin agents discovered from the Copilot CLI config at session start.
+   * Ephemeral — NOT persisted. Populated by the plugin.agents notification.
+   */
+  pluginAgents: AgentConfig[];
+  /** Replace the current plugin agent list (called on each session.create). */
+  setPluginAgents: (agents: AgentConfig[]) => void;
 
   // ─── Skill management ───
   toggleSkill: (name: string) => void;
@@ -50,6 +57,7 @@ export const useSettingsStore = create<SettingsState>()(
       // ─── Initial state ───
       ...DEFAULT_SETTINGS,
       availableModels: null,
+      pluginAgents: [],
 
       // ─── Model management ───
       setAvailableModels: models => {
@@ -74,6 +82,12 @@ export const useSettingsStore = create<SettingsState>()(
 
       getActiveAgent: () => {
         return get().activeAgentId;
+      },
+
+      setPluginAgents: agents => {
+        set({ pluginAgents: agents });
+        // Sync agentService: plugin agents override same-named user-imported agents
+        setImportedAgents([...agents, ...get().importedAgents]);
       },
 
       // ─── Skill management ───
@@ -123,13 +137,13 @@ export const useSettingsStore = create<SettingsState>()(
         const existing = get().importedAgents.filter(a => a.metadata.name !== agent.metadata.name);
         const updated = [...existing, agent];
         set({ importedAgents: updated });
-        setImportedAgents(updated);
+        setImportedAgents([...get().pluginAgents, ...updated]);
       },
 
       removeImportedAgent: name => {
         const updated = get().importedAgents.filter(a => a.metadata.name !== name);
         set({ importedAgents: updated });
-        setImportedAgents(updated);
+        setImportedAgents([...get().pluginAgents, ...updated]);
       },
 
       // ─── Upload: imported MCP servers ───

--- a/tests/integration/agent-picker.test.tsx
+++ b/tests/integration/agent-picker.test.tsx
@@ -98,8 +98,8 @@ describe('Integration: AgentPicker', () => {
   // not just when activeAgentId literally matches. If the stored agent was deleted,
   // the host-default should still show a checkmark in the dropdown.
   it('[REGRESSION] imported/custom agents are visible in the dropdown', async () => {
-    // Bug: AgentPicker only rendered bundledAgents; imported agents were never shown
-    const { setImportedAgents } = await import('@/services/agents');
+    // Bug: AgentPicker only rendered bundledAgents; imported agents were never shown.
+    // Also regression: AgentPicker must react to plugin agents arriving via the store.
     const { parseAgentFrontmatter } = await import('@/services/agents');
 
     const customAgent = parseAgentFrontmatter(`---
@@ -111,7 +111,8 @@ defaultForHosts: []
 ---
 Custom instructions.`);
 
-    setImportedAgents([customAgent]);
+    // Use store action (not module-level setImportedAgents) so the picker re-renders
+    useSettingsStore.getState().setPluginAgents([customAgent]);
 
     renderWithProviders(<AgentPicker />);
 
@@ -121,11 +122,11 @@ Custom instructions.`);
     expect(screen.getByText('MyCustomAgent')).toBeInTheDocument();
 
     // Clean up
-    setImportedAgents([]);
+    useSettingsStore.getState().setPluginAgents([]);
   });
 
   it('[REGRESSION] clicking a custom agent updates the store', async () => {
-    const { setImportedAgents, parseAgentFrontmatter } = await import('@/services/agents');
+    const { parseAgentFrontmatter } = await import('@/services/agents');
 
     const customAgent = parseAgentFrontmatter(`---
 name: MySelectableAgent
@@ -136,7 +137,7 @@ defaultForHosts: []
 ---
 Instructions.`);
 
-    setImportedAgents([customAgent]);
+    useSettingsStore.getState().setPluginAgents([customAgent]);
 
     renderWithProviders(<AgentPicker />);
 
@@ -146,7 +147,7 @@ Instructions.`);
     expect(useSettingsStore.getState().activeAgentId).toBe('MySelectableAgent');
 
     // Clean up
-    setImportedAgents([]);
+    useSettingsStore.getState().setPluginAgents([]);
     useSettingsStore.getState().reset();
   });
 

--- a/tests/integration/use-office-chat.test.tsx
+++ b/tests/integration/use-office-chat.test.tsx
@@ -13,7 +13,7 @@ import type { SessionEvent } from '@github/copilot-sdk';
 import { useOfficeChat } from '@/hooks/useOfficeChat';
 import { useSettingsStore } from '@/stores/settingsStore';
 import { useSessionHistoryStore } from '@/stores/sessionHistoryStore';
-import { setImportedAgents, getImportedAgents } from '@/services/agents';
+import { setImportedAgents } from '@/services/agents';
 
 // ─── Fake session builder ─────────────────────────────────────────────────────
 
@@ -801,12 +801,12 @@ describe('useOfficeChat', () => {
       await new Promise(r => setTimeout(r, 50));
     });
 
-    // The imported agents should now include the plugin agent
-    const imported = getImportedAgents();
-    expect(imported.some(a => a.metadata.name === 'Plugin Agent')).toBe(true);
+    // The plugin agents should now be in the store's pluginAgents
+    const pluginAgents = useSettingsStore.getState().pluginAgents;
+    expect(pluginAgents.some(a => a.metadata.name === 'Plugin Agent')).toBe(true);
 
     // Cleanup
-    setImportedAgents([]);
+    useSettingsStore.getState().setPluginAgents([]);
   });
 
   it('does not include empty text parts in intermediate message content', async () => {


### PR DESCRIPTION
## Fixes

- **PowerPoint agent duplicate**: Used reference equality (\includes(a)\) to detect bundled agents — plugin agents with the same name are different object instances, so they leaked into Custom. Now uses **name-based deduplication**.
- **Plugin agents not showing (SPT IQ etc.)**: \plugin.agents\ notification only updated the module-level variable — \AgentPicker\ had no Zustand subscription to it and never re-rendered. Now calls \store.setPluginAgents()\ which updates a new **\pluginAgents\ store field** (ephemeral, not persisted), triggering a reactive re-render.
- **User-imported agents wiped on session start**: \setImportedAgents(agentConfigs)\ replaced all imported agents with plugin agents. Fixed: \setPluginAgents\ combines plugin + user-imported agents when syncing \gentService\.

72/72 affected tests pass.