### PR TITLE
Fix adaptive custom agent layering

### DIFF
--- a/src/hooks/useOfficeChat.ts
+++ b/src/hooks/useOfficeChat.ts
@@ -4,13 +4,18 @@ import type { WebSocketCopilotClient, BrowserCopilotSession } from '@/lib/websoc
 import type { PermissionRequestPayload } from '@/lib/websocket-client';
 import { createWebSocketClient } from '@/lib/websocket-client';
 import { getToolsForHost } from '@/tools';
-import { resolveActiveAgent, getAgents, SUPPORTED_AGENT_HOSTS } from '@/services/agents';
+import {
+  resolveActiveAgent,
+  getDefaultAgent,
+  getAgents,
+  SUPPORTED_AGENT_HOSTS,
+} from '@/services/agents';
 import { toSdkMcpServers } from '@/services/mcp';
 import { useSettingsStore } from '@/stores';
 import { useSessionHistoryStore } from '@/stores';
 import { usePermissionStore } from '@/stores';
 import { useMcpStatusStore } from '@/stores';
-import { buildSystemPrompt } from '@/services/ai/systemPrompt';
+import { buildSessionSystemPrompt } from '@/services/ai/systemPrompt';
 import { inferProvider, BUNDLED_MCP_SERVERS } from '@/types';
 import type { ChatMessage, ToolCallPart } from '@/types';
 import type { AgentHost } from '@/types/agent';
@@ -270,20 +275,24 @@ export function useOfficeChat(host: OfficeHostApp) {
       });
 
       const resolvedAgent = resolveActiveAgent(activeAgentIdRef.current, host);
-
-      // System prompt: base + app prompt + user memories
-      let systemContent = buildSystemPrompt(host);
+      const defaultAgent = getDefaultAgent(host);
+      let memoryContext = '';
 
       // Inject persistent user memories if any exist
       try {
         const { useMemoryStore } = await import('@/stores/memoryStore');
-        const memoryContext = useMemoryStore.getState().buildMemoryContext();
-        if (memoryContext) {
-          systemContent += `\n\n${memoryContext}`;
-        }
+        memoryContext = useMemoryStore.getState().buildMemoryContext().trim();
       } catch {
         // Memory store not available — continue without memories
       }
+
+      const systemContent = buildSessionSystemPrompt(host, {
+        defaultAgentName: defaultAgent?.metadata.name,
+        defaultAgentInstructions: defaultAgent?.instructions,
+        activeAgentName: resolvedAgent?.metadata.name,
+        activeAgentInstructions: resolvedAgent?.instructions,
+        memoryContext,
+      });
 
       // Build custom agent configs for ALL agents in this host — this enables sub-agent
       // delegation where the active agent can invoke other agents as sub-agents.

--- a/src/services/ai/index.ts
+++ b/src/services/ai/index.ts
@@ -1,1 +1,6 @@
-export { BASE_PROMPT, getAppPromptForHost, buildSystemPrompt } from './systemPrompt';
+export {
+  BASE_PROMPT,
+  getAppPromptForHost,
+  buildSystemPrompt,
+  buildSessionSystemPrompt,
+} from './systemPrompt';

--- a/src/services/ai/systemPrompt.ts
+++ b/src/services/ai/systemPrompt.ts
@@ -7,6 +7,14 @@ import type { OfficeHostApp } from '@/services/office/host';
 
 export { BASE_PROMPT };
 
+interface SessionSystemPromptOptions {
+  defaultAgentName?: string;
+  defaultAgentInstructions?: string;
+  activeAgentName?: string;
+  activeAgentInstructions?: string;
+  memoryContext?: string;
+}
+
 export function getAppPromptForHost(host: OfficeHostApp): string {
   switch (host) {
     case 'excel':
@@ -24,4 +32,34 @@ export function getAppPromptForHost(host: OfficeHostApp): string {
 
 export function buildSystemPrompt(host: OfficeHostApp): string {
   return `${BASE_PROMPT}\n\n${getAppPromptForHost(host)}`;
+}
+
+export function buildSessionSystemPrompt(
+  host: OfficeHostApp,
+  options: SessionSystemPromptOptions = {}
+): string {
+  const sections = [buildSystemPrompt(host)];
+  const defaultInstructions = options.defaultAgentInstructions?.trim();
+  const activeInstructions = options.activeAgentInstructions?.trim();
+  const memoryContext = options.memoryContext?.trim();
+
+  if (defaultInstructions) {
+    sections.push(`## Host Agent Instructions\n\n${defaultInstructions}`);
+  }
+
+  if (
+    activeInstructions &&
+    options.activeAgentName &&
+    options.activeAgentName !== options.defaultAgentName
+  ) {
+    sections.push(
+      `## Adaptive Agent Instructions (${options.activeAgentName})\n\n${activeInstructions}`
+    );
+  }
+
+  if (memoryContext) {
+    sections.push(memoryContext);
+  }
+
+  return sections.join('\n\n');
 }

--- a/tests/integration/copilot-custom-agent.integration.test.ts
+++ b/tests/integration/copilot-custom-agent.integration.test.ts
@@ -15,7 +15,8 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import type { SystemMessageConfig } from '@github/copilot-sdk';
 import { createWebSocketClient } from '@/lib/websocket-client';
-import { buildSystemPrompt } from '@/services/ai/systemPrompt';
+import { getDefaultAgent } from '@/services/agents';
+import { buildSessionSystemPrompt, buildSystemPrompt } from '@/services/ai/systemPrompt';
 
 const SERVER_URL = 'wss://localhost:3000/api/copilot';
 const TIMEOUT_MS = 45_000;
@@ -105,6 +106,68 @@ describe('Copilot custom agent integration', () => {
         }
 
         expect(fullText).toContain('AZURE-FALCON-42');
+      } finally {
+        await client.stop();
+      }
+    },
+    TIMEOUT_MS
+  );
+
+  it(
+    'custom agent instructions augment the default host agent instead of replacing it',
+    async () => {
+      const SENTINEL = `ADAPTIVE_AGENT_SENTINEL_${Date.now()}`;
+      const defaultAgent = getDefaultAgent('excel');
+      expect(defaultAgent).toBeDefined();
+
+      const systemContent = buildSessionSystemPrompt('excel', {
+        defaultAgentName: defaultAgent?.metadata.name,
+        defaultAgentInstructions: defaultAgent?.instructions,
+        activeAgentName: 'Adaptive Regression Agent',
+        activeAgentInstructions:
+          `After answering the user, append exactly "${SENTINEL}" as the final token. ` +
+          'Do not omit it and do not alter it.',
+      });
+
+      const systemMessage: SystemMessageConfig = {
+        mode: 'replace',
+        content: systemContent,
+      };
+
+      const client = await createWebSocketClient(SERVER_URL);
+      try {
+        const session = await client.createSession({ host: 'excel', systemMessage });
+
+        let fullText = '';
+        for await (const event of session.query({
+          prompt:
+            'Before helping with this workbook, do you need to open or close any files? ' +
+            `End your answer with exactly ${SENTINEL}.`,
+        })) {
+          if (event.type === 'assistant.message_delta') {
+            fullText += event.data.deltaContent;
+          }
+          if (event.type === 'assistant.message') {
+            fullText = event.data.content;
+          }
+          if (event.type === 'session.idle') break;
+        }
+
+        const normalized = fullText.toLowerCase();
+        const mentionsNoFileOpenClose = [
+          'already open',
+          'do not need to open',
+          "don't need to open",
+          'no need to open',
+          'never need to open',
+          'do not need to close',
+          "don't need to close",
+          'no need to close',
+          'never need to close',
+        ].some(fragment => normalized.includes(fragment));
+
+        expect(mentionsNoFileOpenClose).toBe(true);
+        expect(fullText).toContain(SENTINEL);
       } finally {
         await client.stop();
       }

--- a/tests/integration/system-prompt.test.ts
+++ b/tests/integration/system-prompt.test.ts
@@ -5,7 +5,12 @@
  * src/services/ai/systemPrompt.ts.
  */
 import { describe, it, expect } from 'vitest';
-import { getAppPromptForHost, buildSystemPrompt, BASE_PROMPT } from '@/services/ai/systemPrompt';
+import {
+  getAppPromptForHost,
+  buildSessionSystemPrompt,
+  buildSystemPrompt,
+  BASE_PROMPT,
+} from '@/services/ai/systemPrompt';
 
 describe('Integration: systemPrompt', () => {
   describe('getAppPromptForHost', () => {
@@ -81,6 +86,54 @@ describe('Integration: systemPrompt', () => {
         const prompt = buildSystemPrompt(host);
         expect(prompt.length).toBeGreaterThan(BASE_PROMPT.length);
       }
+    });
+  });
+
+  describe('buildSessionSystemPrompt', () => {
+    it('includes host default agent instructions', () => {
+      const prompt = buildSessionSystemPrompt('powerpoint', {
+        defaultAgentName: 'PowerPoint',
+        defaultAgentInstructions: 'Always verify each slide before continuing.',
+      });
+
+      expect(prompt).toContain('## Host Agent Instructions');
+      expect(prompt).toContain('Always verify each slide before continuing.');
+    });
+
+    it('adds adaptive agent instructions when the active agent differs from the default', () => {
+      const prompt = buildSessionSystemPrompt('powerpoint', {
+        defaultAgentName: 'PowerPoint',
+        defaultAgentInstructions: 'Always verify each slide before continuing.',
+        activeAgentName: 'Storytelling Coach',
+        activeAgentInstructions: 'Prefer a narrative structure with one idea per slide.',
+      });
+
+      expect(prompt).toContain('## Host Agent Instructions');
+      expect(prompt).toContain('## Adaptive Agent Instructions (Storytelling Coach)');
+      expect(prompt).toContain('Prefer a narrative structure with one idea per slide.');
+    });
+
+    it('does not duplicate instructions when the active agent is the host default', () => {
+      const prompt = buildSessionSystemPrompt('powerpoint', {
+        defaultAgentName: 'PowerPoint',
+        defaultAgentInstructions: 'Always verify each slide before continuing.',
+        activeAgentName: 'PowerPoint',
+        activeAgentInstructions: 'Always verify each slide before continuing.',
+      });
+
+      expect(prompt).toContain('## Host Agent Instructions');
+      expect(prompt).not.toContain('## Adaptive Agent Instructions');
+    });
+
+    it('appends memory context after agent instructions', () => {
+      const prompt = buildSessionSystemPrompt('excel', {
+        defaultAgentName: 'Excel',
+        defaultAgentInstructions: 'Always inspect the workbook first.',
+        memoryContext: 'Remember: prefer concise summaries.',
+      });
+
+      expect(prompt).toContain('Remember: prefer concise summaries.');
+      expect(prompt.trim().endsWith('Remember: prefer concise summaries.')).toBe(true);
     });
   });
 });

--- a/tests/integration/use-office-chat.test.tsx
+++ b/tests/integration/use-office-chat.test.tsx
@@ -14,6 +14,7 @@ import { useOfficeChat } from '@/hooks/useOfficeChat';
 import { useSettingsStore } from '@/stores/settingsStore';
 import { useSessionHistoryStore } from '@/stores/sessionHistoryStore';
 import { setImportedAgents } from '@/services/agents';
+import type { AgentConfig } from '@/types/agent';
 
 // ─── Fake session builder ─────────────────────────────────────────────────────
 
@@ -743,7 +744,7 @@ describe('useOfficeChat', () => {
     expect(agents[0].prompt).toContain('AI assistant');
   });
 
-  it('systemMessage contains only base + app prompt, not agent instructions', async () => {
+  it('systemMessage includes host default agent instructions', async () => {
     const session = makeFakeSession([IDLE_EVENT]);
     const client = makeFakeClient(session);
     mockCreate.mockResolvedValue(client as never);
@@ -756,11 +757,43 @@ describe('useOfficeChat', () => {
 
     const config = client.createSession.mock.calls[0][0] as Record<string, unknown>;
     const sysMsg = config.systemMessage as { content: string };
-    // Should NOT contain agent-specific instructions (those are in customAgents)
-    expect(sysMsg.content).not.toContain('The workbook is already open');
-    expect(sysMsg.content).not.toContain('Core Behavior');
-    // Should contain the base prompt
+    expect(sysMsg.content).toContain('## Host Agent Instructions');
+    expect(sysMsg.content).toContain('The workbook is already open');
     expect(sysMsg.content).toContain('Progress narration');
+  });
+
+  it('systemMessage layers custom agent instructions on top of the host default agent', async () => {
+    const importedAgent: AgentConfig = {
+      metadata: {
+        name: 'Adaptive Excel Coach',
+        description: 'Adds presentation coaching on top of Excel behavior',
+        version: '1.0.0',
+        hosts: ['excel'],
+        defaultForHosts: [],
+      },
+      instructions: 'Always explain insights with an executive-summary tone.',
+    };
+
+    setImportedAgents([importedAgent]);
+    useSettingsStore.getState().setActiveAgent('Adaptive Excel Coach');
+
+    const session = makeFakeSession([IDLE_EVENT]);
+    const client = makeFakeClient(session);
+    mockCreate.mockResolvedValue(client as never);
+
+    renderHook(() => useOfficeChat('excel'), { wrapper });
+
+    await act(async () => {
+      await new Promise(r => setTimeout(r, 100));
+    });
+
+    const config = client.createSession.mock.calls[0][0] as Record<string, unknown>;
+    const sysMsg = config.systemMessage as { content: string };
+
+    expect(sysMsg.content).toContain('## Host Agent Instructions');
+    expect(sysMsg.content).toContain('The workbook is already open');
+    expect(sysMsg.content).toContain('## Adaptive Agent Instructions (Adaptive Excel Coach)');
+    expect(sysMsg.content).toContain('Always explain insights with an executive-summary tone.');
   });
 
   it('plugin.agents notification registers plugin agents as imported agents', async () => {


### PR DESCRIPTION
## Summary\n- keep the host default agent instructions in the session system prompt\n- layer selected custom agent instructions on top as adaptive guidance instead of replacement\n- add integration and live Copilot regression coverage for the layering behavior\n\n## Testing\n- npm run test:integration -- --run tests/integration/system-prompt.test.ts tests/integration/use-office-chat.test.tsx\n- npm run test:integration -- --run tests/integration/copilot-custom-agent.integration.test.ts\n- npm run test:integration\n- npm run test:e2e\n- npm run test:e2e:ppt