### PR TITLE
feat: plugin MCP server discovery + full pipeline regression tests

### DIFF
--- a/src/copilotProxy.mjs
+++ b/src/copilotProxy.mjs
@@ -24,6 +24,7 @@ import {
   discoverPluginSkillObjects,
   discoverPluginAgents,
   discoverPluginPrompts,
+  discoverPluginMcpServers,
 } from './pluginDiscovery.mjs';
 
 const execFileAsync = promisify(execFile);
@@ -468,8 +469,33 @@ async function handleConnection(ws) {
           console.warn('[proxy] Plugin prompt discovery failed:', err.message);
         }
 
+        // Discover plugin MCP servers and notify the browser so it can surface
+        // them in the MCP manager. Also merge them into the session's mcpServers
+        // so the SDK can connect to them.
+        let mergedMcpServers = { ...(mcpServers || {}) };
+        try {
+          const pluginMcpServers = await discoverPluginMcpServers(host, pluginConfigPath);
+          if (pluginMcpServers.length > 0) {
+            console.log(`[proxy] Sending ${pluginMcpServers.length} plugin MCP server(s) to browser`);
+            sendNotification('plugin.mcp', { servers: pluginMcpServers });
+            // Merge into session mcpServers — plugin servers do NOT override explicitly
+            // configured ones (browser-provided ones take precedence by name).
+            for (const srv of pluginMcpServers) {
+              if (!(srv.name in mergedMcpServers)) {
+                if (srv.transport === 'stdio' && srv.command) {
+                  mergedMcpServers[srv.name] = { type: 'local', command: srv.command, args: srv.args ?? [], env: srv.env ?? {} };
+                } else if (srv.url) {
+                  mergedMcpServers[srv.name] = { type: 'remote', url: srv.url };
+                }
+              }
+            }
+          }
+        } catch (err) {
+          console.warn('[proxy] Plugin MCP server discovery failed:', err.message);
+        }
+
         // Emit 'starting' status for each configured MCP server
-        const mcpServerNames = Object.keys(mcpServers || {});
+        const mcpServerNames = Object.keys(mergedMcpServers);
         for (const name of mcpServerNames) {
           sendNotification('mcp.status', { server: name, status: 'starting' });
           sendNotification('mcp.log', {
@@ -489,7 +515,7 @@ async function handleConnection(ws) {
             sessionId,
             systemMessage,
             tools,
-            mcpServers,
+            mcpServers: mergedMcpServers,
             availableTools,
             skillDirectories,
             disabledSkills: disabledSkills?.length > 0 ? disabledSkills : undefined,

--- a/src/hooks/useOfficeChat.ts
+++ b/src/hooks/useOfficeChat.ts
@@ -273,6 +273,11 @@ export function useOfficeChat(host: OfficeHostApp) {
         useSettingsStore.getState().setPluginPrompts(prompts);
       });
 
+      // Register plugin.mcp notification — populates the plugin MCP server list.
+      client.onPluginMcp(({ servers }) => {
+        useSettingsStore.getState().setPluginMcpServers(servers);
+      });
+
       const resolvedAgent = resolveActiveAgent(activeAgentIdRef.current, host);
 
       // System prompt: base + app prompt + user memories

--- a/src/lib/websocket-client.ts
+++ b/src/lib/websocket-client.ts
@@ -283,6 +283,23 @@ export interface PluginPromptsPayload {
   prompts: PluginPromptDescriptor[];
 }
 
+/** A single MCP server descriptor from a plugin's mcp.json. */
+export interface PluginMcpDescriptor {
+  name: string;
+  description?: string;
+  transport: 'http' | 'sse' | 'stdio';
+  url?: string;
+  headers?: Record<string, string>;
+  command?: string;
+  args?: string[];
+  env?: Record<string, string>;
+}
+
+/** Payload for the plugin.mcp notification. */
+export interface PluginMcpPayload {
+  servers: PluginMcpDescriptor[];
+}
+
 /**
  * Browser-compatible Copilot client connected via WebSocket proxy.
  */
@@ -296,6 +313,7 @@ export class WebSocketCopilotClient {
   private pluginAgentsHandlers = new Set<(payload: PluginAgentsPayload) => void>();
   private pluginSkillsHandlers = new Set<(payload: PluginSkillsPayload) => void>();
   private pluginPromptsHandlers = new Set<(payload: PluginPromptsPayload) => void>();
+  private pluginMcpHandlers = new Set<(payload: PluginMcpPayload) => void>();
 
   constructor(private url: string) {}
 
@@ -407,6 +425,13 @@ export class WebSocketCopilotClient {
     };
   }
 
+  onPluginMcp(handler: (payload: PluginMcpPayload) => void): () => void {
+    this.pluginMcpHandlers.add(handler);
+    return () => {
+      this.pluginMcpHandlers.delete(handler);
+    };
+  }
+
   async stop(): Promise<void> {
     for (const session of this.sessions.values()) {
       try {
@@ -502,6 +527,17 @@ export class WebSocketCopilotClient {
     this.connection.onNotification('plugin.prompts', (notification: unknown) => {
       const payload = notification as PluginPromptsPayload;
       for (const handler of this.pluginPromptsHandlers) {
+        try {
+          handler(payload);
+        } catch {
+          /* ignore */
+        }
+      }
+    });
+
+    this.connection.onNotification('plugin.mcp', (notification: unknown) => {
+      const payload = notification as PluginMcpPayload;
+      for (const handler of this.pluginMcpHandlers) {
         try {
           handler(payload);
         } catch {

--- a/src/pluginDiscovery.d.ts
+++ b/src/pluginDiscovery.d.ts
@@ -11,5 +11,20 @@ declare module '*/pluginDiscovery.mjs' {
     host?: string,
     configPath?: string
   ): Promise<Array<{ name: string; description: string; prompt: string; hosts: string[] }>>;
+  export function discoverPluginMcpServers(
+    host?: string,
+    configPath?: string
+  ): Promise<
+    Array<{
+      name: string;
+      description?: string;
+      transport: 'http' | 'sse' | 'stdio';
+      url?: string;
+      headers?: Record<string, string>;
+      command?: string;
+      args?: string[];
+      env?: Record<string, string>;
+    }>
+  >;
   export const COPILOT_CONFIG_PATH: string;
 }

--- a/src/pluginDiscovery.mjs
+++ b/src/pluginDiscovery.mjs
@@ -309,6 +309,74 @@ export async function discoverPluginPrompts(host, configPath = COPILOT_CONFIG_PA
   return prompts;
 }
 
+/**
+ * Discover MCP server configurations from installed plugin directories.
+ *
+ * For each enabled plugin with a cache_path, reads <cache_path>/mcp.json and
+ * parses it as either Claude Desktop format ({ mcpServers: {} }) or VS Code
+ * format ({ servers: {} }).  Entries are mapped to McpServerConfig objects
+ * compatible with the browser's importedMcpServers store field.
+ *
+ * @param {string} [host] - Office host slug for filtering
+ * @param {string} [configPath] - path to config.json (defaults to COPILOT_CONFIG_PATH)
+ * @returns {Promise<Array<{name: string, description?: string, transport: string, url?: string, command?: string, args?: string[], env?: Record<string,string>}>>}
+ */
+export async function discoverPluginMcpServers(host, configPath = COPILOT_CONFIG_PATH) {
+  const config = await readCopilotConfig(configPath);
+  const plugins = config.installed_plugins || [];
+  const servers = [];
+
+  for (const plugin of plugins) {
+    if (!plugin.enabled || !plugin.cache_path) continue;
+    if (!existsSync(plugin.cache_path)) continue;
+    if (host && !isPluginForHost(plugin.name, host)) continue;
+
+    const mcpJsonPath = join(plugin.cache_path, 'mcp.json');
+    if (!existsSync(mcpJsonPath)) continue;
+
+    let raw;
+    try {
+      raw = JSON.parse(await readFile(mcpJsonPath, 'utf8'));
+    } catch {
+      continue; // malformed JSON — skip
+    }
+
+    // Support both Claude Desktop format { mcpServers: {} } and VS Code format { servers: {} }
+    const serversMap = raw.mcpServers ?? raw.servers ?? {};
+
+    for (const [name, entry] of Object.entries(serversMap)) {
+      if (!entry || typeof entry !== 'object') continue;
+
+      const description = entry.description ?? `MCP server '${name}' from plugin ${plugin.name}`;
+
+      if (entry.command) {
+        // stdio transport
+        servers.push({
+          name,
+          description,
+          transport: 'stdio',
+          command: entry.command,
+          args: Array.isArray(entry.args) ? entry.args : [],
+          env: entry.env && typeof entry.env === 'object' ? entry.env : undefined,
+        });
+      } else if (entry.url) {
+        // HTTP or SSE transport
+        const transport = entry.type === 'sse' || entry.transport === 'sse' ? 'sse' : 'http';
+        servers.push({
+          name,
+          description,
+          transport,
+          url: entry.url,
+          headers: entry.headers && typeof entry.headers === 'object' ? entry.headers : undefined,
+        });
+      }
+      // Entries with neither command nor url are skipped (invalid)
+    }
+  }
+
+  return servers;
+}
+
 // ─── Internal helpers ────────────────────────────────────────────────────────
 
 const HOST_PREFIXES = ['excel', 'powerpoint', 'word', 'outlook'];

--- a/src/stores/settingsStore.ts
+++ b/src/stores/settingsStore.ts
@@ -44,6 +44,14 @@ interface SettingsState extends UserSettings {
   /** Replace the current plugin prompt list (called on each session.create). */
   setPluginPrompts: (prompts: PluginPrompt[]) => void;
 
+  /**
+   * MCP servers discovered from plugin mcp.json files.
+   * Ephemeral — NOT persisted. Populated by the plugin.mcp notification.
+   */
+  pluginMcpServers: McpServerConfig[];
+  /** Replace the current plugin MCP server list (called on each session.create). */
+  setPluginMcpServers: (servers: McpServerConfig[]) => void;
+
   // ─── Skill management ───
   toggleSkill: (name: string) => void;
   isSkillEnabled: (name: string) => boolean;
@@ -77,6 +85,7 @@ export const useSettingsStore = create<SettingsState>()(
       pluginAgents: [],
       pluginSkills: [],
       pluginPrompts: [],
+      pluginMcpServers: [],
 
       // ─── Model management ───
       setAvailableModels: models => {
@@ -117,6 +126,10 @@ export const useSettingsStore = create<SettingsState>()(
 
       setPluginPrompts: prompts => {
         set({ pluginPrompts: prompts });
+      },
+
+      setPluginMcpServers: servers => {
+        set({ pluginMcpServers: servers });
       },
 
       // ─── Skill management ───
@@ -187,7 +200,13 @@ export const useSettingsStore = create<SettingsState>()(
 
       // ─── Reset ───
       reset: () => {
-        set({ ...DEFAULT_SETTINGS, pluginAgents: [], pluginSkills: [], pluginPrompts: [] });
+        set({
+          ...DEFAULT_SETTINGS,
+          pluginAgents: [],
+          pluginSkills: [],
+          pluginPrompts: [],
+          pluginMcpServers: [],
+        });
         setImportedSkills([]);
         setImportedAgents([]);
       },

--- a/tests/fixtures/test-plugin/agents/test-excel-agent.agent.md
+++ b/tests/fixtures/test-plugin/agents/test-excel-agent.agent.md
@@ -1,0 +1,11 @@
+---
+name: Test Excel Agent
+description: A regression-test agent that helps with Excel analysis tasks.
+version: 1.0.0
+hosts: [excel]
+defaultForHosts: []
+---
+
+You are a specialised Excel analysis agent used in regression tests.
+
+When the user asks for help, provide concise Excel-focused answers.

--- a/tests/fixtures/test-plugin/mcp.json
+++ b/tests/fixtures/test-plugin/mcp.json
@@ -1,0 +1,9 @@
+{
+  "mcpServers": {
+    "test-excel-mcp": {
+      "command": "node",
+      "args": ["--version"],
+      "description": "Regression-test MCP server (echo node version — not a real server)."
+    }
+  }
+}

--- a/tests/fixtures/test-plugin/plugin.json
+++ b/tests/fixtures/test-plugin/plugin.json
@@ -1,0 +1,6 @@
+{
+  "name": "office-excel-test-plugin",
+  "description": "Regression test plugin — verifies agents, skills, prompts, and MCP servers are discovered and surfaced in the add-in UI.",
+  "version": "1.0.0",
+  "author": "test"
+}

--- a/tests/fixtures/test-plugin/prompts/test-excel-prompt.prompt.md
+++ b/tests/fixtures/test-plugin/prompts/test-excel-prompt.prompt.md
@@ -1,0 +1,11 @@
+---
+name: test-excel-prompt
+description: Analyse a named Excel range and summarise the data.
+agent: Test Excel Agent
+argument-hint: Range name (e.g. SalesData)
+---
+
+Please analyse the Excel range "${input:rangeName}" and provide:
+1. A summary of the data (row/column count, data types).
+2. Key statistics (min, max, average where applicable).
+3. Any obvious data quality issues.

--- a/tests/fixtures/test-plugin/skills/test-excel-skill/SKILL.md
+++ b/tests/fixtures/test-plugin/skills/test-excel-skill/SKILL.md
@@ -1,0 +1,16 @@
+---
+name: test-excel-skill
+description: A regression-test skill providing Excel best-practice guidance.
+version: 1.2.0
+hosts: [excel]
+---
+
+# Test Excel Skill
+
+This skill provides guidance on Excel best practices for regression testing.
+
+## Guidelines
+
+- Always validate input ranges before performing calculations.
+- Use named ranges for clarity.
+- Prefer structured table references over A1 notation in formulas.

--- a/tests/integration/copilot-plugin-e2e.integration.test.ts
+++ b/tests/integration/copilot-plugin-e2e.integration.test.ts
@@ -18,7 +18,12 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { randomUUID } from 'node:crypto';
 import { createWebSocketClient } from '@/lib/websocket-client';
-import type { PluginSkillsPayload, PluginPromptsPayload } from '@/lib/websocket-client';
+import type {
+  PluginAgentsPayload,
+  PluginSkillsPayload,
+  PluginPromptsPayload,
+  PluginMcpPayload,
+} from '@/lib/websocket-client';
 
 const SERVER_URL = 'wss://localhost:3000/api/copilot';
 const TIMEOUT_MS = 45_000;
@@ -467,6 +472,139 @@ ${promptBody}`,
         expect(prompt!.agent).toBe(agentName);
         expect(prompt!.argumentHint).toBe(argumentHint);
         expect(prompt!.body).toContain('${input:accountId}');
+      } finally {
+        await client.stop();
+      }
+    },
+    TIMEOUT_MS
+  );
+
+  it(
+    'proxy sends plugin.agents notification with correct agent metadata',
+    async () => {
+      const agentName = `E2E Agent ${randomUUID().replace(/-/g, '').slice(0, 8)}`;
+      const agentDescription = 'E2E integration test custom agent description';
+
+      const pluginDir = await makePluginDir();
+      const agentsDir = join(pluginDir, 'agents');
+      const agentFileName = `custom-agent-${randomUUID().replace(/-/g, '').slice(0, 8)}`;
+      await mkdir(agentsDir, { recursive: true });
+      await writeFile(
+        join(agentsDir, `${agentFileName}.agent.md`),
+        `---
+name: ${agentName}
+description: ${agentDescription}
+version: 2.0.0
+hosts: [excel]
+defaultForHosts: []
+---
+
+You are a custom E2E test agent. Reply concisely.`,
+        'utf8'
+      );
+
+      const configDir = await makePluginDir();
+      const configPath = await makeConfigFile(configDir, [
+        { name: 'office-excel', enabled: true, cache_path: pluginDir },
+      ]);
+
+      const client = await createWebSocketClient(SERVER_URL);
+      try {
+        let receivedAgentsPayload: PluginAgentsPayload | undefined;
+        const agentsReceived = new Promise<void>(resolve => {
+          client.onPluginAgents(payload => {
+            receivedAgentsPayload = payload;
+            resolve();
+          });
+        });
+
+        const NOTIF_TIMEOUT = 30_000;
+        await Promise.all([
+          client.createSession({
+            host: 'excel',
+            pluginConfigPath: configPath,
+          }),
+          Promise.race([
+            agentsReceived,
+            new Promise<void>((_, reject) =>
+              setTimeout(
+                () => reject(new Error('plugin.agents notification timed out')),
+                NOTIF_TIMEOUT
+              )
+            ),
+          ]),
+        ]);
+
+        expect(receivedAgentsPayload).toBeDefined();
+        // The proxy uses the filename stem as the agent name; find by unique description
+        const agent = receivedAgentsPayload!.agents.find(a => a.description === agentDescription);
+        expect(agent).toBeDefined();
+        expect(agent!.hosts).toContain('excel');
+      } finally {
+        await client.stop();
+      }
+    },
+    TIMEOUT_MS
+  );
+
+  it(
+    'proxy sends plugin.mcp notification with correct MCP server metadata',
+    async () => {
+      const serverName = `e2e-mcp-${randomUUID().replace(/-/g, '').slice(0, 8)}`;
+
+      const pluginDir = await makePluginDir();
+      await writeFile(
+        join(pluginDir, 'mcp.json'),
+        JSON.stringify({
+          mcpServers: {
+            [serverName]: {
+              command: 'node',
+              args: ['--version'],
+              description: 'E2E regression test MCP server',
+            },
+          },
+        }),
+        'utf8'
+      );
+
+      const configDir = await makePluginDir();
+      const configPath = await makeConfigFile(configDir, [
+        { name: 'office-excel', enabled: true, cache_path: pluginDir },
+      ]);
+
+      const client = await createWebSocketClient(SERVER_URL);
+      try {
+        let receivedMcpPayload: PluginMcpPayload | undefined;
+        const mcpReceived = new Promise<void>(resolve => {
+          client.onPluginMcp(payload => {
+            receivedMcpPayload = payload;
+            resolve();
+          });
+        });
+
+        const NOTIF_TIMEOUT = 30_000;
+        await Promise.all([
+          client.createSession({
+            host: 'excel',
+            pluginConfigPath: configPath,
+          }),
+          Promise.race([
+            mcpReceived,
+            new Promise<void>((_, reject) =>
+              setTimeout(
+                () => reject(new Error('plugin.mcp notification timed out')),
+                NOTIF_TIMEOUT
+              )
+            ),
+          ]),
+        ]);
+
+        expect(receivedMcpPayload).toBeDefined();
+        const srv = receivedMcpPayload!.servers.find(s => s.name === serverName);
+        expect(srv).toBeDefined();
+        expect(srv!.transport).toBe('stdio');
+        expect(srv!.command).toBe('node');
+        expect(srv!.args).toEqual(['--version']);
       } finally {
         await client.stop();
       }

--- a/tests/integration/copilot-plugin-e2e.integration.test.ts
+++ b/tests/integration/copilot-plugin-e2e.integration.test.ts
@@ -18,6 +18,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { randomUUID } from 'node:crypto';
 import { createWebSocketClient } from '@/lib/websocket-client';
+import type { PluginSkillsPayload, PluginPromptsPayload } from '@/lib/websocket-client';
 
 const SERVER_URL = 'wss://localhost:3000/api/copilot';
 const TIMEOUT_MS = 45_000;
@@ -317,6 +318,155 @@ The secret phrase is: ${SENTINEL}`,
         }
 
         expect(fullText).not.toContain(SENTINEL);
+      } finally {
+        await client.stop();
+      }
+    },
+    TIMEOUT_MS
+  );
+
+  it(
+    'proxy sends plugin.skills notification with correct skill metadata',
+    async () => {
+      const skillName = `e2e-skill-${randomUUID().replace(/-/g, '').slice(0, 8)}`;
+      const skillDescription = 'E2E integration test skill description';
+
+      const pluginDir = await makePluginDir();
+      const skillDir = join(pluginDir, 'skills', skillName);
+      await mkdir(skillDir, { recursive: true });
+      await writeFile(
+        join(skillDir, 'SKILL.md'),
+        `---
+name: ${skillName}
+description: ${skillDescription}
+version: 2.1.0
+hosts: [excel]
+---
+
+# ${skillName}
+
+Skill body content for E2E test.`,
+        'utf8'
+      );
+
+      const configDir = await makePluginDir();
+      const configPath = await makeConfigFile(configDir, [
+        { name: 'office-excel', enabled: true, cache_path: pluginDir },
+      ]);
+
+      const client = await createWebSocketClient(SERVER_URL);
+      try {
+        // Capture the plugin.skills notification that the proxy sends DURING session.create
+        // (before the session.create response arrives). Race the notification against
+        // the full session creation so we don't miss it if event-loop scheduling delays
+        // the callback slightly past when createSession() returns.
+        let receivedSkillsPayload: PluginSkillsPayload | undefined;
+        const skillsReceived = new Promise<void>(resolve => {
+          client.onPluginSkills(payload => {
+            receivedSkillsPayload = payload;
+            resolve();
+          });
+        });
+
+        // Run createSession and the notification race concurrently.
+        // The notification is sent before the session.create response so it typically
+        // arrives while createSession() is still awaiting — but we race with 30s to
+        // be resilient to any Node.js event-loop scheduling variances.
+        const NOTIF_TIMEOUT = 30_000;
+        await Promise.all([
+          client.createSession({
+            host: 'excel',
+            pluginConfigPath: configPath,
+          }),
+          Promise.race([
+            skillsReceived,
+            new Promise<void>((_, reject) =>
+              setTimeout(
+                () => reject(new Error('plugin.skills notification timed out')),
+                NOTIF_TIMEOUT
+              )
+            ),
+          ]),
+        ]);
+
+        expect(receivedSkillsPayload).toBeDefined();
+        const skill = receivedSkillsPayload!.skills.find(s => s.name === skillName);
+        expect(skill).toBeDefined();
+        expect(skill!.description).toBe(skillDescription);
+        expect(skill!.version).toBe('2.1.0');
+        expect(skill!.hosts).toContain('excel');
+        expect(skill!.content).toContain(`# ${skillName}`);
+      } finally {
+        await client.stop();
+      }
+    },
+    TIMEOUT_MS
+  );
+
+  it(
+    'proxy sends plugin.prompts notification with correct prompt metadata',
+    async () => {
+      const promptName = `e2e-prompt-${randomUUID().replace(/-/g, '').slice(0, 8)}`;
+      const promptDescription = 'E2E test prompt description';
+      const agentName = 'E2E Test Agent';
+      const argumentHint = 'Account ID';
+      const promptBody = 'Please analyse account ${input:accountId} in detail.';
+
+      const pluginDir = await makePluginDir();
+      const promptsDir = join(pluginDir, 'prompts');
+      await mkdir(promptsDir, { recursive: true });
+      await writeFile(
+        join(promptsDir, `${promptName}.prompt.md`),
+        `---
+name: ${promptName}
+description: '${promptDescription}'
+agent: "${agentName}"
+argument-hint: '${argumentHint}'
+---
+
+${promptBody}`,
+        'utf8'
+      );
+
+      const configDir = await makePluginDir();
+      const configPath = await makeConfigFile(configDir, [
+        { name: 'office-excel', enabled: true, cache_path: pluginDir },
+      ]);
+
+      const client = await createWebSocketClient(SERVER_URL);
+      try {
+        let receivedPromptsPayload: PluginPromptsPayload | undefined;
+        const promptsReceived = new Promise<void>(resolve => {
+          client.onPluginPrompts(payload => {
+            receivedPromptsPayload = payload;
+            resolve();
+          });
+        });
+
+        const NOTIF_TIMEOUT = 30_000;
+        await Promise.all([
+          client.createSession({
+            host: 'excel',
+            pluginConfigPath: configPath,
+          }),
+          Promise.race([
+            promptsReceived,
+            new Promise<void>((_, reject) =>
+              setTimeout(
+                () => reject(new Error('plugin.prompts notification timed out')),
+                NOTIF_TIMEOUT
+              )
+            ),
+          ]),
+        ]);
+
+        expect(receivedPromptsPayload).toBeDefined();
+        const prompt = receivedPromptsPayload!.prompts.find(p => p.name === promptName);
+        expect(prompt).toBeDefined();
+        expect(prompt!.description).toBe(promptDescription);
+        expect(prompt!.agent).toBe(agentName);
+        expect(prompt!.argumentHint).toBe(argumentHint);
+        expect(prompt!.body).toContain('${input:accountId}');
       } finally {
         await client.stop();
       }

--- a/tests/integration/plugin-pipeline.test.tsx
+++ b/tests/integration/plugin-pipeline.test.tsx
@@ -1,0 +1,317 @@
+/**
+ * Integration tests: full plugin pipeline regression suite.
+ *
+ * Verifies all 4 plugin asset types (agents, skills, prompts, MCP servers) are:
+ *   - Discoverable from the fixture test-plugin directory
+ *   - Stored in the Zustand settings store
+ *   - Visible in the UI components (AgentPicker, SkillPicker, ChatComposer)
+ *
+ * No live server required — uses store manipulation + fixture files on disk.
+ */
+
+// @vitest-environment jsdom
+import { describe, it, expect, beforeEach, afterAll } from 'vitest';
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { renderWithProviders } from '../test-utils';
+import { AgentPicker } from '@/components/AgentPicker';
+import { SkillPicker } from '@/components/SkillPicker';
+import { ChatComposer } from '@/components/chat/ChatComposer';
+import { useSettingsStore } from '@/stores/settingsStore';
+import { parseAgentFrontmatter } from '@/services/agents';
+import type { McpServerConfig } from '@/types/mcp';
+import { writeFile, mkdir, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { randomUUID } from 'node:crypto';
+
+// Path to the persistent fixture test-plugin
+const FIXTURE_PLUGIN_DIR = resolve(__dirname, '../fixtures/test-plugin');
+
+beforeEach(() => {
+  useSettingsStore.getState().reset();
+});
+
+// ─── [A] AgentPicker shows plugin agent ───────────────────────────────────────
+
+describe('[A] Plugin agent visible in AgentPicker', () => {
+  it('custom plugin agent appears in the dropdown after setPluginAgents', async () => {
+    const customAgent = parseAgentFrontmatter(`---
+name: Test Excel Agent
+description: A regression-test agent that helps with Excel analysis tasks.
+version: 1.0.0
+hosts: [excel]
+defaultForHosts: []
+---
+You are a specialised Excel analysis agent used in regression tests.`);
+
+    useSettingsStore.getState().setPluginAgents([customAgent]);
+    renderWithProviders(<AgentPicker />);
+
+    await userEvent.click(screen.getByLabelText('Select agent'));
+
+    // Plugin agent name must appear in the picker dropdown
+    expect(screen.getByText('Test Excel Agent')).toBeInTheDocument();
+  });
+
+  it('custom plugin agent is selectable and updates the store', async () => {
+    const customAgent = parseAgentFrontmatter(`---
+name: Test Excel Agent
+description: A regression-test agent that helps with Excel analysis tasks.
+version: 1.0.0
+hosts: [excel]
+defaultForHosts: []
+---
+You are a specialised Excel analysis agent.`);
+
+    useSettingsStore.getState().setPluginAgents([customAgent]);
+    renderWithProviders(<AgentPicker />);
+
+    await userEvent.click(screen.getByLabelText('Select agent'));
+    // Click the agent by its text label (existing pattern from agent-picker.test.tsx)
+    await userEvent.click(screen.getByText('Test Excel Agent'));
+
+    expect(useSettingsStore.getState().activeAgentId).toBe('Test Excel Agent');
+  });
+
+  it('clearing pluginAgents removes the custom agent from the dropdown', async () => {
+    const customAgent = parseAgentFrontmatter(`---
+name: TemporaryPluginAgent
+description: Will be removed.
+version: 1.0.0
+hosts: [excel]
+defaultForHosts: []
+---
+Temp.`);
+
+    useSettingsStore.getState().setPluginAgents([customAgent]);
+    const { unmount } = renderWithProviders(<AgentPicker />);
+    unmount();
+
+    useSettingsStore.getState().setPluginAgents([]);
+    renderWithProviders(<AgentPicker />);
+
+    await userEvent.click(screen.getByLabelText('Select agent'));
+    expect(screen.queryByText('TemporaryPluginAgent')).not.toBeInTheDocument();
+  });
+});
+
+// ─── [B] SkillPicker shows plugin skill ───────────────────────────────────────
+
+describe('[B] Plugin skill visible in SkillPicker', () => {
+  it('plugin skill appears under "Plugin" section after setPluginSkills', async () => {
+    useSettingsStore.getState().setPluginSkills([
+      {
+        metadata: {
+          name: 'test-excel-skill',
+          description: 'A regression-test skill providing Excel best-practice guidance.',
+          version: '1.2.0',
+          tags: [],
+          hosts: ['excel'],
+        },
+        content: '# Test Excel Skill\n\nGuidance content.',
+      },
+    ]);
+
+    renderWithProviders(<SkillPicker />);
+
+    await userEvent.click(screen.getByLabelText('Agent skills'));
+
+    // Skill name must be visible
+    expect(screen.getByText('test-excel-skill')).toBeInTheDocument();
+  });
+
+  it('clearing pluginSkills removes the skill from the picker', async () => {
+    useSettingsStore.getState().setPluginSkills([
+      {
+        metadata: {
+          name: 'temp-plugin-skill',
+          description: 'Temporary skill',
+          version: '1.0.0',
+          tags: [],
+          hosts: [],
+        },
+        content: '# Temp',
+      },
+    ]);
+
+    const { unmount } = renderWithProviders(<SkillPicker />);
+    unmount();
+
+    useSettingsStore.getState().setPluginSkills([]);
+    renderWithProviders(<SkillPicker />);
+
+    await userEvent.click(screen.getByLabelText('Agent skills'));
+    expect(screen.queryByText('temp-plugin-skill')).not.toBeInTheDocument();
+  });
+});
+
+// ─── [C] ChatComposer slash menu shows plugin prompts ─────────────────────────
+
+describe('[C] Plugin prompts visible in ChatComposer slash menu', () => {
+  it('plugin prompt appears in the slash command menu when "/" is typed', async () => {
+    const prompts = [
+      {
+        name: 'test-excel-prompt',
+        description: 'Analyse a named Excel range and summarise the data.',
+        agent: 'Test Excel Agent',
+        argumentHint: 'Range name (e.g. SalesData)',
+        body: 'Please analyse the Excel range "${input:rangeName}".',
+      },
+    ];
+
+    renderWithProviders(
+      <ChatComposer
+        onSend={async () => {}}
+        onCancel={() => {}}
+        isRunning={false}
+        slashCommands={prompts}
+      />
+    );
+
+    const input = screen.getByLabelText('Message input');
+    await userEvent.type(input, '/');
+
+    // Prompt name appears prefixed with "/" in the slash command dropdown
+    expect(screen.getByRole('listbox', { name: /slash commands/i })).toBeInTheDocument();
+    expect(screen.getByText('/test-excel-prompt')).toBeInTheDocument();
+  });
+});
+
+// ─── [D] Store holds plugin MCP servers ───────────────────────────────────────
+
+describe('[D] pluginMcpServers store field', () => {
+  it('setPluginMcpServers populates pluginMcpServers in the store', () => {
+    const server: McpServerConfig = {
+      name: 'test-excel-mcp',
+      description: 'Regression-test MCP server',
+      transport: 'stdio',
+      command: 'node',
+      args: ['--version'],
+    };
+
+    useSettingsStore.getState().setPluginMcpServers([server]);
+
+    const stored = useSettingsStore.getState().pluginMcpServers;
+    expect(stored).toHaveLength(1);
+    expect(stored[0].name).toBe('test-excel-mcp');
+    expect(stored[0].command).toBe('node');
+    expect(stored[0].transport).toBe('stdio');
+  });
+
+  it('reset() clears pluginMcpServers back to empty array', () => {
+    useSettingsStore.getState().setPluginMcpServers([
+      { name: 'my-mcp', transport: 'http', url: 'http://localhost:3001' },
+    ]);
+
+    expect(useSettingsStore.getState().pluginMcpServers).toHaveLength(1);
+
+    useSettingsStore.getState().reset();
+    expect(useSettingsStore.getState().pluginMcpServers).toHaveLength(0);
+  });
+
+  it('initial pluginMcpServers is an empty array', () => {
+    expect(useSettingsStore.getState().pluginMcpServers).toEqual([]);
+  });
+});
+
+// ─── [E] discoverPluginMcpServers reads fixture mcp.json ──────────────────────
+
+describe('[E] discoverPluginMcpServers reads fixture test-plugin', () => {
+  const tempDirs: string[] = [];
+
+  afterAll(async () => {
+    await Promise.all(tempDirs.map(d => rm(d, { recursive: true, force: true })));
+  });
+
+  it('discovers test-excel-mcp server from fixture plugin mcp.json', async () => {
+    const configDir = join(tmpdir(), `oca-plugin-pipe-${randomUUID()}`);
+    await mkdir(configDir, { recursive: true });
+    tempDirs.push(configDir);
+
+    const configPath = join(configDir, 'config.json');
+    await writeFile(
+      configPath,
+      JSON.stringify({
+        installed_plugins: [
+          {
+            name: 'office-excel-test-plugin',
+            marketplace: 'test',
+            version: '1.0.0',
+            installed_at: new Date().toISOString(),
+            enabled: true,
+            cache_path: FIXTURE_PLUGIN_DIR,
+          },
+        ],
+      }),
+      'utf8'
+    );
+
+    const { discoverPluginMcpServers } = await import('../../src/pluginDiscovery.mjs');
+    const servers = await discoverPluginMcpServers('excel', configPath);
+
+    expect(servers).toHaveLength(1);
+    const srv = servers[0];
+    expect(srv.name).toBe('test-excel-mcp');
+    expect(srv.transport).toBe('stdio');
+    expect(srv.command).toBe('node');
+    expect(srv.args).toEqual(['--version']);
+  });
+
+  it('returns empty array when plugin is disabled', async () => {
+    const configDir = join(tmpdir(), `oca-plugin-pipe-${randomUUID()}`);
+    await mkdir(configDir, { recursive: true });
+    tempDirs.push(configDir);
+
+    const configPath = join(configDir, 'config.json');
+    await writeFile(
+      configPath,
+      JSON.stringify({
+        installed_plugins: [
+          {
+            name: 'office-excel-test-plugin',
+            marketplace: 'test',
+            version: '1.0.0',
+            installed_at: new Date().toISOString(),
+            enabled: false,
+            cache_path: FIXTURE_PLUGIN_DIR,
+          },
+        ],
+      }),
+      'utf8'
+    );
+
+    const { discoverPluginMcpServers } = await import('../../src/pluginDiscovery.mjs');
+    const servers = await discoverPluginMcpServers('excel', configPath);
+    expect(servers).toHaveLength(0);
+  });
+
+  it('returns empty array when host does not match plugin name', async () => {
+    const configDir = join(tmpdir(), `oca-plugin-pipe-${randomUUID()}`);
+    await mkdir(configDir, { recursive: true });
+    tempDirs.push(configDir);
+
+    const configPath = join(configDir, 'config.json');
+    await writeFile(
+      configPath,
+      JSON.stringify({
+        installed_plugins: [
+          {
+            name: 'office-excel-test-plugin',
+            marketplace: 'test',
+            version: '1.0.0',
+            installed_at: new Date().toISOString(),
+            enabled: true,
+            cache_path: FIXTURE_PLUGIN_DIR,
+          },
+        ],
+      }),
+      'utf8'
+    );
+
+    const { discoverPluginMcpServers } = await import('../../src/pluginDiscovery.mjs');
+    // Host is 'powerpoint' but plugin name contains 'excel' → should be skipped
+    const servers = await discoverPluginMcpServers('powerpoint', configPath);
+    expect(servers).toHaveLength(0);
+  });
+});

--- a/tests/integration/thread-message-rendering.test.tsx
+++ b/tests/integration/thread-message-rendering.test.tsx
@@ -57,6 +57,7 @@ function makeFakeClient(session: ReturnType<typeof makeFakeSession>) {
     onPluginAgents: vi.fn(() => () => undefined),
     onPluginSkills: vi.fn(() => () => undefined),
     onPluginPrompts: vi.fn(() => () => undefined),
+    onPluginMcp: vi.fn(() => () => undefined),
   };
 }
 

--- a/tests/integration/use-office-chat.test.tsx
+++ b/tests/integration/use-office-chat.test.tsx
@@ -57,6 +57,7 @@ function makeFakeClient(
     onPluginAgents: vi.fn(() => () => undefined),
     onPluginSkills: vi.fn(() => () => undefined),
     onPluginPrompts: vi.fn(() => () => undefined),
+    onPluginMcp: vi.fn(() => () => undefined),
   };
 }
 


### PR DESCRIPTION
Adds plugin MCP server discovery (discoverPluginMcpServers, plugin.mcp notification, store field, websocket handler) plus a full regression test suite covering all 4 plugin asset types (agents, skills, prompts, MCP servers). Adds persistent fixture plugin under tests/fixtures/test-plugin/ and 12 new non-server tests in plugin-pipeline.test.tsx, plus live E2E tests for plugin.agents and plugin.mcp notifications. All 861 integration tests pass.