### PR TITLE
fix: harden localhost server

### DIFF
--- a/.squad/agents/irving/history.md
+++ b/.squad/agents/irving/history.md
@@ -7,6 +7,21 @@
 
 ## Learnings
 
+### 2026-03-16 — Localhost server hardening shipped
+
+**What changed:**
+- Added shared origin and browse-path guards in `src/serverSecurity.mjs` and used them in both `src/server.mjs` and `src/server-prod.mjs`.
+- Replaced wildcard CORS with an allowlist for localhost plus trusted Microsoft/Office hosts, and reject unexpected `Origin` headers before `/api` routes run.
+- Added WebSocket `Origin` validation in `src/copilotProxy.mjs` so `/api/copilot` now returns HTTP 403 for untrusted browser origins.
+- Locked `/api/env` down to non-sensitive runtime metadata only, and removed the PermissionManager dependency on path-bearing env data.
+- Hardened `/api/browse` with trusted-caller checks, canonical path checks, and explicit `..` traversal rejection while still allowing project/home browsing.
+- Updated live WebSocket integration tests to send `Origin: https://localhost:3000`, which matches real browser behaviour after the new upgrade gate.
+
+**Verification:**
+- `npm run build:dev`
+- `npm run test:integration`
+- Manual probes confirmed 403 responses for untrusted REST origins, path traversal on `/api/browse`, and untrusted WebSocket upgrades.
+
 ### 2026-03-16 — Backend/server review findings
 
 **Key findings:**

--- a/.squad/decisions/inbox/irving-server-security.md
+++ b/.squad/decisions/inbox/irving-server-security.md
@@ -1,0 +1,41 @@
+# Irving — Server security hardening decisions
+
+## Context
+Security review flagged overly-permissive localhost API exposure in `src/server.mjs` and unchecked WebSocket upgrades in `src/copilotProxy.mjs`.
+
+## Decisions made
+
+1. **Restrict API origins to trusted callers**
+   - Allow localhost variants (`https://localhost:*`, `http://localhost:*`, `127.0.0.1`, `::1`) for local development and same-machine tooling.
+   - Allow trusted Microsoft web origins (`https://*.officeapps.live.com`, `https://*.office.com`, `https://*.microsoft.com`) for Office-hosted task pane scenarios.
+   - Reject unexpected `Origin` headers on `/api/*` with HTTP 403 instead of silently serving the request.
+
+2. **Gate sensitive localhost APIs by trusted origin or loopback caller**
+   - `/api/env` and `/api/browse` now require either a trusted `Origin` header or a no-origin loopback request.
+   - This treats the local add-in/browser as the only supported caller while preserving same-machine diagnostics and automated tests.
+
+3. **Reduce `/api/env` data to non-sensitive metadata**
+   - Removed filesystem path disclosure (`cwd`, `home`).
+   - Kept only non-sensitive runtime hints (`platform`, `nodeEnv`, `browseRestricted`).
+   - Updated the Permission Manager UI to bootstrap directly from `/api/browse`, so it no longer needs path data from `/api/env`.
+
+4. **Constrain `/api/browse` to canonical approved roots**
+   - Approved roots are the project working directory and the user home directory.
+   - Requests are resolved through `realpath()` before authorization so prefix tricks and symlink escapes do not bypass the allowlist.
+   - Any request containing `..` path traversal segments is rejected.
+
+5. **Validate WebSocket upgrade origins**
+   - `/api/copilot` now rejects untrusted upgrade requests with HTTP 403 before `ws.handleUpgrade()` runs.
+   - No-origin loopback upgrades remain allowed for local tooling, but browser-origin upgrades must match the trusted allowlist.
+
+## Validation
+- `npm run build:dev`
+- `npm run test:integration`
+- Manual negative checks:
+  - bad REST origin => 403
+  - `/api/browse?path=..\\` => 403
+  - bad WebSocket origin => 403
+
+## Follow-up notes
+- The allowlist is intentionally practical, not exhaustive. If future Office hosts use different origins, extend `src/serverSecurity.mjs` rather than reopening wildcard CORS.
+- This change hardens both `src/server.mjs` and `src/server-prod.mjs` to avoid dev/prod security drift.

--- a/src/components/PermissionManagerDialog.tsx
+++ b/src/components/PermissionManagerDialog.tsx
@@ -49,20 +49,7 @@ export const PermissionManagerPanel: React.FC = () => {
   };
 
   useEffect(() => {
-    if (workingDirectory) {
-      void loadDir(workingDirectory);
-      return;
-    }
-    void (async () => {
-      try {
-        const response = await fetch(`${getLocalApiBase()}/api/env`);
-        const data = (await response.json()) as { cwd?: string; home?: string };
-        void loadDir(data.cwd ?? data.home);
-      } catch {
-        // Server unavailable — load root or leave empty
-        void loadDir();
-      }
-    })();
+    void loadDir(workingDirectory ?? undefined);
   }, [workingDirectory]);
 
   return (

--- a/src/copilotProxy.mjs
+++ b/src/copilotProxy.mjs
@@ -24,6 +24,7 @@ import {
   discoverPluginAgents,
   discoverPluginPrompts,
 } from './pluginDiscovery.mjs';
+import { isTrustedRequestOrigin } from './serverSecurity.mjs';
 
 const execFileAsync = promisify(execFile);
 /** On Windows, npm is npm.cmd — use the .cmd variant when on win32. */
@@ -736,6 +737,12 @@ export function setupCopilotProxy(httpsServer) {
     const url = new URL(request.url, `https://${request.headers.host}`);
 
     if (url.pathname === '/api/copilot') {
+      if (!isTrustedRequestOrigin(request.headers.origin, request.socket?.remoteAddress)) {
+        socket.write('HTTP/1.1 403 Forbidden\r\nConnection: close\r\n\r\n');
+        socket.destroy();
+        return;
+      }
+
       wss.handleUpgrade(request, socket, head, ws => {
         wss.emit('connection', ws, request);
       });

--- a/src/server-prod.mjs
+++ b/src/server-prod.mjs
@@ -10,6 +10,13 @@ import { resolve } from 'node:path';
 import { execSync } from 'node:child_process';
 import { setupCopilotProxy, checkCopilotHealth } from './copilotProxy.mjs';
 import { listMarketplaces, removeMarketplace as removeMarketplaceSvc } from './marketplaceService.mjs';
+import {
+  getBrowseRoots,
+  isAllowedOrigin,
+  isPathWithinRoot,
+  isTrustedRequestOrigin,
+  resolveBrowsePath,
+} from './serverSecurity.mjs';
 
 // ─── Copilot Plugin Helpers ────────────────────────────────────────────────
 
@@ -196,10 +203,41 @@ export async function createServer() {
   await checkPort(PORT);
 
   const app = express();
-  app.use(cors({ origin: '*' }));
+  const browseRoots = await getBrowseRoots();
+
+  app.use('/api', (req, res, next) => {
+    const origin = req.headers.origin;
+    if (origin && !isAllowedOrigin(origin)) {
+      res.status(403).json({ error: 'Origin is not allowed.' });
+      return;
+    }
+    next();
+  });
+  app.use(
+    '/api',
+    cors({
+      origin(origin, callback) {
+        if (!origin || isAllowedOrigin(origin)) {
+          callback(null, true);
+          return;
+        }
+        callback(null, false);
+      },
+    })
+  );
 
   const apiRouter = express.Router();
   apiRouter.use(express.json({ limit: '50mb' }));
+
+  const requireTrustedLocalAccess = (req, res, next) => {
+    const remoteAddress = req.socket?.remoteAddress;
+    if (isTrustedRequestOrigin(req.headers.origin, remoteAddress)) {
+      next();
+      return;
+    }
+
+    res.status(403).json({ error: 'This endpoint is only available to the local add-in.' });
+  };
 
   apiRouter.get('/hello', (_req, res) => {
     res.json({ message: 'Copilot proxy running', timestamp: new Date().toISOString() });
@@ -209,31 +247,34 @@ export async function createServer() {
     res.json({ ok: true });
   });
 
-  apiRouter.get('/env', (_req, res) => {
+  apiRouter.get('/env', requireTrustedLocalAccess, (_req, res) => {
     res.json({
-      cwd: process.cwd(),
-      home: os.homedir(),
       platform: process.platform,
+      nodeEnv: process.env.NODE_ENV ?? 'production',
+      browseRestricted: true,
     });
   });
 
-  apiRouter.get('/browse', async (req, res) => {
+  apiRouter.get('/browse', requireTrustedLocalAccess, async (req, res) => {
     try {
-      const requestedPath = typeof req.query.path === 'string' ? req.query.path : process.cwd();
-      const absolutePath = path.resolve(requestedPath);
+      const requestedPath = typeof req.query.path === 'string' ? req.query.path : undefined;
+      const absolutePath = await resolveBrowsePath(requestedPath, browseRoots);
       const entries = await fs.promises.readdir(absolutePath, { withFileTypes: true });
       const dirs = entries
         .filter(entry => entry.isDirectory())
         .map(entry => entry.name)
         .sort((a, b) => a.localeCompare(b));
       const parent = path.dirname(absolutePath);
+      const parentAllowed = parent !== absolutePath && browseRoots.some(root => isPathWithinRoot(root, parent));
       res.json({
         path: absolutePath,
-        parent: parent === absolutePath ? null : parent,
+        parent: parentAllowed ? parent : null,
         dirs,
       });
     } catch (error) {
-      res.status(400).json({ error: error instanceof Error ? error.message : String(error) });
+      const message = error instanceof Error ? error.message : String(error);
+      const status = /restricted|traversal/i.test(message) ? 403 : 400;
+      res.status(status).json({ error: message });
     }
   });
 

--- a/src/server.mjs
+++ b/src/server.mjs
@@ -21,6 +21,13 @@ import { fileURLToPath } from 'node:url';
 import { execSync } from 'node:child_process';
 import { setupCopilotProxy, checkCopilotHealth } from './copilotProxy.mjs';
 import { listMarketplaces, removeMarketplace as removeMarketplaceSvc } from './marketplaceService.mjs';
+import {
+  getBrowseRoots,
+  isAllowedOrigin,
+  isPathWithinRoot,
+  isTrustedRequestOrigin,
+  resolveBrowsePath,
+} from './serverSecurity.mjs';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const PORT = 3000;
@@ -217,11 +224,42 @@ async function createServer() {
   await checkPort(PORT);
 
   const app = express();
-  app.use(cors({ origin: '*' }));
+  const browseRoots = await getBrowseRoots();
+
+  app.use('/api', (req, res, next) => {
+    const origin = req.headers.origin;
+    if (origin && !isAllowedOrigin(origin)) {
+      res.status(403).json({ error: 'Origin is not allowed.' });
+      return;
+    }
+    next();
+  });
+  app.use(
+    '/api',
+    cors({
+      origin(origin, callback) {
+        if (!origin || isAllowedOrigin(origin)) {
+          callback(null, true);
+          return;
+        }
+        callback(null, false);
+      },
+    })
+  );
 
   // ─── API Routes ──────────────────────────────────────────────────────────────
   const apiRouter = express.Router();
   apiRouter.use(express.json({ limit: '50mb' }));
+
+  const requireTrustedLocalAccess = (req, res, next) => {
+    const remoteAddress = req.socket?.remoteAddress;
+    if (isTrustedRequestOrigin(req.headers.origin, remoteAddress)) {
+      next();
+      return;
+    }
+
+    res.status(403).json({ error: 'This endpoint is only available to the local add-in.' });
+  };
 
   apiRouter.get('/hello', (_req, res) => {
     res.json({ message: 'Copilot proxy running', timestamp: new Date().toISOString() });
@@ -231,42 +269,34 @@ async function createServer() {
     res.json({ ok: true });
   });
 
-  apiRouter.get('/env', (_req, res) => {
+  apiRouter.get('/env', requireTrustedLocalAccess, (_req, res) => {
     res.json({
-      cwd: process.cwd(),
-      home: os.homedir(),
       platform: process.platform,
+      nodeEnv: process.env.NODE_ENV ?? 'development',
+      browseRestricted: true,
     });
   });
 
-  apiRouter.get('/browse', async (req, res) => {
+  apiRouter.get('/browse', requireTrustedLocalAccess, async (req, res) => {
     try {
-      const requestedPath = typeof req.query.path === 'string' ? req.query.path : process.cwd();
-      const absolutePath = path.resolve(requestedPath);
-
-      // Security: restrict browsing to home directory or current working directory
-      const homeDir = os.homedir();
-      const cwdDir = process.cwd();
-      const isAllowed = absolutePath.startsWith(homeDir) || absolutePath.startsWith(cwdDir);
-      if (!isAllowed) {
-        res.status(403).json({ error: 'Browsing is restricted to the home or project directory.' });
-        return;
-      }
-
+      const requestedPath = typeof req.query.path === 'string' ? req.query.path : undefined;
+      const absolutePath = await resolveBrowsePath(requestedPath, browseRoots);
       const entries = await fs.promises.readdir(absolutePath, { withFileTypes: true });
       const dirs = entries
         .filter(entry => entry.isDirectory())
         .map(entry => entry.name)
         .sort((a, b) => a.localeCompare(b));
       const parent = path.dirname(absolutePath);
-      const parentAllowed = parent !== absolutePath && (parent.startsWith(homeDir) || parent.startsWith(cwdDir));
+      const parentAllowed = parent !== absolutePath && browseRoots.some(root => isPathWithinRoot(root, parent));
       res.json({
         path: absolutePath,
         parent: parentAllowed ? parent : null,
         dirs,
       });
     } catch (error) {
-      res.status(400).json({ error: error instanceof Error ? error.message : String(error) });
+      const message = error instanceof Error ? error.message : String(error);
+      const status = /restricted|traversal/i.test(message) ? 403 : 400;
+      res.status(status).json({ error: message });
     }
   });
 

--- a/src/serverSecurity.mjs
+++ b/src/serverSecurity.mjs
@@ -1,0 +1,83 @@
+import path from 'node:path';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+
+const LOOPBACK_HOST_RE = /^(localhost|127\.0\.0\.1|::1)$/i;
+const TRUSTED_HTTPS_HOST_RE = /^(?:[a-z0-9-]+\.)*(officeapps\.live\.com|office\.com|microsoft\.com)$/i;
+const PATH_TRAVERSAL_RE = /(^|[\\/])\.\.([\\/]|$)/;
+
+export function isAllowedOrigin(origin) {
+  if (!origin || typeof origin !== 'string') return false;
+
+  try {
+    const parsed = new URL(origin);
+    const protocol = parsed.protocol.toLowerCase();
+    const host = parsed.hostname.toLowerCase();
+
+    if (LOOPBACK_HOST_RE.test(host)) {
+      return protocol === 'https:' || protocol === 'http:';
+    }
+
+    return protocol === 'https:' && TRUSTED_HTTPS_HOST_RE.test(host);
+  } catch {
+    return false;
+  }
+}
+
+export function isLoopbackAddress(address) {
+  if (!address || typeof address !== 'string') return false;
+
+  const normalized = address.toLowerCase();
+  return (
+    normalized === '::1' ||
+    normalized === '127.0.0.1' ||
+    normalized === '::ffff:127.0.0.1' ||
+    normalized === '::ffff:7f00:1'
+  );
+}
+
+export function isTrustedRequestOrigin(origin, remoteAddress) {
+  if (origin) {
+    return isAllowedOrigin(origin);
+  }
+
+  return isLoopbackAddress(remoteAddress);
+}
+
+export async function getBrowseRoots() {
+  const candidates = [process.cwd(), os.homedir()];
+  const resolvedRoots = await Promise.all(
+    candidates.map(async candidate => {
+      try {
+        return await fs.realpath(candidate);
+      } catch {
+        return path.resolve(candidate);
+      }
+    })
+  );
+
+  return [...new Set(resolvedRoots)];
+}
+
+export function isPathWithinRoot(rootPath, targetPath) {
+  const relativePath = path.relative(rootPath, targetPath);
+  return relativePath === '' || (!relativePath.startsWith('..') && !path.isAbsolute(relativePath));
+}
+
+export async function resolveBrowsePath(requestedPath, allowedRoots) {
+  if (typeof requestedPath === 'string' && PATH_TRAVERSAL_RE.test(requestedPath)) {
+    throw new Error('Path traversal is not allowed.');
+  }
+
+  const candidatePath = typeof requestedPath === 'string' && requestedPath.trim()
+    ? requestedPath
+    : process.cwd();
+  const realPath = await fs.realpath(path.resolve(candidatePath));
+
+  const isAllowed = allowedRoots.some(root => isPathWithinRoot(root, realPath));
+  if (!isAllowed) {
+    throw new Error('Browsing is restricted to approved directories.');
+  }
+
+  return realPath;
+}

--- a/tests/integration/copilot-custom-agent.integration.test.ts
+++ b/tests/integration/copilot-custom-agent.integration.test.ts
@@ -25,6 +25,7 @@ global.WebSocket = class PatchedWebSocket extends WS {
   constructor(url: string | URL, protocols?: string | string[]) {
     super(url, typeof protocols === 'string' ? protocols : (protocols ?? []), {
       rejectUnauthorized: false,
+      origin: 'https://localhost:3000',
     });
   }
 } as unknown as typeof WebSocket;

--- a/tests/integration/copilot-plugin-e2e.integration.test.ts
+++ b/tests/integration/copilot-plugin-e2e.integration.test.ts
@@ -27,6 +27,7 @@ global.WebSocket = class PatchedWebSocket extends WS {
   constructor(url: string | URL, protocols?: string | string[]) {
     super(url, typeof protocols === 'string' ? protocols : (protocols ?? []), {
       rejectUnauthorized: false,
+      origin: 'https://localhost:3000',
     });
   }
 } as unknown as typeof WebSocket;

--- a/tests/integration/copilot-websocket.integration.test.ts
+++ b/tests/integration/copilot-websocket.integration.test.ts
@@ -24,6 +24,7 @@ global.WebSocket = class PatchedWebSocket extends WS {
   constructor(url: string | URL, protocols?: string | string[]) {
     super(url, typeof protocols === 'string' ? protocols : (protocols ?? []), {
       rejectUnauthorized: false,
+      origin: 'https://localhost:3000',
     });
   }
 } as unknown as typeof WebSocket;

--- a/tests/integration/permission-manager-dialog.test.tsx
+++ b/tests/integration/permission-manager-dialog.test.tsx
@@ -12,7 +12,7 @@ import { renderWithProviders } from '../test-utils';
 import { PermissionManagerPanel } from '@/components/PermissionManagerDialog';
 import { usePermissionStore } from '@/stores/permissionStore';
 
-// Mock fetch for /api/browse and /api/env
+// Mock fetch for /api/browse
 const mockFetchResponses: Record<string, unknown> = {};
 
 beforeEach(() => {
@@ -23,7 +23,6 @@ beforeEach(() => {
   });
 
   // Default fetch mocks
-  mockFetchResponses['/api/env'] = { cwd: '/Users/test/project', home: '/Users/test' };
   mockFetchResponses['/api/browse'] = {
     path: '/Users/test/project',
     parent: '/Users/test',


### PR DESCRIPTION
## Summary
- replace wildcard localhost API CORS with a trusted origin allowlist for localhost and Microsoft Office hosts
- reject untrusted /api/copilot WebSocket upgrades and lock /api/env + /api/browse behind trusted caller checks
- harden directory browsing with canonical root checks and traversal rejection, and update the permission manager/tests for the new flow

## Validation
- npm run build:dev
- npm run test:integration
- manual 403 checks for bad REST origins, browse traversal attempts, and bad WebSocket origins

Please use **Squash and merge** when merging.