### PR TITLE
fix(ci): resolve EnvironmentTeardownError in app-state test teardown

### DIFF
--- a/tests/integration/app-state.test.tsx
+++ b/tests/integration/app-state.test.tsx
@@ -31,6 +31,36 @@ vi.mock('@/components/ChatPanel', () => ({
     }),
 }));
 
+// Prevent real WebSocket connection attempts during teardown (no dev server in CI).
+// app-state.test.tsx only tests theme detection and App state transitions — it
+// doesn't need a live Copilot session.
+vi.mock('@/hooks/useOfficeChat', () => ({
+  useOfficeChat: () => ({
+    messages: [],
+    isRunning: false,
+    send: vi.fn(),
+    cancel: vi.fn(),
+    sessionError: null,
+    isConnecting: false,
+    clearMessages: vi.fn(),
+    restoreSession: vi.fn(),
+    deleteSession: vi.fn(),
+    sessions: [],
+    activeSessionId: undefined,
+    pendingPermission: null,
+    allowAllPermissions: vi.fn(),
+    approvePermission: vi.fn(),
+    denyPermission: vi.fn(),
+    allowPermissionAlways: vi.fn(),
+    compactSession: vi.fn().mockResolvedValue(undefined),
+    switchModel: vi.fn().mockResolvedValue(undefined),
+    enqueue: vi.fn(),
+    queuedPrompts: [],
+    dequeue: vi.fn(),
+    clearQueue: vi.fn(),
+  }),
+}));
+
 const { App } = await import('@/taskpane/App');
 
 describe('App — state transitions and theme', () => {


### PR DESCRIPTION
## Problem

CI exits with code 1 despite all tests passing. Root cause: app-state.test.tsx renders App, which mounts ReadyAssistant, which calls useOfficeChat(host). The hook immediately fires a WebSocket connection to ws://localhost:3000/api/copilot. In CI (no dev server), the connection fails asynchronously, triggering console.error('[chat] initSession failed'). That log fires during Vitest worker teardown, when the onUserConsoleLog RPC channel is already closing -- crashing the run with EnvironmentTeardownError even though every assertion passed.

## Fix

Added vi.mock('@/hooks/useOfficeChat') to app-state.test.tsx with a stable no-op return value. The test only exercises App theme detection and render state -- it never needed a live Copilot session. The mock returns the full correct hook shape so ReadyAssistant renders normally.

## Verification

- app-state.test.tsx: 4/4 tests pass, exit code 0, no teardown error
- npm run test:integration: 759 passing tests unaffected; 17 remaining failures are pre-existing live-server tests requiring npm run dev

## Merge

Please use Squash and merge on GitHub.
