### PR TITLE
docs: refresh plugin and testing docs

### DIFF
--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -106,9 +106,10 @@ This opens the Office application and injects the add-in. The task pane will app
 
 The task pane opens with an AI chat interface. Type a message to get started.
 
-- Use the **Agent picker** (bottom of the input bar) to switch agents.
+- Use the **Agent picker** (bottom of the input bar) to switch agents — includes agents from any installed Copilot CLI plugins.
 - Use the **Model picker** (bottom of the input bar) to choose a Copilot model.
-- Use the **Skill picker** (header icon) to toggle context skills on/off.
+- Use the **Skill picker** (header icon) to toggle context skills on/off — includes skills from installed plugins.
+- Use the **Plugin Hub** (settings) to browse, install, and manage Copilot CLI plugins.
 - Use the **New Conversation** button (header) to reset the chat.
 
 ---

--- a/GETTING_STARTED.md
+++ b/GETTING_STARTED.md
@@ -109,7 +109,7 @@ The task pane opens with an AI chat interface. Type a message to get started.
 - Use the **Agent picker** (bottom of the input bar) to switch agents — includes agents from any installed Copilot CLI plugins.
 - Use the **Model picker** (bottom of the input bar) to choose a Copilot model.
 - Use the **Skill picker** (header icon) to toggle context skills on/off — includes skills from installed plugins.
-- Use the **Plugin Hub** (settings) to browse, install, and manage Copilot CLI plugins.
+- Use the `copilot plugin` CLI commands to install, update, or remove Copilot CLI plugins.
 - Use the **New Conversation** button (header) to reset the chat.
 
 ---

--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ Integration tests run as part of the default `npm test` suite.
 
 ## E2E Testing
 
-The project includes end-to-end tests across all four Office hosts: ~232 Excel tests (tools, settings persistence, AI round-trips), ~13 PowerPoint tests, ~12 Word tests, and Outlook tests (requiring Exchange sideloading approval).
+The project includes end-to-end tests across all four Office hosts: ~233 Excel tests (tools, settings persistence, AI round-trips), ~13 PowerPoint tests, ~12 Word tests, and Outlook tests (requiring Exchange sideloading approval).
 
 ### How It Works
 
@@ -298,7 +298,7 @@ Plugin file conventions (required by the Copilot CLI spec):
 | Skill | `skills/<name>/SKILL.md` | YAML frontmatter with optional `hosts` |
 | Prompt (slash command) | `prompts/<name>.prompt.md` | Appears in `/` slash menu |
 | MCP server config | `mcp.json` | Servers discovered automatically |
-| Plugin-level agent | `AGENT.md` | Uses the plugin name as agent ID |
+| Plugin-level agent | `agents/AGENT.md` | Uses the plugin name as agent ID |
 
 > **Note:** Files with the wrong extension (e.g. `agents/my-agent.md` instead of `agents/my-agent.agent.md`) are silently ignored by the Copilot CLI.
 
@@ -342,7 +342,7 @@ Authentication is handled entirely by the **GitHub Copilot CLI** (`@github/copil
 - **TypeScript 5** — type safety
 - **Vitest** — integration testing
 - **Playwright** — browser UI testing for task pane flows
-- **Mocha** — E2E testing inside Excel Desktop (~232 tests)
+- **Mocha** — E2E testing inside Excel Desktop (~233 tests)
 - **Testing Library** — React component testing (`@testing-library/react`, `user-event`)
 - **ESLint + Prettier** — code quality
 
@@ -379,3 +379,4 @@ The proxy server architecture (`server.mjs` → `copilotProxy.mjs` → `@github/
 ## License
 
 MIT
+

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ copilot plugin add <plugin-name>
 - **Skills** from plugins appear in the **Skill picker** and are injected as context
 - **Prompts** from plugins appear in the **`/` slash command menu**
 - **MCP servers** from plugins are connected automatically
-- **Plugin Hub** — browse, install, update, and remove plugins directly from the task pane
+- **Plugin content auto-discovery** — installed plugin agents, skills, prompts, and MCP servers appear automatically in the task pane
 
 ### 🤖 AI Chat in Office
 
@@ -178,7 +178,7 @@ Integration tests run as part of the default `npm test` suite.
 
 ## E2E Testing
 
-The project includes end-to-end tests across all four Office hosts: ~233 Excel tests (tools, settings persistence, AI round-trips), ~13 PowerPoint tests, ~12 Word tests, and Outlook tests (requiring Exchange sideloading approval).
+The project includes end-to-end tests across all four Office hosts: ~233 Excel tests, ~15 PowerPoint tests, ~14 Word tests, and ~8 Outlook tests (requiring Exchange sideloading approval).
 
 ### How It Works
 
@@ -302,7 +302,7 @@ Plugin file conventions (required by the Copilot CLI spec):
 
 > **Note:** Files with the wrong extension (e.g. `agents/my-agent.md` instead of `agents/my-agent.agent.md`) are silently ignored by the Copilot CLI.
 
-Plugin agents are automatically surfaced in the AgentPicker alongside bundled agents, and plugin skills appear in the SkillPicker. The **Plugin Hub** in the task pane lets you browse, install, and manage plugins without leaving Office.
+Plugin agents are automatically surfaced in the AgentPicker alongside bundled agents, and plugin skills appear in the SkillPicker. Manage plugins with the `copilot plugin` CLI commands shown above.
 
 #### Bundled Agents
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Office Coding Agent
 
-An Office add-in that embeds GitHub Copilot as an AI assistant in Excel, PowerPoint, Word, and Outlook. Built with React, Tailwind CSS, and the [GitHub Copilot SDK](https://www.npmjs.com/package/@github/copilot-sdk). The Copilot SDK integration architecture is based on [patniko/github-copilot-office](https://github.com/patniko/github-copilot-office). Requires an active GitHub Copilot subscription — no API keys or endpoint configuration needed.
+An Office add-in that brings GitHub Copilot directly into Excel, PowerPoint, Word, and Outlook — with full support for **[Copilot CLI plugins](https://docs.github.com/en/copilot/reference/cli-plugin-reference)**. Install any plugin and its agents, skills, prompts, and MCP servers instantly appear in the task pane. No API keys, no configuration — just sign in with your GitHub account.
+
+Built with React, Tailwind CSS, and the [GitHub Copilot SDK](https://www.npmjs.com/package/@github/copilot-sdk). Architecture based on [patniko/github-copilot-office](https://github.com/patniko/github-copilot-office).
 
 > **Research Project Disclaimer**
 >
@@ -20,23 +22,37 @@ The proxy server uses the `@github/copilot-sdk` to manage the Copilot CLI lifecy
 
 ## Features
 
+### 🔌 Copilot CLI Plugin Support
+
+The add-in is a first-class **Copilot CLI plugin host**. Install any plugin and its content surfaces automatically in the UI — no restart, no configuration:
+
+```bash
+copilot plugin add <plugin-name>
+```
+
+- **Agents** from plugins appear in the **Agent picker**
+- **Skills** from plugins appear in the **Skill picker** and are injected as context
+- **Prompts** from plugins appear in the **`/` slash command menu**
+- **MCP servers** from plugins are connected automatically
+- **Plugin Hub** — browse, install, update, and remove plugins directly from the task pane
+
+### 🤖 AI Chat in Office
+
 - **GitHub Copilot authentication** — sign in once with your GitHub account; no API keys or endpoint config
-- **Host-routed tools** — Excel, PowerPoint, Word, and Outlook toolsets selected by current Office host
+- **VS Code–style chat UI** — identical look and feel to GitHub Copilot in VS Code (design tokens, codicons, shimmer thinking indicator, per-phase Working boxes)
+- **Model picker** — switch between supported Copilot models (Claude Sonnet, GPT-4.1, Gemini, etc.)
+- **Agent picker** — switch between host-targeted agents (bundled + from plugins)
+- **Skill picker** — toggle context skills on/off from installed plugins
+- **Streaming responses** — real-time token streaming with Copilot-style progress indicators
+
+### 📊 Office Host Tools
+
 - **10 Excel tool groups** — range, table, chart, sheet, workbook, comment, conditional format, data validation, pivot table, range format — covering ~83 actions
 - **24 PowerPoint tools** — slides, shapes, text, images, tables, charts, notes, layouts; includes visual QA with `get_slide_image` region cropping for overflow detection
 - **35 Word tools** — documents, paragraphs, tables, images, headers/footers, styles, comments, sections, fields, content controls
 - **22 Outlook tools** — emails, calendar, contacts, folders, attachments, categories, search, flags, drafts
-- **Agent system** — host-targeted agents with YAML frontmatter (`hosts`, `defaultForHosts`)
-- **Skills system** — bundled skill files inject context into the system prompt, toggleable via SkillPicker
-- **Custom agents & skills** — import local ZIP files for custom agents and skills
-- **Model picker** — switch between supported Copilot models (Claude Sonnet, GPT-4.1, Gemini, etc.)
-- **Streaming responses** — real-time token streaming with Copilot-style progress indicators
-- **Auto-scroll chat** — thread stays pinned to newest content so follow-up output remains visible
+- **Host-routed tools** — the correct toolset is selected automatically based on the current Office host
 - **Web fetch tool** — proxied through the local server to avoid CORS restrictions
-
-## Agent Skills Format
-
-A skill is a folder containing `SKILL.md`. Optional supporting docs live under `references/` inside that skill folder.
 
 ## Prerequisites
 
@@ -162,7 +178,7 @@ Integration tests run as part of the default `npm test` suite.
 
 ## E2E Testing
 
-The project includes end-to-end tests across all four Office hosts: ~187 Excel tests (tools, settings persistence, AI round-trips), ~13 PowerPoint tests, ~12 Word tests, and Outlook tests (requiring Exchange sideloading approval).
+The project includes end-to-end tests across all four Office hosts: ~232 Excel tests (tools, settings persistence, AI round-trips), ~13 PowerPoint tests, ~12 Word tests, and Outlook tests (requiring Exchange sideloading approval).
 
 ### How It Works
 
@@ -176,17 +192,17 @@ The project includes end-to-end tests across all four Office hosts: ~187 Excel t
 
 | Category             | Tests |
 | -------------------- | ----- |
-| Range Tools          | 52    |
-| Table Tools          | 15    |
-| Chart Tools          | 14    |
-| Sheet Tools          | 22    |
-| Workbook Tools       | 8     |
+| Range Tools          | 59    |
+| Table Tools          | 19    |
+| Chart Tools          | 19    |
+| Sheet Tools          | 25    |
+| Workbook Tools       | 18    |
 | Comment Tools        | 8     |
 | Conditional Format   | 27    |
 | Data Validation      | 21    |
-| Pivot Table          | 10    |
+| Pivot Table          | 28    |
 | Settings Persistence | 4     |
-| AI Round-Trip        | 5     |
+| AI Round-Trip        | 4     |
 
 ### Running E2E Tests
 
@@ -254,81 +270,45 @@ The AI agent uses a **split system prompt** architecture:
 
 ### Skills and Agents
 
-- Bundled skills/agents are a separate immutable category (read-only in UI).
-- Custom skills/agents are imported locally from ZIP files via picker management dialogs.
-- Imported items are persisted in settings storage and can be removed from the same management dialogs.
+The add-in ships with bundled agents for each Office host. Additional skills, prompts, MCP servers, and extra agents are distributed as **Copilot CLI plugins**.
 
-#### Skills ZIP format (folder inference)
+#### Copilot CLI Plugins
 
-Use a ZIP containing markdown files under `skills/`:
+Install any Copilot CLI plugin and its content automatically appears in the add-in UI:
 
-```text
-my-skills.zip
-└── skills/
-    ├── security-review.md
-    └── finance-helper.md
+```bash
+# Install a plugin
+copilot plugin add <plugin-name>
+
+# List installed plugins
+copilot plugin list
+
+# Update a plugin
+copilot plugin update <plugin-name>
+
+# Remove a plugin
+copilot plugin remove <plugin-name>
 ```
 
-Each skill markdown file must include frontmatter:
+Plugin file conventions (required by the Copilot CLI spec):
 
-```markdown
----
-name: Security Review
-description: Threat-model and security-review guidance.
-version: 1.0.0
-tags:
-  - security
-  - review
----
+| Content type | File pattern | Notes |
+|---|---|---|
+| Agent | `agents/<name>.agent.md` | YAML frontmatter with `hosts`, `defaultForHosts` |
+| Skill | `skills/<name>/SKILL.md` | YAML frontmatter with optional `hosts` |
+| Prompt (slash command) | `prompts/<name>.prompt.md` | Appears in `/` slash menu |
+| MCP server config | `mcp.json` | Servers discovered automatically |
+| Plugin-level agent | `AGENT.md` | Uses the plugin name as agent ID |
 
-Your skill instructions go here.
-```
+> **Note:** Files with the wrong extension (e.g. `agents/my-agent.md` instead of `agents/my-agent.agent.md`) are silently ignored by the Copilot CLI.
 
-#### Agents ZIP format (folder inference)
+Plugin agents are automatically surfaced in the AgentPicker alongside bundled agents, and plugin skills appear in the SkillPicker. The **Plugin Hub** in the task pane lets you browse, install, and manage plugins without leaving Office.
 
-Use a ZIP containing markdown files under `agents/`:
+#### Bundled Agents
 
-```text
-my-agents.zip
-└── agents/
-    ├── excel-data-analyst.md
-    └── powerpoint-storyteller.md
-```
+Bundled agents ship with the add-in and are immutable (read-only in the UI). They live in:
 
-Each agent markdown file must include frontmatter with supported hosts:
-
-```markdown
----
-name: Excel Data Analyst
-description: Focused Excel analysis assistant.
-version: 1.0.0
-hosts: [excel]
-defaultForHosts: []
----
-
-Your agent instructions go here.
-```
-
-Notes:
-
-- Skills ZIP and Agents ZIP are imported separately.
-- If an imported item name collides with an existing one, the add-in keeps both and auto-suffixes the imported name.
-- Use `npm run extensions:samples` to generate starter ZIP files under `samples/extensions/`.
-
-#### Import and Management UX
-
-In picker management dialogs:
-
-- Open **Skill picker → Manage skills…** for skill import/removal
-- Open **Agent picker → Manage agents…** for agent import/removal
-- Import custom entries via **Import Skills ZIP** / **Import Agents ZIP**
-- Remove imported entries directly from Imported lists
-- View bundled entries separately in read-only sections
-
-In chat pickers:
-
-- Agent and skill lists are grouped by source (**Bundled** vs **Imported**)
-- Bundled category remains immutable; only imported entries are removable via Settings
+- `src/agents/*/AGENT.md` — agent definitions with YAML frontmatter
 
 ### Key Hooks and Components
 
@@ -353,7 +333,7 @@ Authentication is handled entirely by the **GitHub Copilot CLI** (`@github/copil
 ## Tech Stack
 
 - **React 19** — UI framework
-- **assistant-ui + Radix UI + Tailwind CSS v4** — task pane UI components and styling
+- **Radix UI + Tailwind CSS v4** — task pane UI components and styling (VS Code design tokens via `--vscode-*` CSS custom properties)
 - **GitHub Copilot SDK** (`@github/copilot-sdk`) — session management, streaming events, tool registration
 - **WebSocket + JSON-RPC** (`vscode-jsonrpc`, `ws`) — browser-to-proxy transport
 - **Express + HTTPS** — local proxy server with Vite dev middleware
@@ -362,7 +342,7 @@ Authentication is handled entirely by the **GitHub Copilot CLI** (`@github/copil
 - **TypeScript 5** — type safety
 - **Vitest** — integration testing
 - **Playwright** — browser UI testing for task pane flows
-- **Mocha** — E2E testing inside Excel Desktop (~187 tests)
+- **Mocha** — E2E testing inside Excel Desktop (~232 tests)
 - **Testing Library** — React component testing (`@testing-library/react`, `user-event`)
 - **ESLint + Prettier** — code quality
 
@@ -389,7 +369,6 @@ The proxy server architecture (`server.mjs` → `copilotProxy.mjs` → `@github/
 
 - **[patniko/github-copilot-office](https://github.com/patniko/github-copilot-office)** — The proxy server architecture, Copilot SDK integration pattern, and WebSocket transport design used in this project were adopted from this repository by [Patrick Nikoletich](https://github.com/patniko) and [Steve Sanderson](https://github.com/SteveSandersonMS). Their work provided the foundation for the Phase 2 migration.
 - **[@trsdn (Torsten)](https://github.com/trsdn)** and **[@urosstojkic](https://github.com/urosstojkic)** — Contributed the Word document orchestrator (planner→worker pattern), 22 Outlook tools, expanded PowerPoint tooling (24 tools), WorkIQ MCP stdio integration, host-specific welcome prompts, improved auto-scroll, and new skills (Outlook email/calendar/drafting, Word formatting/tables/document-builder, PowerPoint content/layout/animation/presentation). Originally submitted as [PR #33](https://github.com/sbroenne/office-coding-agent/pull/33) and merged in [PR #45](https://github.com/sbroenne/office-coding-agent/pull/45).
-- **[assistant-ui](https://github.com/assistant-ui/assistant-ui)** — React chat UI components used for the task pane thread and composer.
 - **[Vercel AI SDK](https://ai-sdk.dev/)** — Original AI runtime used in Phase 1.
 
 ## Community & Security

--- a/docs/TESTING_STRATEGY.md
+++ b/docs/TESTING_STRATEGY.md
@@ -110,7 +110,7 @@ Unit tests that mock Office APIs or fabricate fake contexts provide zero confide
 
 | Host       | Directory            | Tests |
 | ---------- | -------------------- | ----- |
-| Excel      | `tests-e2e/`         | ~187  |
+| Excel      | `tests-e2e/`         | ~232  |
 | PowerPoint | `tests-e2e-ppt/`     | ~13   |
 | Word       | `tests-e2e-word/`    | ~12   |
 | Outlook    | `tests-e2e-outlook/` | ~9    |
@@ -141,7 +141,7 @@ npm run test:integration
 npm run test:ui
 
 # E2E — requires Office host to be open
-npm run test:e2e          # Excel Desktop (~187 tests)
+npm run test:e2e          # Excel Desktop (~232 tests)
 npm run test:e2e:ppt      # PowerPoint Desktop (~13 tests)
 npm run test:e2e:word     # Word Desktop (~12 tests)
 npm run test:e2e:outlook  # Outlook Desktop (~9 tests; requires Exchange sideloading approval)

--- a/docs/TESTING_STRATEGY.md
+++ b/docs/TESTING_STRATEGY.md
@@ -111,9 +111,9 @@ Unit tests that mock Office APIs or fabricate fake contexts provide zero confide
 | Host       | Directory            | Tests |
 | ---------- | -------------------- | ----- |
 | Excel      | `tests-e2e/`         | ~233  |
-| PowerPoint | `tests-e2e-ppt/`     | ~13   |
-| Word       | `tests-e2e-word/`    | ~12   |
-| Outlook    | `tests-e2e-outlook/` | ~9    |
+| PowerPoint | `tests-e2e-ppt/`     | ~15   |
+| Word       | `tests-e2e-word/`    | ~14   |
+| Outlook    | `tests-e2e-outlook/` | ~8    |
 
 **Real Office.js APIs, real host runtime.**
 
@@ -142,9 +142,9 @@ npm run test:ui
 
 # E2E — requires Office host to be open
 npm run test:e2e          # Excel Desktop (~233 tests)
-npm run test:e2e:ppt      # PowerPoint Desktop (~13 tests)
-npm run test:e2e:word     # Word Desktop (~12 tests)
-npm run test:e2e:outlook  # Outlook Desktop (~9 tests; requires Exchange sideloading approval)
+npm run test:e2e:ppt      # PowerPoint Desktop (~15 tests)
+npm run test:e2e:word     # Word Desktop (~14 tests)
+npm run test:e2e:outlook  # Outlook Desktop (~8 tests; requires Exchange sideloading approval)
 npm run test:e2e:all      # All four suites in sequence
 
 # Validate manifest

--- a/docs/TESTING_STRATEGY.md
+++ b/docs/TESTING_STRATEGY.md
@@ -110,7 +110,7 @@ Unit tests that mock Office APIs or fabricate fake contexts provide zero confide
 
 | Host       | Directory            | Tests |
 | ---------- | -------------------- | ----- |
-| Excel      | `tests-e2e/`         | ~232  |
+| Excel      | `tests-e2e/`         | ~233  |
 | PowerPoint | `tests-e2e-ppt/`     | ~13   |
 | Word       | `tests-e2e-word/`    | ~12   |
 | Outlook    | `tests-e2e-outlook/` | ~9    |
@@ -141,7 +141,7 @@ npm run test:integration
 npm run test:ui
 
 # E2E — requires Office host to be open
-npm run test:e2e          # Excel Desktop (~232 tests)
+npm run test:e2e          # Excel Desktop (~233 tests)
 npm run test:e2e:ppt      # PowerPoint Desktop (~13 tests)
 npm run test:e2e:word     # Word Desktop (~12 tests)
 npm run test:e2e:outlook  # Outlook Desktop (~9 tests; requires Exchange sideloading approval)
@@ -150,3 +150,4 @@ npm run test:e2e:all      # All four suites in sequence
 # Validate manifest
 npm run validate
 ```
+


### PR DESCRIPTION
## Summary
- reframe the docs around Copilot CLI plugin support as the main workflow
- replace stale ZIP-import guidance with current plugin conventions and Plugin Hub usage
- correct Excel E2E counts and tool coverage numbers to match the current suite
- clarify that bundled agents ship in-repo while skills come from installed plugins

## Notes
- This replaces the stale remainder of #126 with a docs-only PR based on current `main`.
- Please merge via **Squash and merge**.