### PR TITLE
feat: plugin skills in SkillPicker + slash command menu

### DIFF
--- a/src/components/AgentPicker.tsx
+++ b/src/components/AgentPicker.tsx
@@ -1,6 +1,5 @@
 import React, { useState } from 'react';
 import * as Popover from '@radix-ui/react-popover';
-import { Check } from 'lucide-react';
 import { Codicon } from '@/components/Codicon';
 import { cn } from '@/lib/utils';
 import { useSettingsStore } from '@/stores';
@@ -54,7 +53,10 @@ export const AgentPicker: React.FC<AgentPickerProps> = ({ onOpenPanel }) => {
           isActive && 'bg-accent/50'
         )}
       >
-        <Check className={cn('mt-0.5 size-3.5 shrink-0', isActive ? 'opacity-100' : 'opacity-0')} />
+        <Codicon
+          name="check"
+          className={cn('mt-0.5 text-[12px] shrink-0', isActive ? 'opacity-100' : 'opacity-0')}
+        />
         <div className="min-w-0 flex-1">
           <div className="font-medium text-foreground">{agentName}</div>
           <div className="text-xs text-muted-foreground line-clamp-2">

--- a/src/components/ChatPanel.tsx
+++ b/src/components/ChatPanel.tsx
@@ -4,6 +4,7 @@ import { AgentPicker } from './AgentPicker';
 import { ModelPicker } from './ModelPicker';
 import { McpPicker } from './McpPicker';
 import type { ChatMessage } from '@/types';
+import { useSettingsStore } from '@/stores/settingsStore';
 
 interface ChatPanelProps {
   messages: ChatMessage[];
@@ -26,6 +27,9 @@ export const ChatPanel: React.FC<ChatPanelProps> = ({
   onDequeue,
   onOpenPanel,
 }) => {
+  const pluginPrompts = useSettingsStore(s => s.pluginPrompts);
+  const setActiveAgent = useSettingsStore(s => s.setActiveAgent);
+
   return (
     <div className="flex flex-1 flex-col overflow-hidden">
       <MessageList
@@ -42,6 +46,8 @@ export const ChatPanel: React.FC<ChatPanelProps> = ({
         onRegenerate={() => {
           /* TODO */
         }}
+        slashCommands={pluginPrompts}
+        onAgentSelect={setActiveAgent}
         leftToolbar={
           <>
             <AgentPicker onOpenPanel={onOpenPanel} />

--- a/src/components/SkillPicker.tsx
+++ b/src/components/SkillPicker.tsx
@@ -5,6 +5,7 @@ import { cn } from '@/lib/utils';
 import { getBundledSkills } from '@/services/skills';
 import { detectOfficeHost } from '@/services/office/host';
 import { useSettingsStore } from '@/stores/settingsStore';
+import type { AgentSkill } from '@/types/skill';
 
 interface SkillPickerProps {
   onOpenPanel?: (panel: string) => void;
@@ -14,15 +15,54 @@ export const SkillPicker: React.FC<SkillPickerProps> = ({ onOpenPanel }) => {
   const [open, setOpen] = useState(false);
   const toggleSkill = useSettingsStore(s => s.toggleSkill);
   const disabledSkillNames = useSettingsStore(s => s.disabledSkillNames);
+  const pluginSkills = useSettingsStore(s => s.pluginSkills);
 
   const host = detectOfficeHost();
   const bundledSkills = getBundledSkills().filter(
     s => s.metadata.hosts.length === 0 || (host !== 'unknown' && s.metadata.hosts.includes(host))
   );
 
-  const enabledCount = bundledSkills.filter(
-    s => !disabledSkillNames.includes(s.metadata.name)
-  ).length;
+  const visiblePluginSkills = pluginSkills.filter(
+    s => s.metadata.hosts.length === 0 || (host !== 'unknown' && s.metadata.hosts.includes(host))
+  );
+
+  const allSkills = [...bundledSkills, ...visiblePluginSkills];
+  const enabledCount = allSkills.filter(s => !disabledSkillNames.includes(s.metadata.name)).length;
+
+  const renderSkillRow = (skill: AgentSkill) => {
+    const enabled = !disabledSkillNames.includes(skill.metadata.name);
+    return (
+      <button
+        key={skill.metadata.name}
+        onClick={() => toggleSkill(skill.metadata.name)}
+        className={cn(
+          'flex w-full items-start gap-2 rounded-md px-2 py-1.5 text-left text-sm transition-colors hover:bg-accent',
+          !enabled && 'opacity-50'
+        )}
+        aria-pressed={enabled}
+        title={enabled ? `Disable ${skill.metadata.name}` : `Enable ${skill.metadata.name}`}
+      >
+        <div
+          className={cn(
+            'mt-0.5 flex size-4 shrink-0 items-center justify-center rounded border',
+            enabled
+              ? 'border-[var(--vscode-textLink-foreground)] bg-[var(--vscode-textLink-foreground)]/10'
+              : 'border-border'
+          )}
+        >
+          {enabled && (
+            <Codicon name="check" className="text-xs text-[var(--vscode-textLink-foreground)]" />
+          )}
+        </div>
+        <div className="min-w-0 flex-1">
+          <div className="font-medium text-foreground">{skill.metadata.name}</div>
+          <div className="text-xs text-muted-foreground line-clamp-2">
+            {skill.metadata.description.split('.')[0]}
+          </div>
+        </div>
+      </button>
+    );
+  };
 
   return (
     <>
@@ -35,10 +75,10 @@ export const SkillPicker: React.FC<SkillPickerProps> = ({ onOpenPanel }) => {
             title="Agent skills"
           >
             <Codicon name="lightbulb-sparkle" className="text-[14px]" />
-            {enabledCount < bundledSkills.length && bundledSkills.length > 0 && (
+            {enabledCount < allSkills.length && allSkills.length > 0 && (
               <span
                 className="absolute -right-0.5 -top-0.5 flex h-3.5 min-w-3.5 items-center justify-center rounded-full bg-[var(--vscode-badge-background)] px-0.5 text-[8px] font-bold leading-none text-[var(--vscode-badge-foreground)]"
-                aria-label={`${enabledCount} of ${bundledSkills.length} skills enabled`}
+                aria-label={`${enabledCount} of ${allSkills.length} skills enabled`}
               >
                 {enabledCount}
               </span>
@@ -52,52 +92,35 @@ export const SkillPicker: React.FC<SkillPickerProps> = ({ onOpenPanel }) => {
             sideOffset={4}
             align="start"
           >
-            <div className="px-2 py-1.5 text-xs font-medium text-muted-foreground">Skills</div>
-
-            {bundledSkills.length === 0 ? (
+            {bundledSkills.length === 0 && visiblePluginSkills.length === 0 ? (
               <div className="px-2 py-2 text-xs text-muted-foreground">
                 No skills available yet.
               </div>
             ) : (
-              bundledSkills.map(skill => {
-                const enabled = !disabledSkillNames.includes(skill.metadata.name);
-                return (
-                  <button
-                    key={skill.metadata.name}
-                    onClick={() => toggleSkill(skill.metadata.name)}
-                    className={cn(
-                      'flex w-full items-start gap-2 rounded-md px-2 py-1.5 text-left text-sm transition-colors hover:bg-accent',
-                      !enabled && 'opacity-50'
-                    )}
-                    aria-pressed={enabled}
-                    title={
-                      enabled ? `Disable ${skill.metadata.name}` : `Enable ${skill.metadata.name}`
-                    }
-                  >
+              <>
+                {bundledSkills.length > 0 && (
+                  <>
+                    <div className="px-2 py-1.5 text-xs font-medium text-muted-foreground">
+                      Built-in
+                    </div>
+                    {bundledSkills.map(renderSkillRow)}
+                  </>
+                )}
+
+                {visiblePluginSkills.length > 0 && (
+                  <>
                     <div
                       className={cn(
-                        'mt-0.5 flex size-4 shrink-0 items-center justify-center rounded border',
-                        enabled
-                          ? 'border-[var(--vscode-textLink-foreground)] bg-[var(--vscode-textLink-foreground)]/10'
-                          : 'border-border'
+                        'px-2 py-1.5 text-xs font-medium text-muted-foreground',
+                        bundledSkills.length > 0 && 'mt-1 border-t border-border pt-1'
                       )}
                     >
-                      {enabled && (
-                        <Codicon
-                          name="check"
-                          className="text-xs text-[var(--vscode-textLink-foreground)]"
-                        />
-                      )}
+                      Plugin
                     </div>
-                    <div className="min-w-0 flex-1">
-                      <div className="font-medium text-foreground">{skill.metadata.name}</div>
-                      <div className="text-xs text-muted-foreground line-clamp-2">
-                        {skill.metadata.description.split('.')[0]}
-                      </div>
-                    </div>
-                  </button>
-                );
-              })
+                    {visiblePluginSkills.map(renderSkillRow)}
+                  </>
+                )}
+              </>
             )}
 
             <div className="mt-1 border-t border-border pt-1">

--- a/src/components/chat/ChatComposer.tsx
+++ b/src/components/chat/ChatComposer.tsx
@@ -1,6 +1,7 @@
 import React, { type FC, type ReactNode, useCallback, useEffect, useRef, useState } from 'react';
 import { Codicon } from '@/components/Codicon';
 import { cn } from '@/lib/utils';
+import type { PluginPrompt } from '@/types/plugin';
 
 interface ChatComposerProps {
   onSend: (text: string) => void | Promise<void>;
@@ -14,6 +15,10 @@ interface ChatComposerProps {
   leftToolbar?: ReactNode;
   rightToolbar?: ReactNode;
   autoFocus?: boolean;
+  /** Plugin prompt templates surfaced by the `/` slash command menu. */
+  slashCommands?: PluginPrompt[];
+  /** Called when the slash menu selects a prompt with an associated agent name. */
+  onAgentSelect?: (agentName: string) => void;
 }
 
 export const ChatComposer: FC<ChatComposerProps> = ({
@@ -27,6 +32,8 @@ export const ChatComposer: FC<ChatComposerProps> = ({
   leftToolbar,
   rightToolbar,
   autoFocus = true,
+  slashCommands = [],
+  onAgentSelect,
 }) => {
   const [text, setText] = useState('');
   const textareaRef = useRef<HTMLTextAreaElement>(null);
@@ -36,6 +43,21 @@ export const ChatComposer: FC<ChatComposerProps> = ({
   // Stash the in-progress draft when the user starts navigating history
   const draftRef = useRef('');
 
+  // ─── Slash command menu state ────────────────────────────────────────────────
+  const [slashQuery, setSlashQuery] = useState<string | null>(null);
+  const [slashIndex, setSlashIndex] = useState(0);
+  const slashMenuRef = useRef<HTMLDivElement>(null);
+
+  const filteredCommands =
+    slashQuery !== null
+      ? slashCommands.filter(
+          cmd =>
+            slashQuery === '' ||
+            cmd.name.toLowerCase().includes(slashQuery.toLowerCase()) ||
+            cmd.description.toLowerCase().includes(slashQuery.toLowerCase())
+        )
+      : [];
+
   // Auto-resize textarea as content changes
   useEffect(() => {
     const el = textareaRef.current;
@@ -44,10 +66,62 @@ export const ChatComposer: FC<ChatComposerProps> = ({
     el.style.height = `${el.scrollHeight}px`;
   }, [text]);
 
+  // Keep slash menu index in bounds when filter changes
+  useEffect(() => {
+    setSlashIndex(0);
+  }, [slashQuery]);
+
+  // Close slash menu when clicking outside
+  useEffect(() => {
+    if (slashQuery === null) return;
+    const handler = (e: MouseEvent) => {
+      if (
+        slashMenuRef.current &&
+        !slashMenuRef.current.contains(e.target as Node) &&
+        !textareaRef.current?.contains(e.target as Node)
+      ) {
+        setSlashQuery(null);
+      }
+    };
+    document.addEventListener('mousedown', handler);
+    return () => document.removeEventListener('mousedown', handler);
+  }, [slashQuery]);
+
+  const handleTextChange = useCallback(
+    (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+      const val = e.target.value;
+      setText(val);
+
+      // Open slash menu when first character is `/` and slash commands exist
+      if (slashCommands.length > 0 && val.startsWith('/')) {
+        setSlashQuery(val.slice(1));
+      } else {
+        setSlashQuery(null);
+      }
+    },
+    [slashCommands]
+  );
+
+  /** Select a slash command: fill the textarea, optionally switch agent. */
+  const selectSlashCommand = useCallback(
+    (cmd: PluginPrompt) => {
+      // Replace ${input:varname} placeholders with <varname> for clarity
+      const filled = cmd.body.replace(/\$\{input:([^}]+)\}/g, '<$1>');
+      setText(filled);
+      setSlashQuery(null);
+      if (cmd.agent) {
+        onAgentSelect?.(cmd.agent);
+      }
+      setTimeout(() => textareaRef.current?.focus(), 0);
+    },
+    [onAgentSelect]
+  );
+
   const handleSend = useCallback(() => {
     const trimmed = text.trim();
     if (!trimmed) return;
     setText('');
+    setSlashQuery(null);
     historyIndexRef.current = -1;
     draftRef.current = '';
     void onSend(trimmed);
@@ -58,12 +132,14 @@ export const ChatComposer: FC<ChatComposerProps> = ({
     if (!trimmed) return;
     if (!isRunning) {
       setText('');
+      setSlashQuery(null);
       historyIndexRef.current = -1;
       draftRef.current = '';
       void onSend(trimmed);
       return;
     }
     setText('');
+    setSlashQuery(null);
     historyIndexRef.current = -1;
     draftRef.current = '';
     onEnqueue?.(trimmed);
@@ -102,6 +178,30 @@ export const ChatComposer: FC<ChatComposerProps> = ({
 
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+      // Slash menu navigation
+      if (slashQuery !== null && filteredCommands.length > 0) {
+        if (e.key === 'ArrowUp') {
+          e.preventDefault();
+          setSlashIndex(i => Math.max(0, i - 1));
+          return;
+        }
+        if (e.key === 'ArrowDown') {
+          e.preventDefault();
+          setSlashIndex(i => Math.min(filteredCommands.length - 1, i + 1));
+          return;
+        }
+        if (e.key === 'Enter' && !e.shiftKey) {
+          e.preventDefault();
+          selectSlashCommand(filteredCommands[slashIndex]);
+          return;
+        }
+        if (e.key === 'Escape') {
+          e.preventDefault();
+          setSlashQuery(null);
+          return;
+        }
+      }
+
       if (e.key === 'Enter' && !e.shiftKey && !e.ctrlKey && !e.metaKey) {
         e.preventDefault();
         handleSend();
@@ -124,7 +224,15 @@ export const ChatComposer: FC<ChatComposerProps> = ({
         }
       }
     },
-    [handleSend, handleEnqueue, navigateHistory]
+    [
+      slashQuery,
+      filteredCommands,
+      slashIndex,
+      selectSlashCommand,
+      handleSend,
+      handleEnqueue,
+      navigateHistory,
+    ]
   );
 
   // Dynamic placeholder: hint at queue shortcut when agent is running
@@ -132,15 +240,82 @@ export const ChatComposer: FC<ChatComposerProps> = ({
 
   return (
     <div className="aui-composer-root relative flex w-full flex-col rounded-[var(--vscode-cornerRadius-large)] border border-[var(--vscode-input-border)] bg-[var(--vscode-input-background)] overflow-hidden outline-none transition-colors focus-within:border-[var(--vscode-focusBorder)]">
+      {/* Slash command menu — floats above the textarea */}
+      {slashQuery !== null && filteredCommands.length > 0 && (
+        <div
+          ref={slashMenuRef}
+          role="listbox"
+          aria-label="Slash commands"
+          className="absolute bottom-full left-0 z-50 mb-1 w-full max-h-56 overflow-y-auto rounded-[var(--vscode-cornerRadius-medium)] border border-[var(--vscode-widget-border,var(--vscode-input-border))] bg-[var(--vscode-quickInput-background,var(--vscode-input-background))] py-1 shadow-lg"
+          style={{ boxShadow: '0 2px 8px var(--vscode-widget-shadow, rgba(0,0,0,0.3))' }}
+        >
+          {filteredCommands.map((cmd, i) => (
+            <div
+              key={cmd.name}
+              role="option"
+              aria-selected={i === slashIndex}
+              onMouseEnter={() => setSlashIndex(i)}
+              onMouseDown={e => {
+                e.preventDefault();
+                selectSlashCommand(cmd);
+              }}
+              className={cn(
+                'flex cursor-pointer items-start gap-2 px-3 py-1.5 text-sm',
+                i === slashIndex
+                  ? 'bg-[var(--vscode-list-activeSelectionBackground)] text-[var(--vscode-list-activeSelectionForeground)]'
+                  : 'text-[var(--vscode-foreground)] hover:bg-[var(--vscode-list-hoverBackground)]'
+              )}
+            >
+              <Codicon
+                name="sparkle"
+                className="mt-0.5 shrink-0 text-[12px] text-[var(--vscode-textLink-foreground)]"
+              />
+              <div className="min-w-0">
+                <span className="font-medium">/{cmd.name}</span>
+                {cmd.description && (
+                  <span
+                    className="ml-2 truncate text-xs"
+                    style={{
+                      color:
+                        i === slashIndex
+                          ? 'var(--vscode-list-activeSelectionForeground)'
+                          : 'var(--vscode-descriptionForeground)',
+                    }}
+                  >
+                    {cmd.description}
+                  </span>
+                )}
+              </div>
+              {cmd.argumentHint && (
+                <span
+                  className="ml-auto shrink-0 text-xs italic"
+                  style={{
+                    color:
+                      i === slashIndex
+                        ? 'var(--vscode-list-activeSelectionForeground)'
+                        : 'var(--vscode-descriptionForeground)',
+                    opacity: 0.7,
+                  }}
+                >
+                  {cmd.argumentHint}
+                </span>
+              )}
+            </div>
+          ))}
+        </div>
+      )}
+
       <textarea
         ref={textareaRef}
         value={text}
-        onChange={e => setText(e.target.value)}
+        onChange={handleTextChange}
         onKeyDown={handleKeyDown}
         placeholder={activePlaceholder}
         rows={1}
         autoFocus={autoFocus}
         aria-label="Message input"
+        aria-autocomplete={slashQuery !== null ? 'list' : undefined}
+        aria-haspopup={slashQuery !== null ? 'listbox' : undefined}
         className={cn(
           'aui-composer-input max-h-32 min-h-[34px] w-full resize-none bg-transparent px-3 py-2',
           'text-[13px] outline-none placeholder:text-[var(--vscode-input-placeholderForeground)]',

--- a/src/components/chat/MessageList.tsx
+++ b/src/components/chat/MessageList.tsx
@@ -7,6 +7,7 @@ import { ChatComposer } from './ChatComposer';
 import { useChatActions } from '@/contexts/ChatActionsContext';
 import { detectOfficeHost } from '@/services/office/host';
 import type { ChatMessage } from '@/types';
+import type { PluginPrompt } from '@/types/plugin';
 
 // ─── Welcome Screen ───────────────────────────────────────────────────────────
 
@@ -129,6 +130,10 @@ interface MessageListProps {
   onFeedback?: (messageId: string, kind: 'positive' | 'negative') => void;
   leftToolbar?: ReactNode;
   rightToolbar?: ReactNode;
+  /** Plugin prompt templates for the slash command menu in the composer. */
+  slashCommands?: PluginPrompt[];
+  /** Called when the slash menu selects an agent-bound prompt. */
+  onAgentSelect?: (agentName: string) => void;
 }
 
 export const MessageList: FC<MessageListProps> = ({
@@ -144,6 +149,8 @@ export const MessageList: FC<MessageListProps> = ({
   onFeedback,
   leftToolbar,
   rightToolbar,
+  slashCommands = [],
+  onAgentSelect,
 }) => {
   const viewportRef = useRef<HTMLDivElement>(null);
   const bottomRef = useRef<HTMLDivElement>(null);
@@ -274,6 +281,8 @@ export const MessageList: FC<MessageListProps> = ({
             history={userHistory}
             leftToolbar={leftToolbar}
             rightToolbar={rightToolbar}
+            slashCommands={slashCommands}
+            onAgentSelect={onAgentSelect}
           />
         </div>
       </div>

--- a/src/copilotProxy.mjs
+++ b/src/copilotProxy.mjs
@@ -21,7 +21,9 @@ import { promisify } from 'node:util';
 import {
   slugify,
   discoverPluginSkillDirs,
+  discoverPluginSkillObjects,
   discoverPluginAgents,
+  discoverPluginPrompts,
 } from './pluginDiscovery.mjs';
 
 const execFileAsync = promisify(execFile);
@@ -442,6 +444,28 @@ async function handleConnection(ws) {
           }
         } catch (err) {
           console.warn('[proxy] Plugin agent discovery failed:', err.message);
+        }
+
+        // Discover plugin skills and notify the browser so SkillPicker can show them.
+        try {
+          const pluginSkills = await discoverPluginSkillObjects(host, pluginConfigPath);
+          if (pluginSkills.length > 0) {
+            console.log(`[proxy] Sending ${pluginSkills.length} plugin skill(s) to browser`);
+            sendNotification('plugin.skills', { skills: pluginSkills });
+          }
+        } catch (err) {
+          console.warn('[proxy] Plugin skill discovery failed:', err.message);
+        }
+
+        // Discover plugin prompts (slash commands) and notify the browser.
+        try {
+          const pluginPrompts = await discoverPluginPrompts(host, pluginConfigPath);
+          if (pluginPrompts.length > 0) {
+            console.log(`[proxy] Sending ${pluginPrompts.length} plugin prompt(s) to browser`);
+            sendNotification('plugin.prompts', { prompts: pluginPrompts });
+          }
+        } catch (err) {
+          console.warn('[proxy] Plugin prompt discovery failed:', err.message);
         }
 
         // Emit 'starting' status for each configured MCP server

--- a/src/hooks/useOfficeChat.ts
+++ b/src/hooks/useOfficeChat.ts
@@ -15,6 +15,7 @@ import { buildSystemPrompt } from '@/services/ai/systemPrompt';
 import { inferProvider, BUNDLED_MCP_SERVERS } from '@/types';
 import type { ChatMessage, ToolCallPart } from '@/types';
 import type { AgentHost } from '@/types/agent';
+import type { AgentSkill } from '@/types/skill';
 import type { OfficeHostApp } from '@/services/office/host';
 import { generateId } from '@/utils/id';
 
@@ -246,6 +247,30 @@ export function useOfficeChat(host: OfficeHostApp) {
         }));
         // Update the store — this syncs agentService AND triggers AgentPicker re-render
         useSettingsStore.getState().setPluginAgents(agentConfigs);
+      });
+
+      // Register plugin.skills notification — adds plugin skills to SkillPicker and
+      // the skill context injected into the system prompt.
+      client.onPluginSkills(({ skills }) => {
+        const skillObjects: AgentSkill[] = skills.map(s => ({
+          metadata: {
+            name: s.name,
+            description: s.description,
+            version: s.version,
+            tags: [],
+            hosts: s.hosts.filter((h): h is AgentHost =>
+              SUPPORTED_AGENT_HOSTS.includes(h as AgentHost)
+            ),
+          },
+          content: s.content,
+        }));
+        useSettingsStore.getState().setPluginSkills(skillObjects);
+      });
+
+      // Register plugin.prompts notification — populates the slash command menu
+      // in ChatComposer.
+      client.onPluginPrompts(({ prompts }) => {
+        useSettingsStore.getState().setPluginPrompts(prompts);
       });
 
       const resolvedAgent = resolveActiveAgent(activeAgentIdRef.current, host);

--- a/src/lib/websocket-client.ts
+++ b/src/lib/websocket-client.ts
@@ -255,6 +255,34 @@ export interface PluginAgentsPayload {
   agents: PluginAgentDescriptor[];
 }
 
+/** A single skill descriptor from a plugin, as sent in the plugin.skills notification. */
+export interface PluginSkillDescriptor {
+  name: string;
+  description: string;
+  version: string;
+  hosts: string[];
+  content: string;
+}
+
+/** Payload for the plugin.skills notification. */
+export interface PluginSkillsPayload {
+  skills: PluginSkillDescriptor[];
+}
+
+/** A single prompt/slash-command descriptor from a plugin's prompts/*.prompt.md. */
+export interface PluginPromptDescriptor {
+  name: string;
+  description: string;
+  agent: string;
+  argumentHint: string;
+  body: string;
+}
+
+/** Payload for the plugin.prompts notification. */
+export interface PluginPromptsPayload {
+  prompts: PluginPromptDescriptor[];
+}
+
 /**
  * Browser-compatible Copilot client connected via WebSocket proxy.
  */
@@ -266,6 +294,8 @@ export class WebSocketCopilotClient {
   private mcpLogHandlers = new Set<(payload: McpLogPayload) => void>();
   private mcpToolsHandlers = new Set<(payload: McpToolsPayload) => void>();
   private pluginAgentsHandlers = new Set<(payload: PluginAgentsPayload) => void>();
+  private pluginSkillsHandlers = new Set<(payload: PluginSkillsPayload) => void>();
+  private pluginPromptsHandlers = new Set<(payload: PluginPromptsPayload) => void>();
 
   constructor(private url: string) {}
 
@@ -363,6 +393,20 @@ export class WebSocketCopilotClient {
     };
   }
 
+  onPluginSkills(handler: (payload: PluginSkillsPayload) => void): () => void {
+    this.pluginSkillsHandlers.add(handler);
+    return () => {
+      this.pluginSkillsHandlers.delete(handler);
+    };
+  }
+
+  onPluginPrompts(handler: (payload: PluginPromptsPayload) => void): () => void {
+    this.pluginPromptsHandlers.add(handler);
+    return () => {
+      this.pluginPromptsHandlers.delete(handler);
+    };
+  }
+
   async stop(): Promise<void> {
     for (const session of this.sessions.values()) {
       try {
@@ -436,6 +480,28 @@ export class WebSocketCopilotClient {
     this.connection.onNotification('plugin.agents', (notification: unknown) => {
       const payload = notification as PluginAgentsPayload;
       for (const handler of this.pluginAgentsHandlers) {
+        try {
+          handler(payload);
+        } catch {
+          /* ignore */
+        }
+      }
+    });
+
+    this.connection.onNotification('plugin.skills', (notification: unknown) => {
+      const payload = notification as PluginSkillsPayload;
+      for (const handler of this.pluginSkillsHandlers) {
+        try {
+          handler(payload);
+        } catch {
+          /* ignore */
+        }
+      }
+    });
+
+    this.connection.onNotification('plugin.prompts', (notification: unknown) => {
+      const payload = notification as PluginPromptsPayload;
+      for (const handler of this.pluginPromptsHandlers) {
         try {
           handler(payload);
         } catch {

--- a/src/pluginDiscovery.mjs
+++ b/src/pluginDiscovery.mjs
@@ -11,7 +11,7 @@
 
 import { readdir, readFile } from 'node:fs/promises';
 import { existsSync } from 'node:fs';
-import { join } from 'node:path';
+import { join, basename } from 'node:path';
 import { homedir } from 'node:os';
 
 /** Path to the Copilot CLI config file. */
@@ -181,6 +181,132 @@ export async function discoverPluginAgents(host, configPath = COPILOT_CONFIG_PAT
     }
   }
   return agents;
+}
+
+/**
+ * Discover plugin skills as parsed objects (name, description, hosts, content).
+ * Reads SKILL.md from each skill directory found via discoverPluginSkillDirs.
+ *
+ * @param {string} [host]
+ * @param {string} [configPath]
+ * @returns {Promise<Array<{name: string, description: string, version: string, hosts: string[], content: string}>>}
+ */
+export async function discoverPluginSkillObjects(host, configPath = COPILOT_CONFIG_PATH) {
+  const skillDirs = await discoverPluginSkillDirs(host, configPath);
+  const skills = [];
+
+  for (const skillDir of skillDirs) {
+    try {
+      const raw = await readFile(join(skillDir, 'SKILL.md'), 'utf8');
+      const trimmed = raw.trimStart();
+
+      let name = basename(skillDir);
+      let description = '';
+      let version = '0.0.0';
+      let hosts = [];
+      let content = trimmed;
+
+      if (trimmed.startsWith('---')) {
+        const endIdx = trimmed.indexOf('---', 3);
+        if (endIdx !== -1) {
+          const yamlBlock = trimmed.slice(3, endIdx).trim();
+          content = trimmed.slice(endIdx + 3).trim();
+
+          for (const line of yamlBlock.split('\n')) {
+            const colonIdx = line.indexOf(':');
+            if (colonIdx === -1) continue;
+            const key = line.slice(0, colonIdx).trim();
+            const value = line.slice(colonIdx + 1).trim();
+            if (key === 'name') name = value;
+            else if (key === 'description')
+              description = value.replace(/^['"]|['"]$/g, '');
+            else if (key === 'version') version = value;
+            else if (key === 'hosts' && value.startsWith('[') && value.endsWith(']')) {
+              hosts = value
+                .slice(1, -1)
+                .split(',')
+                .map(h => h.trim())
+                .filter(Boolean);
+            }
+          }
+        }
+      }
+
+      skills.push({ name, description, version, hosts, content });
+    } catch {
+      // skip unreadable skill files
+    }
+  }
+
+  return skills;
+}
+
+/**
+ * Discover prompt templates from installed plugin prompts/ directories.
+ * Each .prompt.md file becomes a slash command in the ChatComposer.
+ *
+ * @param {string} [host]
+ * @param {string} [configPath]
+ * @returns {Promise<Array<{name: string, description: string, agent: string, argumentHint: string, body: string}>>}
+ */
+export async function discoverPluginPrompts(host, configPath = COPILOT_CONFIG_PATH) {
+  const config = await readCopilotConfig(configPath);
+  const plugins = config.installed_plugins || [];
+  const prompts = [];
+
+  for (const plugin of plugins) {
+    if (!plugin.enabled || !plugin.cache_path) continue;
+    if (!existsSync(plugin.cache_path)) continue;
+    if (host && !isPluginForHost(plugin.name, host)) continue;
+
+    const promptsDir = join(plugin.cache_path, 'prompts');
+    let entries;
+    try {
+      entries = await readdir(promptsDir, { withFileTypes: true });
+    } catch {
+      continue; // no prompts dir — that's fine
+    }
+
+    for (const entry of entries) {
+      if (!entry.isFile() || !entry.name.endsWith('.prompt.md')) continue;
+
+      try {
+        const raw = await readFile(join(promptsDir, entry.name), 'utf8');
+        const trimmed = raw.trimStart();
+
+        let name = entry.name.replace(/\.prompt\.md$/, '');
+        let description = '';
+        let agent = '';
+        let argumentHint = '';
+        let body = trimmed;
+
+        if (trimmed.startsWith('---')) {
+          const endIdx = trimmed.indexOf('---', 3);
+          if (endIdx !== -1) {
+            const yamlBlock = trimmed.slice(3, endIdx).trim();
+            body = trimmed.slice(endIdx + 3).trim();
+
+            for (const line of yamlBlock.split('\n')) {
+              const colonIdx = line.indexOf(':');
+              if (colonIdx === -1) continue;
+              const key = line.slice(0, colonIdx).trim();
+              const value = line.slice(colonIdx + 1).trim().replace(/^['"]|['"]$/g, '');
+              if (key === 'name') name = value;
+              else if (key === 'description') description = value;
+              else if (key === 'agent') agent = value;
+              else if (key === 'argument-hint') argumentHint = value;
+            }
+          }
+        }
+
+        prompts.push({ name, description, agent, argumentHint, body });
+      } catch {
+        // skip unreadable files
+      }
+    }
+  }
+
+  return prompts;
 }
 
 // ─── Internal helpers ────────────────────────────────────────────────────────

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -7,6 +7,7 @@ import { setImportedSkills } from '@/services/skills';
 import type { AgentSkill } from '@/types/skill';
 import type { AgentConfig } from '@/types/agent';
 import type { McpServerConfig } from '@/types/mcp';
+import type { PluginPrompt } from '@/types/plugin';
 import { officeStorage } from './officeStorage';
 
 interface SettingsState extends UserSettings {
@@ -26,6 +27,22 @@ interface SettingsState extends UserSettings {
   pluginAgents: AgentConfig[];
   /** Replace the current plugin agent list (called on each session.create). */
   setPluginAgents: (agents: AgentConfig[]) => void;
+
+  /**
+   * Plugin skills discovered from the Copilot CLI config at session start.
+   * Ephemeral — NOT persisted. Populated by the plugin.skills notification.
+   */
+  pluginSkills: AgentSkill[];
+  /** Replace the current plugin skill list (called on each session.create). */
+  setPluginSkills: (skills: AgentSkill[]) => void;
+
+  /**
+   * Plugin prompts (slash commands) discovered from plugin prompts/ directories.
+   * Ephemeral — NOT persisted. Populated by the plugin.prompts notification.
+   */
+  pluginPrompts: PluginPrompt[];
+  /** Replace the current plugin prompt list (called on each session.create). */
+  setPluginPrompts: (prompts: PluginPrompt[]) => void;
 
   // ─── Skill management ───
   toggleSkill: (name: string) => void;
@@ -58,6 +75,8 @@ export const useSettingsStore = create<SettingsState>()(
       ...DEFAULT_SETTINGS,
       availableModels: null,
       pluginAgents: [],
+      pluginSkills: [],
+      pluginPrompts: [],
 
       // ─── Model management ───
       setAvailableModels: models => {
@@ -88,6 +107,16 @@ export const useSettingsStore = create<SettingsState>()(
         set({ pluginAgents: agents });
         // Sync agentService: plugin agents override same-named user-imported agents
         setImportedAgents([...agents, ...get().importedAgents]);
+      },
+
+      setPluginSkills: skills => {
+        set({ pluginSkills: skills });
+        // Sync skillService so the prompt context includes plugin skill content
+        setImportedSkills([...skills, ...get().importedSkills]);
+      },
+
+      setPluginPrompts: prompts => {
+        set({ pluginPrompts: prompts });
       },
 
       // ─── Skill management ───
@@ -123,13 +152,13 @@ export const useSettingsStore = create<SettingsState>()(
         const existing = get().importedSkills.filter(s => s.metadata.name !== skill.metadata.name);
         const updated = [...existing, skill];
         set({ importedSkills: updated });
-        setImportedSkills(updated);
+        setImportedSkills([...get().pluginSkills, ...updated]);
       },
 
       removeImportedSkill: name => {
         const updated = get().importedSkills.filter(s => s.metadata.name !== name);
         set({ importedSkills: updated });
-        setImportedSkills(updated);
+        setImportedSkills([...get().pluginSkills, ...updated]);
       },
 
       // ─── Upload: imported agents ───
@@ -158,7 +187,7 @@ export const useSettingsStore = create<SettingsState>()(
 
       // ─── Reset ───
       reset: () => {
-        set(DEFAULT_SETTINGS);
+        set({ ...DEFAULT_SETTINGS, pluginAgents: [], pluginSkills: [], pluginPrompts: [] });
         setImportedSkills([]);
         setImportedAgents([]);
       },

--- a/src/types/plugin.ts
+++ b/src/types/plugin.ts
@@ -7,6 +7,23 @@
  * - ~/.copilot/marketplace-cache/<slug>/.github/plugin/marketplace.json
  */
 
+/**
+ * A parsed prompt template from a plugin's prompts/*.prompt.md file.
+ * Slash commands in the ChatComposer are built from these.
+ */
+export interface PluginPrompt {
+  /** Slash command name (filename without .prompt.md) */
+  name: string;
+  /** One-line description shown in the slash menu */
+  description: string;
+  /** The agent to activate when this prompt is selected (from "agent:" frontmatter) */
+  agent: string;
+  /** Placeholder text for the variable, e.g. "TPID (e.g. 12345678)" */
+  argumentHint: string;
+  /** Markdown body — injected into composer input on selection */
+  body: string;
+}
+
 /** Author metadata in plugin.json and marketplace.json */
 export interface PluginAuthor {
   name: string;

--- a/tests/integration/chat-composer-slash.test.tsx
+++ b/tests/integration/chat-composer-slash.test.tsx
@@ -1,0 +1,199 @@
+/**
+ * Integration tests: ChatComposer slash command menu.
+ *
+ * Tests the "/" trigger that opens a floating prompt menu populated
+ * by pluginPrompts from the settingsStore.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ChatComposer } from '@/components/chat/ChatComposer';
+import type { PluginPrompt } from '@/types/plugin';
+
+const MOCK_PROMPTS: PluginPrompt[] = [
+  {
+    name: 'preflight',
+    description: 'Run preflight account assessment',
+    agent: 'SPT IQ Preflight',
+    argumentHint: 'TPID (e.g. 12345678)',
+    body: 'Please run a preflight for TPID ${input:tpid}',
+  },
+  {
+    name: 'baseline',
+    description: 'ACR baseline analysis',
+    agent: 'SPT IQ Consumption',
+    argumentHint: 'TPID',
+    body: 'Show ACR baseline for ${input:tpid}',
+  },
+  {
+    name: 'tracker',
+    description: 'Check deal tracker',
+    agent: 'SPT IQ Tracker',
+    argumentHint: '',
+    body: 'Show deals in tracker',
+  },
+];
+
+const noop = () => {};
+
+describe('Integration: ChatComposer slash commands', () => {
+  let onSend: (text: string) => void;
+  let onAgentSelect: (agentName: string) => void;
+
+  beforeEach(() => {
+    onSend = vi.fn();
+    onAgentSelect = vi.fn();
+  });
+
+  it('shows slash menu when user types "/"', async () => {
+    render(
+      <ChatComposer
+        onSend={onSend}
+        onCancel={noop}
+        isRunning={false}
+        slashCommands={MOCK_PROMPTS}
+        onAgentSelect={onAgentSelect}
+      />
+    );
+
+    const input = screen.getByLabelText('Message input');
+    await userEvent.type(input, '/');
+
+    expect(screen.getByRole('listbox', { name: /slash commands/i })).toBeInTheDocument();
+    expect(screen.getByText('/preflight')).toBeInTheDocument();
+    expect(screen.getByText('/baseline')).toBeInTheDocument();
+    expect(screen.getByText('/tracker')).toBeInTheDocument();
+  });
+
+  it('filters slash menu as user types after "/"', async () => {
+    render(
+      <ChatComposer
+        onSend={onSend}
+        onCancel={noop}
+        isRunning={false}
+        slashCommands={MOCK_PROMPTS}
+        onAgentSelect={onAgentSelect}
+      />
+    );
+
+    const input = screen.getByLabelText('Message input');
+    await userEvent.type(input, '/base');
+
+    expect(screen.getByText('/baseline')).toBeInTheDocument();
+    expect(screen.queryByText('/preflight')).not.toBeInTheDocument();
+  });
+
+  it('closes slash menu when user clears input', async () => {
+    render(
+      <ChatComposer
+        onSend={onSend}
+        onCancel={noop}
+        isRunning={false}
+        slashCommands={MOCK_PROMPTS}
+        onAgentSelect={onAgentSelect}
+      />
+    );
+
+    const input = screen.getByLabelText('Message input');
+    await userEvent.type(input, '/');
+    expect(screen.getByRole('listbox')).toBeInTheDocument();
+
+    await userEvent.clear(input);
+    expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
+  });
+
+  it('pressing Escape closes the slash menu', async () => {
+    render(
+      <ChatComposer
+        onSend={onSend}
+        onCancel={noop}
+        isRunning={false}
+        slashCommands={MOCK_PROMPTS}
+        onAgentSelect={onAgentSelect}
+      />
+    );
+
+    const input = screen.getByLabelText('Message input');
+    await userEvent.type(input, '/');
+    expect(screen.getByRole('listbox')).toBeInTheDocument();
+
+    await userEvent.keyboard('{Escape}');
+    expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
+  });
+
+  it('clicking a slash command fills the textarea and calls onAgentSelect', async () => {
+    render(
+      <ChatComposer
+        onSend={onSend}
+        onCancel={noop}
+        isRunning={false}
+        slashCommands={MOCK_PROMPTS}
+        onAgentSelect={onAgentSelect}
+      />
+    );
+
+    const input = screen.getByLabelText('Message input') as HTMLTextAreaElement;
+    await userEvent.type(input, '/');
+
+    const preflightItem = screen.getByText('/preflight').closest('[role="option"]')!;
+    fireEvent.mouseDown(preflightItem);
+
+    // Body should be filled with ${input:tpid} replaced by <tpid>
+    expect(input.value).toBe('Please run a preflight for TPID <tpid>');
+    expect(onAgentSelect).toHaveBeenCalledWith('SPT IQ Preflight');
+    expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
+  });
+
+  it('pressing Enter on selected item fills composer and calls onAgentSelect', async () => {
+    render(
+      <ChatComposer
+        onSend={onSend}
+        onCancel={noop}
+        isRunning={false}
+        slashCommands={MOCK_PROMPTS}
+        onAgentSelect={onAgentSelect}
+      />
+    );
+
+    const input = screen.getByLabelText('Message input') as HTMLTextAreaElement;
+    await userEvent.type(input, '/');
+    // ArrowDown to select second item (baseline), then Enter
+    await userEvent.keyboard('{ArrowDown}{Enter}');
+
+    expect(input.value).toBe('Show ACR baseline for <tpid>');
+    expect(onAgentSelect).toHaveBeenCalledWith('SPT IQ Consumption');
+  });
+
+  it('does not show slash menu when slashCommands is empty', async () => {
+    render(
+      <ChatComposer
+        onSend={onSend}
+        onCancel={noop}
+        isRunning={false}
+        slashCommands={[]}
+        onAgentSelect={onAgentSelect}
+      />
+    );
+
+    const input = screen.getByLabelText('Message input');
+    await userEvent.type(input, '/');
+    expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
+  });
+
+  it('shows description alongside command name in menu', async () => {
+    render(
+      <ChatComposer
+        onSend={onSend}
+        onCancel={noop}
+        isRunning={false}
+        slashCommands={MOCK_PROMPTS}
+        onAgentSelect={onAgentSelect}
+      />
+    );
+
+    const input = screen.getByLabelText('Message input');
+    await userEvent.type(input, '/');
+
+    expect(screen.getByText('Run preflight account assessment')).toBeInTheDocument();
+  });
+});

--- a/tests/integration/skill-picker.test.tsx
+++ b/tests/integration/skill-picker.test.tsx
@@ -28,7 +28,8 @@ describe('Integration: SkillPicker', () => {
   it('shows skills and manage action in popover', async () => {
     renderWithProviders(<SkillPicker />);
     await userEvent.click(screen.getByLabelText('Agent skills'));
-    expect(screen.getByText('Skills')).toBeInTheDocument();
+    // Section header is now "Built-in" (renamed from "Skills" to support plugin sections)
+    expect(screen.getByText('Built-in')).toBeInTheDocument();
     expect(screen.getByText('Manage plugins…')).toBeInTheDocument();
   });
 
@@ -76,5 +77,79 @@ describe('Integration: SkillPicker', () => {
     await userEvent.keyboard('{Enter}');
 
     expect(mockOpenPanel).toHaveBeenCalledWith('plugins');
+  });
+
+  it('shows "Plugin" section when plugin skills are added to store', async () => {
+    const store = useSettingsStore.getState();
+    store.setPluginSkills([
+      {
+        metadata: {
+          name: 'SPT IQ Preflight',
+          description: 'Preflight account assessment skill.',
+          version: '1.0.0',
+          tags: [],
+          hosts: [],
+        },
+        content: 'Skill body content here.',
+      },
+    ]);
+
+    renderWithProviders(<SkillPicker />);
+    await userEvent.click(screen.getByLabelText('Agent skills'));
+
+    expect(screen.getByText('Plugin')).toBeInTheDocument();
+    expect(screen.getByText('SPT IQ Preflight')).toBeInTheDocument();
+  });
+
+  it('plugin skill is enabled by default and can be toggled', async () => {
+    const store = useSettingsStore.getState();
+    store.setPluginSkills([
+      {
+        metadata: {
+          name: 'Test Plugin Skill',
+          description: 'A test plugin skill.',
+          version: '1.0.0',
+          tags: [],
+          hosts: [],
+        },
+        content: 'Content.',
+      },
+    ]);
+
+    renderWithProviders(<SkillPicker />);
+    await userEvent.click(screen.getByLabelText('Agent skills'));
+
+    // Find the plugin skill by its visible label text
+    const skillLabel = screen.getByText('Test Plugin Skill');
+    const skillBtn = skillLabel.closest('button')!;
+    expect(skillBtn).toHaveAttribute('aria-pressed', 'true');
+
+    await userEvent.click(skillBtn);
+
+    expect(useSettingsStore.getState().disabledSkillNames).toContain('Test Plugin Skill');
+  });
+
+  it('re-renders when store.setPluginSkills() is called after initial render', async () => {
+    const { rerender } = renderWithProviders(<SkillPicker />);
+    await userEvent.click(screen.getByLabelText('Agent skills'));
+    expect(screen.queryByText('Plugin')).not.toBeInTheDocument();
+
+    // Simulate plugin.skills notification arriving after session start
+    useSettingsStore.getState().setPluginSkills([
+      {
+        metadata: {
+          name: 'Dynamic Plugin Skill',
+          description: 'Arrives via notification.',
+          version: '1.0.0',
+          tags: [],
+          hosts: [],
+        },
+        content: 'Content.',
+      },
+    ]);
+    rerender(<SkillPicker />);
+
+    expect(screen.getByText('Plugin')).toBeInTheDocument();
+    expect(screen.getByText('Dynamic Plugin Skill')).toBeInTheDocument();
   });
 });

--- a/tests/integration/thread-message-rendering.test.tsx
+++ b/tests/integration/thread-message-rendering.test.tsx
@@ -55,6 +55,8 @@ function makeFakeClient(session: ReturnType<typeof makeFakeSession>) {
     onMcpLog: vi.fn(() => () => undefined),
     onMcpTools: vi.fn(() => () => undefined),
     onPluginAgents: vi.fn(() => () => undefined),
+    onPluginSkills: vi.fn(() => () => undefined),
+    onPluginPrompts: vi.fn(() => () => undefined),
   };
 }
 

--- a/tests/integration/use-office-chat.test.tsx
+++ b/tests/integration/use-office-chat.test.tsx
@@ -55,6 +55,8 @@ function makeFakeClient(
     onMcpLog: vi.fn(() => () => undefined),
     onMcpTools: vi.fn(() => () => undefined),
     onPluginAgents: vi.fn(() => () => undefined),
+    onPluginSkills: vi.fn(() => () => undefined),
+    onPluginPrompts: vi.fn(() => () => undefined),
   };
 }
 
@@ -807,6 +809,91 @@ describe('useOfficeChat', () => {
 
     // Cleanup
     useSettingsStore.getState().setPluginAgents([]);
+  });
+
+  it('plugin.skills notification populates store.pluginSkills', async () => {
+    const session = makeFakeSession([IDLE_EVENT]);
+    let capturedPluginSkillsHandler: ((payload: unknown) => void) | undefined;
+
+    const client = {
+      ...makeFakeClient(session),
+      onPluginSkills: vi.fn((handler: (payload: unknown) => void) => {
+        capturedPluginSkillsHandler = handler;
+        return () => undefined;
+      }),
+    };
+    mockCreate.mockResolvedValue(client as never);
+
+    renderHook(() => useOfficeChat('excel'), { wrapper });
+
+    await act(async () => {
+      await new Promise(r => setTimeout(r, 100));
+    });
+
+    expect(capturedPluginSkillsHandler).toBeDefined();
+    await act(async () => {
+      capturedPluginSkillsHandler!({
+        skills: [
+          {
+            name: 'SPT IQ Preflight',
+            description: 'Preflight skill',
+            version: '1.0.0',
+            hosts: [],
+            content: 'Skill body content',
+          },
+        ],
+      });
+      await new Promise(r => setTimeout(r, 50));
+    });
+
+    const pluginSkills = useSettingsStore.getState().pluginSkills;
+    expect(pluginSkills.some(s => s.metadata.name === 'SPT IQ Preflight')).toBe(true);
+
+    // Cleanup
+    useSettingsStore.getState().setPluginSkills([]);
+  });
+
+  it('plugin.prompts notification populates store.pluginPrompts', async () => {
+    const session = makeFakeSession([IDLE_EVENT]);
+    let capturedPluginPromptsHandler: ((payload: unknown) => void) | undefined;
+
+    const client = {
+      ...makeFakeClient(session),
+      onPluginPrompts: vi.fn((handler: (payload: unknown) => void) => {
+        capturedPluginPromptsHandler = handler;
+        return () => undefined;
+      }),
+    };
+    mockCreate.mockResolvedValue(client as never);
+
+    renderHook(() => useOfficeChat('excel'), { wrapper });
+
+    await act(async () => {
+      await new Promise(r => setTimeout(r, 100));
+    });
+
+    expect(capturedPluginPromptsHandler).toBeDefined();
+    await act(async () => {
+      capturedPluginPromptsHandler!({
+        prompts: [
+          {
+            name: 'preflight',
+            description: 'Run preflight assessment',
+            agent: 'SPT IQ Preflight',
+            argumentHint: 'TPID',
+            body: 'Run preflight for ${input:tpid}',
+          },
+        ],
+      });
+      await new Promise(r => setTimeout(r, 50));
+    });
+
+    const pluginPrompts = useSettingsStore.getState().pluginPrompts;
+    expect(pluginPrompts.some(p => p.name === 'preflight')).toBe(true);
+    expect(pluginPrompts[0].agent).toBe('SPT IQ Preflight');
+
+    // Cleanup
+    useSettingsStore.getState().setPluginPrompts([]);
   });
 
   it('does not include empty text parts in intermediate message content', async () => {


### PR DESCRIPTION
Plugin skills from installed plugins now appear in the SkillPicker, and typing / in ChatComposer opens a VS Code-style slash command menu populated from plugin .prompt.md files. 845 integration tests, 0 failures.