### PR TITLE
Include plugin MCP servers in add-in discovery

### DIFF
--- a/src/plugins/cliMcpServers.d.ts
+++ b/src/plugins/cliMcpServers.d.ts
@@ -17,6 +17,7 @@ declare module '*/cliMcpServers.mjs' {
   export interface CopilotMcpServerOptions {
     command?: string;
     timeoutMs?: number;
+    installedPluginsDir?: string;
     runCommand?: (options: CopilotMcpServerOptions) => Promise<CopilotCommandResult>;
   }
 
@@ -24,6 +25,14 @@ declare module '*/cliMcpServers.mjs' {
     options?: CopilotMcpServerOptions
   ): Promise<CopilotCommandResult>;
   export function parseCopilotMcpListJson(stdout: string): McpServerConfig[];
+  export function parseMcpServerDocument(
+    parsed: unknown,
+    options?: { source?: string }
+  ): McpServerConfig[];
+  export function getPluginMcpServers(options?: CopilotMcpServerOptions): Promise<{
+    servers: McpServerConfig[];
+    errors: string[];
+  }>;
   export function getCliMcpServers(
     options?: CopilotMcpServerOptions
   ): Promise<CopilotMcpServerListResult>;

--- a/src/plugins/cliMcpServers.mjs
+++ b/src/plugins/cliMcpServers.mjs
@@ -1,6 +1,10 @@
 import { spawn } from 'node:child_process';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
 
 const DEFAULT_TIMEOUT_MS = 30_000;
+const DEFAULT_INSTALLED_PLUGINS_DIR = path.join(os.homedir(), '.copilot', 'installed-plugins');
 
 export function runCopilotMcpListCommand(options = {}) {
   const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
@@ -67,29 +71,43 @@ function normalizeTransport(type) {
   return undefined;
 }
 
-export function parseCopilotMcpListJson(stdout) {
-  const parsed = JSON.parse(stdout);
-  const mcpServers = parsed?.mcpServers;
+function inferTransport(server) {
+  const explicit = normalizeTransport(server.type ?? server.transport);
+  if (explicit) return explicit;
+  if (typeof server.command === 'string') return 'stdio';
+  if (typeof server.url === 'string') return 'http';
+  return undefined;
+}
+
+function parseMcpServerEntries(mcpServers, options = {}) {
   if (!mcpServers || typeof mcpServers !== 'object') return [];
 
   return Object.entries(mcpServers)
     .map(([name, server]) => {
       if (!server || typeof server !== 'object') return undefined;
-      const transport = normalizeTransport(server.type);
+      const transport = inferTransport(server);
       if (!transport) return undefined;
+      const source = typeof server.source === 'string' ? server.source : options.source;
 
       const base = {
         name,
-        description: server.source ? `Source: ${server.source}` : undefined,
+        description:
+          typeof server.description === 'string'
+            ? server.description
+            : source
+              ? `Source: ${source}`
+              : undefined,
         transport,
-        source: server.source,
+        source,
       };
 
       if (transport === 'stdio') {
         return {
           ...base,
           command: typeof server.command === 'string' ? server.command : '',
-          args: Array.isArray(server.args) ? server.args.filter(arg => typeof arg === 'string') : [],
+          args: Array.isArray(server.args)
+            ? server.args.filter(arg => typeof arg === 'string')
+            : [],
           ...(server.env && typeof server.env === 'object' ? { env: server.env } : {}),
         };
       }
@@ -97,10 +115,90 @@ export function parseCopilotMcpListJson(stdout) {
       return {
         ...base,
         url: typeof server.url === 'string' ? server.url : '',
-        ...(server.headers && typeof server.headers === 'object' ? { headers: server.headers } : {}),
+        ...(server.headers && typeof server.headers === 'object'
+          ? { headers: server.headers }
+          : {}),
       };
     })
     .filter(Boolean);
+}
+
+export function parseCopilotMcpListJson(stdout, options = {}) {
+  const parsed = JSON.parse(stdout);
+  return parseMcpServerDocument(parsed, options);
+}
+
+export function parseMcpServerDocument(parsed, options = {}) {
+  return parseMcpServerEntries(parsed?.mcpServers ?? parsed?.servers, options);
+}
+
+async function findPluginManifestPaths(root) {
+  let entries;
+  try {
+    entries = await fs.readdir(root, { withFileTypes: true });
+  } catch (error) {
+    if (error?.code === 'ENOENT') return [];
+    throw error;
+  }
+
+  const manifests = [];
+  for (const entry of entries) {
+    const entryPath = path.join(root, entry.name);
+    if (entry.isFile() && entry.name === 'plugin.json') {
+      manifests.push(entryPath);
+    } else if (entry.isDirectory() && entry.name !== '.git' && entry.name !== 'node_modules') {
+      manifests.push(...(await findPluginManifestPaths(entryPath)));
+    }
+  }
+  return manifests;
+}
+
+async function readPluginMcpServers(manifestPath) {
+  const manifest = JSON.parse(await fs.readFile(manifestPath, 'utf8'));
+  const pluginDir = path.dirname(manifestPath);
+  const pluginName = typeof manifest.name === 'string' ? manifest.name : path.basename(pluginDir);
+  const source = `plugin:${pluginName}`;
+  const mcpServers = manifest.mcpServers;
+
+  if (typeof mcpServers === 'string') {
+    const mcpPath = path.resolve(pluginDir, mcpServers);
+    const document = JSON.parse(await fs.readFile(mcpPath, 'utf8'));
+    return parseMcpServerDocument(document, { source });
+  }
+
+  if (mcpServers && typeof mcpServers === 'object') {
+    return parseMcpServerEntries(mcpServers, { source });
+  }
+
+  return [];
+}
+
+export async function getPluginMcpServers(options = {}) {
+  const installedPluginsDir = options.installedPluginsDir ?? DEFAULT_INSTALLED_PLUGINS_DIR;
+  const manifestPaths = await findPluginManifestPaths(installedPluginsDir);
+  const servers = [];
+  const errors = [];
+
+  for (const manifestPath of manifestPaths) {
+    try {
+      servers.push(...(await readPluginMcpServers(manifestPath)));
+    } catch (error) {
+      errors.push(`${manifestPath}: ${error instanceof Error ? error.message : String(error)}`);
+    }
+  }
+
+  return { servers, errors };
+}
+
+function mergeServers(cliServers, pluginServers) {
+  const seen = new Set();
+  const merged = [];
+  for (const server of [...cliServers, ...pluginServers]) {
+    if (seen.has(server.name)) continue;
+    seen.add(server.name);
+    merged.push(server);
+  }
+  return merged;
 }
 
 export async function getCliMcpServers(options = {}) {
@@ -113,7 +211,15 @@ export async function getCliMcpServers(options = {}) {
   }
 
   try {
-    return { servers: parseCopilotMcpListJson(result.stdout), error: undefined };
+    const cliServers = parseCopilotMcpListJson(result.stdout);
+    const pluginResult = await getPluginMcpServers(options);
+    return {
+      servers: mergeServers(cliServers, pluginResult.servers),
+      error:
+        pluginResult.errors.length > 0
+          ? `Failed to load plugin MCP servers: ${pluginResult.errors.join('; ')}`
+          : undefined,
+    };
   } catch (error) {
     return {
       servers: [],

--- a/src/tools/codegen/factory.ts
+++ b/src/tools/codegen/factory.ts
@@ -40,7 +40,15 @@ function jsonSchemaForType(type: ParamType, enumValues?: readonly string[]): JSO
     case 'string[]':
       return { type: 'array', items: { type: 'string' } };
     case 'any[][]':
-      return { type: 'array', items: { type: 'array' } };
+      return {
+        type: 'array',
+        items: {
+          type: 'array',
+          items: {
+            anyOf: [{ type: 'string' }, { type: 'number' }, { type: 'boolean' }, { type: 'null' }],
+          },
+        },
+      };
     case 'string[][]':
       return { type: 'array', items: { type: 'array', items: { type: 'string' } } };
   }

--- a/tests/integration/cli-mcp-servers.test.ts
+++ b/tests/integration/cli-mcp-servers.test.ts
@@ -1,5 +1,12 @@
 import { describe, expect, it } from 'vitest';
-import { getCliMcpServers, parseCopilotMcpListJson } from '@/../src/plugins/cliMcpServers.mjs';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import {
+  getCliMcpServers,
+  parseCopilotMcpListJson,
+  parseMcpServerDocument,
+} from '@/../src/plugins/cliMcpServers.mjs';
 
 describe('CLI MCP servers', () => {
   it('parses Copilot CLI MCP list JSON into task pane server configs', () => {
@@ -55,6 +62,114 @@ describe('CLI MCP servers', () => {
     expect(result).toEqual({
       servers: [],
       error: 'copilot failed',
+    });
+  });
+
+  it('parses MCP documents that use VS Code-style servers without explicit transport types', () => {
+    const servers = parseMcpServerDocument({
+      servers: {
+        'powerbi-remote': {
+          url: 'https://api.fabric.microsoft.com/v1/mcp/powerbi',
+        },
+        workiq: {
+          command: 'npx',
+          args: ['-y', '@microsoft/workiq@latest', 'mcp'],
+        },
+      },
+    });
+
+    expect(servers).toEqual([
+      {
+        name: 'powerbi-remote',
+        description: undefined,
+        transport: 'http',
+        url: 'https://api.fabric.microsoft.com/v1/mcp/powerbi',
+        source: undefined,
+      },
+      {
+        name: 'workiq',
+        description: undefined,
+        transport: 'stdio',
+        command: 'npx',
+        args: ['-y', '@microsoft/workiq@latest', 'mcp'],
+        source: undefined,
+      },
+    ]);
+  });
+
+  it('merges plugin-declared MCP servers into the CLI-backed server list', async () => {
+    const installedPluginsDir = await fs.mkdtemp(path.join(os.tmpdir(), 'oca-mcp-plugins-'));
+    const pluginDir = path.join(installedPluginsDir, 'iq-core');
+    await fs.mkdir(pluginDir, { recursive: true });
+    await fs.writeFile(
+      path.join(pluginDir, 'plugin.json'),
+      JSON.stringify({
+        name: 'iq-core',
+        mcpServers: '.mcp.json',
+      })
+    );
+    await fs.writeFile(
+      path.join(pluginDir, '.mcp.json'),
+      JSON.stringify({
+        mcpServers: {
+          'powerbi-remote': {
+            type: 'http',
+            url: 'https://api.fabric.microsoft.com/v1/mcp/powerbi',
+          },
+          workiq: {
+            command: 'npx',
+            args: ['-y', '@microsoft/workiq@latest', 'mcp'],
+          },
+        },
+      })
+    );
+
+    const result = await getCliMcpServers({
+      installedPluginsDir,
+      runCommand: async () => ({
+        success: true,
+        stdout: JSON.stringify({
+          mcpServers: {
+            's360-breeze': {
+              type: 'stdio',
+              command: 'agency.exe',
+              args: ['mcp', 'remote'],
+              source: 'user',
+            },
+          },
+        }),
+        stderr: '',
+        message: '',
+      }),
+    });
+
+    expect(result).toEqual({
+      error: undefined,
+      servers: [
+        {
+          name: 's360-breeze',
+          description: 'Source: user',
+          transport: 'stdio',
+          command: 'agency.exe',
+          args: ['mcp', 'remote'],
+          source: 'user',
+        },
+        {
+          name: 'powerbi-remote',
+          description: 'Source: plugin:iq-core',
+          transport: 'http',
+          url: 'https://api.fabric.microsoft.com/v1/mcp/powerbi',
+          source: 'plugin:iq-core',
+        },
+        {
+          name: 'workiq',
+          description: 'Source: plugin:iq-core',
+          transport: 'stdio',
+          command: 'npx',
+          args: ['-y', '@microsoft/workiq@latest', 'mcp'],
+          source: 'plugin:iq-core',
+        },
+      ],
     });
   });
 });

--- a/tests/integration/excel-tools.test.ts
+++ b/tests/integration/excel-tools.test.ts
@@ -18,6 +18,20 @@ function validate(schema: unknown, data: unknown): { success: boolean } {
   return { success: !!fn(data) };
 }
 
+/** Assert every array schema declares items, as required by Copilot function schemas. */
+function expectArraySchemasDeclareItems(schema: unknown, path = 'parameters'): void {
+  if (!schema || typeof schema !== 'object') return;
+
+  const node = schema as Record<string, unknown>;
+  if (node.type === 'array') {
+    expect(node, `${path} array schema`).toHaveProperty('items');
+  }
+
+  for (const [key, value] of Object.entries(node)) {
+    expectArraySchemasDeclareItems(value, `${path}.${key}`);
+  }
+}
+
 /** Look up an Excel tool by name */
 const toolsByName = Object.fromEntries(excelTools.map(t => [t.name, t]));
 
@@ -59,6 +73,12 @@ describe('Integration: Excel tool configs — structural', () => {
         expect(tool.parameters).toBeDefined();
         expect(typeof tool.handler).toBe('function');
       }
+    }
+  });
+
+  it('every generated schema declares items for array parameters', () => {
+    for (const tool of excelTools) {
+      expectArraySchemasDeclareItems(tool.parameters, tool.name);
     }
   });
 });


### PR DESCRIPTION
## Summary
- include MCP servers declared by installed Copilot CLI plugin manifests in /api/mcp-servers
- support both mcpServers and VS Code-style servers MCP document shapes
- add integration coverage for plugin-declared Power BI/WorkIQ MCP servers

## Validation
- npm run typecheck
- npm run test:integration

Please review and merge using **Squash and merge** on GitHub.