### PR TITLE
chore: upgrade @github/copilot to 1.0.5 (security fix)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,10 @@ tests-pptx/~$*
 tests-pptx/*.pptx
 tests-pptx/*.jpg
 tests-pptx/*.png
+# Squad: ignore runtime state (logs, inbox, sessions)
+.squad/orchestration-log/
+.squad/log/
+.squad/decisions/inbox/
+.squad/sessions/
+# Squad: SubSquad activation file (local to this machine)
+.squad-workstream

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,8 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@github/copilot": "^0.0.414",
-        "@github/copilot-sdk": "^0.1.30",
+        "@github/copilot": "^1.0.5",
+        "@github/copilot-sdk": "^0.1.32",
         "@radix-ui/react-collapsible": "^1.1.12",
         "@radix-ui/react-dialog": "^1.1.15",
         "@radix-ui/react-popover": "^1.1.15",
@@ -2283,26 +2283,26 @@
       "license": "MIT"
     },
     "node_modules/@github/copilot": {
-      "version": "0.0.414",
-      "resolved": "https://registry.npmjs.org/@github/copilot/-/copilot-0.0.414.tgz",
-      "integrity": "sha512-jseJ2S02CLWrFks5QK22zzq7as2ErY5m1wMCFBOE6sro1uACq1kvqqM1LwM4qy58YSZFrM1ZAn1s7UOVd9zhIA==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@github/copilot/-/copilot-1.0.5.tgz",
+      "integrity": "sha512-lQGN1/qw7gJRT+lSW1U79Ltrf9rkF6UP8FcEb0hGEf9hq0K8/MaulzK+iDtH/gwXYweFXID29E3QlwSqbdsHqQ==",
       "license": "SEE LICENSE IN LICENSE.md",
       "bin": {
         "copilot": "npm-loader.js"
       },
       "optionalDependencies": {
-        "@github/copilot-darwin-arm64": "0.0.414",
-        "@github/copilot-darwin-x64": "0.0.414",
-        "@github/copilot-linux-arm64": "0.0.414",
-        "@github/copilot-linux-x64": "0.0.414",
-        "@github/copilot-win32-arm64": "0.0.414",
-        "@github/copilot-win32-x64": "0.0.414"
+        "@github/copilot-darwin-arm64": "1.0.5",
+        "@github/copilot-darwin-x64": "1.0.5",
+        "@github/copilot-linux-arm64": "1.0.5",
+        "@github/copilot-linux-x64": "1.0.5",
+        "@github/copilot-win32-arm64": "1.0.5",
+        "@github/copilot-win32-x64": "1.0.5"
       }
     },
     "node_modules/@github/copilot-darwin-arm64": {
-      "version": "0.0.414",
-      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-arm64/-/copilot-darwin-arm64-0.0.414.tgz",
-      "integrity": "sha512-PW4v89v41i4Mg/NYl4+gEhwnDaVz+olNL+RbqtiQI3IV89gZdS+RZQbUEJfOwMaFcT2GfiUK1OuB+YDv5GrkBg==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-arm64/-/copilot-darwin-arm64-1.0.5.tgz",
+      "integrity": "sha512-XBwo8t5higPXzCvXVYkADImixt9k8P2XsflWup2b86x9KtcssYTcfEWWIg42AOCe8J/OJRJN2MMTQuWt5aeK9w==",
       "cpu": [
         "arm64"
       ],
@@ -2316,9 +2316,9 @@
       }
     },
     "node_modules/@github/copilot-darwin-x64": {
-      "version": "0.0.414",
-      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-x64/-/copilot-darwin-x64-0.0.414.tgz",
-      "integrity": "sha512-NyPYm0NovQTwtuI42WJIi4cjYd2z0wBHEvWlUSczRsSuYEyImAClmZmBPegUU63e5JdZd1PdQkQ7FqrrfL2fZQ==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-x64/-/copilot-darwin-x64-1.0.5.tgz",
+      "integrity": "sha512-zUlMEKct5oPk/ImnYKz+fUjI9xfIwRE2/WI8BrpuDDe16aFDW2Co/6WFFr5rgYcXoGX2Jm8HT563UUxaFbnnOA==",
       "cpu": [
         "x64"
       ],
@@ -2332,9 +2332,9 @@
       }
     },
     "node_modules/@github/copilot-linux-arm64": {
-      "version": "0.0.414",
-      "resolved": "https://registry.npmjs.org/@github/copilot-linux-arm64/-/copilot-linux-arm64-0.0.414.tgz",
-      "integrity": "sha512-VgdRsvA1FiZ1lcU/AscSvyJWEUWZzoXv2tSZ6WV3NE0uUTuO1Qoq4xuqbKZ/+vKJmn1b8afe7sxAAOtCoWPBHQ==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@github/copilot-linux-arm64/-/copilot-linux-arm64-1.0.5.tgz",
+      "integrity": "sha512-Rp5Key6IBcm00K3+yc8rga3IXaJKN7mwYtP/mpkCKaJJp7izpJK7Z7Dr1slb63Z3yCAyPwMeYlE+adFCwlnYUA==",
       "cpu": [
         "arm64"
       ],
@@ -2348,9 +2348,9 @@
       }
     },
     "node_modules/@github/copilot-linux-x64": {
-      "version": "0.0.414",
-      "resolved": "https://registry.npmjs.org/@github/copilot-linux-x64/-/copilot-linux-x64-0.0.414.tgz",
-      "integrity": "sha512-3HyZsbZqYTF5jcT7/e+nDIYBCQXo8UCVWjBI3raOE4lzAw9b2ucL290IhtA23s1+EiquMxJ4m3FnjwFmwlQ12A==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@github/copilot-linux-x64/-/copilot-linux-x64-1.0.5.tgz",
+      "integrity": "sha512-ZEKOi57SUo3Ds2ZeYkIkHJ9MJA0Im1i04i0vdAPKH5Xibb2AC6I2EHO2dU/MWwqIeXoK5QDRh0r0Gs+BkHA/dg==",
       "cpu": [
         "x64"
       ],
@@ -2364,12 +2364,12 @@
       }
     },
     "node_modules/@github/copilot-sdk": {
-      "version": "0.1.30",
-      "resolved": "https://registry.npmjs.org/@github/copilot-sdk/-/copilot-sdk-0.1.30.tgz",
-      "integrity": "sha512-Stg+h8xsPRR0TNGBQfd9laxhJfWZ6DsdpbowcKIZoyKxZvMAbjnY0zyDeOpewJbxWBTJVhBZb5okOq6iaPNMZw==",
+      "version": "0.1.32",
+      "resolved": "https://registry.npmjs.org/@github/copilot-sdk/-/copilot-sdk-0.1.32.tgz",
+      "integrity": "sha512-mPWM0fw1Gqc/SW8nl45K8abrFH+92fO7y6tRtRl5imjS5hGapLf/dkX5WDrgPtlsflD0c41lFXVUri5NVJwtoA==",
       "license": "MIT",
       "dependencies": {
-        "@github/copilot": "^0.0.420",
+        "@github/copilot": "^1.0.2",
         "vscode-jsonrpc": "^8.2.1",
         "zod": "^4.3.6"
       },
@@ -2377,123 +2377,10 @@
         "node": ">=20.0.0"
       }
     },
-    "node_modules/@github/copilot-sdk/node_modules/@github/copilot": {
-      "version": "0.0.420",
-      "resolved": "https://registry.npmjs.org/@github/copilot/-/copilot-0.0.420.tgz",
-      "integrity": "sha512-UpPuSjxUxQ+j02WjZEFffWf0scLb23LvuGHzMFtaSsweR+P/BdbtDUI5ZDIA6T0tVyyt6+X1/vgfsJiRqd6jig==",
-      "license": "SEE LICENSE IN LICENSE.md",
-      "bin": {
-        "copilot": "npm-loader.js"
-      },
-      "optionalDependencies": {
-        "@github/copilot-darwin-arm64": "0.0.420",
-        "@github/copilot-darwin-x64": "0.0.420",
-        "@github/copilot-linux-arm64": "0.0.420",
-        "@github/copilot-linux-x64": "0.0.420",
-        "@github/copilot-win32-arm64": "0.0.420",
-        "@github/copilot-win32-x64": "0.0.420"
-      }
-    },
-    "node_modules/@github/copilot-sdk/node_modules/@github/copilot-darwin-arm64": {
-      "version": "0.0.420",
-      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-arm64/-/copilot-darwin-arm64-0.0.420.tgz",
-      "integrity": "sha512-sj8Oxcf3oKDbeUotm2gtq5YU1lwCt3QIzbMZioFD/PMLOeqSX/wrecI+c0DDYXKofFhALb0+DxxnWgbEs0mnkQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "SEE LICENSE IN LICENSE.md",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "bin": {
-        "copilot-darwin-arm64": "copilot"
-      }
-    },
-    "node_modules/@github/copilot-sdk/node_modules/@github/copilot-darwin-x64": {
-      "version": "0.0.420",
-      "resolved": "https://registry.npmjs.org/@github/copilot-darwin-x64/-/copilot-darwin-x64-0.0.420.tgz",
-      "integrity": "sha512-2acA93IqXz1uuz3TVUm0Y7BVrBr0MySh1kQa8LqMILhTsG0YHRMm8ybzTp2HA7Mi1tl5CjqMSk163kkS7OzfUA==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "SEE LICENSE IN LICENSE.md",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "bin": {
-        "copilot-darwin-x64": "copilot"
-      }
-    },
-    "node_modules/@github/copilot-sdk/node_modules/@github/copilot-linux-arm64": {
-      "version": "0.0.420",
-      "resolved": "https://registry.npmjs.org/@github/copilot-linux-arm64/-/copilot-linux-arm64-0.0.420.tgz",
-      "integrity": "sha512-h/IvEryTOYm1HzR2GNq8s2aDtN4lvT4MxldfZuS42CtWJDOfVG2jLLsoHWU1T3QV8j1++PmDgE//HX0JLpLMww==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "SEE LICENSE IN LICENSE.md",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "bin": {
-        "copilot-linux-arm64": "copilot"
-      }
-    },
-    "node_modules/@github/copilot-sdk/node_modules/@github/copilot-linux-x64": {
-      "version": "0.0.420",
-      "resolved": "https://registry.npmjs.org/@github/copilot-linux-x64/-/copilot-linux-x64-0.0.420.tgz",
-      "integrity": "sha512-iL2NpZvXIDZ+3lw7sO2fo5T0nKmP5dZbU2gdYcv+SFBm/ONhCxIY5VRX4yN/9VkFaa9ePv5JzCnsl3vZINiDxg==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "SEE LICENSE IN LICENSE.md",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "bin": {
-        "copilot-linux-x64": "copilot"
-      }
-    },
-    "node_modules/@github/copilot-sdk/node_modules/@github/copilot-win32-arm64": {
-      "version": "0.0.420",
-      "resolved": "https://registry.npmjs.org/@github/copilot-win32-arm64/-/copilot-win32-arm64-0.0.420.tgz",
-      "integrity": "sha512-Njlc2j9vYSBAL+lC6FIEhQ3C+VxO3xavwKnw0ecVRiNLcGLyPrTdzPfPQOmEjC63gpVCqLabikoDGv8fuLPA2w==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "SEE LICENSE IN LICENSE.md",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "bin": {
-        "copilot-win32-arm64": "copilot.exe"
-      }
-    },
-    "node_modules/@github/copilot-sdk/node_modules/@github/copilot-win32-x64": {
-      "version": "0.0.420",
-      "resolved": "https://registry.npmjs.org/@github/copilot-win32-x64/-/copilot-win32-x64-0.0.420.tgz",
-      "integrity": "sha512-rZlH35oNehAP2DvQbu4vQFVNeCh/1p3rUjafBYaEY0Nkhx7RmdrYBileL5U3PtRPPRsBPaq3Qp+pVIrGoCDLzQ==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "SEE LICENSE IN LICENSE.md",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "bin": {
-        "copilot-win32-x64": "copilot.exe"
-      }
-    },
     "node_modules/@github/copilot-win32-arm64": {
-      "version": "0.0.414",
-      "resolved": "https://registry.npmjs.org/@github/copilot-win32-arm64/-/copilot-win32-arm64-0.0.414.tgz",
-      "integrity": "sha512-8gdaoF4MPpeV0h8UnCZ8TKI5l274EP0fvAaV9BGjsdyEydDcEb+DHqQiXgitWVKKiHAAaPi12aH8P5OsEDUneQ==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@github/copilot-win32-arm64/-/copilot-win32-arm64-1.0.5.tgz",
+      "integrity": "sha512-pkhuKJZ1AcRAkVS2OO4BEBfMovGSuGWem4isBq+cgRDtuXRfRiZuc88Z9WcrtDCCwpdLx9rSYPVSWQG5fvupPQ==",
       "cpu": [
         "arm64"
       ],
@@ -2507,9 +2394,9 @@
       }
     },
     "node_modules/@github/copilot-win32-x64": {
-      "version": "0.0.414",
-      "resolved": "https://registry.npmjs.org/@github/copilot-win32-x64/-/copilot-win32-x64-0.0.414.tgz",
-      "integrity": "sha512-E1Oq1jXHaL1oWNsmmiCd4G30/CfgVdswg/T5oDFUxx3Ri+6uBekciIzdyCDelsP1kn2+fC1EYz2AerQ6F+huzg==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@github/copilot-win32-x64/-/copilot-win32-x64-1.0.5.tgz",
+      "integrity": "sha512-x6PWG80uCuCI+IgCLD1fnBJtfuf9nMBzJwOcMlFwjRtHduV/V9OOW3c89ooGwh/lRhCatAP5GxZGTyC7AJR3kQ==",
       "cpu": [
         "x64"
       ],
@@ -3881,17 +3768,6 @@
         "vscode-jsonrpc": "^4.0.0"
       }
     },
-    "node_modules/@microsoft/dev-tunnels-contracts/node_modules/vscode-jsonrpc": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-4.0.0.tgz",
-      "integrity": "sha512-perEnXQdQOJMTDFNv+UF3h1Y0z4iSiaN9jIlb0OqIYgosPCZGYh/MCUlkFtV2668PL69lRDO32hmvL2yiidUYg==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=8.0.0 || >=10.0.0"
-      }
-    },
     "node_modules/@microsoft/dev-tunnels-management": {
       "version": "1.1.9",
       "resolved": "https://registry.npmjs.org/@microsoft/dev-tunnels-management/-/dev-tunnels-management-1.1.9.tgz",
@@ -3905,17 +3781,6 @@
         "buffer": "^5.2.1",
         "debug": "^4.1.1",
         "vscode-jsonrpc": "^4.0.0"
-      }
-    },
-    "node_modules/@microsoft/dev-tunnels-management/node_modules/vscode-jsonrpc": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-4.0.0.tgz",
-      "integrity": "sha512-perEnXQdQOJMTDFNv+UF3h1Y0z4iSiaN9jIlb0OqIYgosPCZGYh/MCUlkFtV2668PL69lRDO32hmvL2yiidUYg==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "engines": {
-        "node": ">=8.0.0 || >=10.0.0"
       }
     },
     "node_modules/@microsoft/kiota": {

--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
   "scripts": {
     "build": "vite build",
     "build:dev": "vite build --mode development",
-    "dev": "node scripts/kill-port.mjs && node src/server.mjs",
-    "start:prod-server": "node src/server-prod.mjs",
+    "dev": "node scripts/kill-port.mjs && node --import ./scripts/esm-resolve.mjs src/server.mjs",
+    "start:prod-server": "node --import ./scripts/esm-resolve.mjs src/server-prod.mjs",
     "start:tray": "npm run build && electron .",
     "start:tray:desktop": "node scripts/start-tray-desktop.mjs",
     "stop:tray:desktop": "node scripts/stop-tray-desktop.mjs",
@@ -73,8 +73,8 @@
     "prepare": "husky"
   },
   "dependencies": {
-    "@github/copilot": "^0.0.414",
-    "@github/copilot-sdk": "^0.1.30",
+    "@github/copilot": "^1.0.5",
+    "@github/copilot-sdk": "^0.1.32",
     "@radix-ui/react-collapsible": "^1.1.12",
     "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-popover": "^1.1.15",
@@ -149,7 +149,8 @@
   },
   "overrides": {
     "tmp": "0.2.4",
-    "@noble/hashes": "2.0.1"
+    "@noble/hashes": "2.0.1",
+    "vscode-jsonrpc": "$vscode-jsonrpc"
   },
   "build": {
     "appId": "com.officecodingagent.tray",

--- a/scripts/esm-resolve-hook.mjs
+++ b/scripts/esm-resolve-hook.mjs
@@ -1,0 +1,8 @@
+// Resolve hook: fix extensionless subpath imports for packages without exports maps.
+// vscode-jsonrpc 8.x exposes "node.js" but @github/copilot-sdk imports "node" (no extension).
+export async function resolve(specifier, context, nextResolve) {
+  if (specifier === 'vscode-jsonrpc/node') {
+    return nextResolve('vscode-jsonrpc/node.js', context);
+  }
+  return nextResolve(specifier, context);
+}

--- a/scripts/esm-resolve.mjs
+++ b/scripts/esm-resolve.mjs
@@ -1,0 +1,6 @@
+// Custom ESM resolve hook for vscode-jsonrpc subpath imports.
+// @github/copilot-sdk imports "vscode-jsonrpc/node" (extensionless)
+// but vscode-jsonrpc 8.x has no exports map, so Node ESM resolution fails.
+// This hook appends ".js" when needed.
+import { register } from 'node:module';
+register('./esm-resolve-hook.mjs', import.meta.url);


### PR DESCRIPTION
## Summary

Upgrades core Copilot dependencies to fix a **critical security vulnerability** (GHSA-g8r9-g2v8-jv6f: shell expansion → arbitrary code execution).

### Changes
- **@github/copilot** 0.0.414 → 1.0.5
- **@github/copilot-sdk** 0.1.30 → 0.1.32
- Added ESM resolve hook (vscode-jsonrpc 8.x lacks exports map; SDK imports extensionless subpath)
- Added \scode-jsonrpc\ npm override to deduplicate nested copies
- Added \.squad/\ runtime state to \.gitignore\

### Verification
- ✅ TypeScript typecheck passes
- ✅ Production build passes
- ✅ All 776 integration tests pass (0 failures)
- ✅ Dev server starts and connects to Copilot CLI successfully
- ✅ Vuln count reduced from 12 → 10 (2 critical eliminated)

### Security
Fixes [GHSA-g8r9-g2v8-jv6f](https://github.com/advisories/GHSA-g8r9-g2v8-jv6f) — the old \@github/copilot\ 0.x package had a shell expansion vulnerability that could lead to arbitrary code execution.