### PR TITLE
Add SDK plan mode and permission management

### DIFF
--- a/src/components/AgentPicker.tsx
+++ b/src/components/AgentPicker.tsx
@@ -16,7 +16,7 @@ export const AgentPicker: React.FC<AgentPickerProps> = ({ onSwitchAgent }) => {
 
   const agents = availableAgents ?? [];
   const activeAgent = activeAgentName ? agents.find(agent => agent.name === activeAgentName) : null;
-  const displayName = activeAgent?.displayName ?? 'Default';
+  const displayName = activeAgent?.displayName ?? 'Office default';
 
   const selectAgent = (agentName: string | null) => {
     void (async () => {
@@ -96,8 +96,8 @@ export const AgentPicker: React.FC<AgentPickerProps> = ({ onSwitchAgent }) => {
           <div className="px-2 py-1.5 text-xs font-medium text-muted-foreground">Agents</div>
           {renderAgentOption(
             null,
-            'Default',
-            'Use the default Copilot CLI agent for this Office host.',
+            'Office default',
+            'Use the bundled Office CLI plugin agent for this host.',
             activeAgentName === null
           )}
           {availableAgents === null ? (

--- a/src/components/ChatPanel.tsx
+++ b/src/components/ChatPanel.tsx
@@ -3,8 +3,10 @@ import { MessageList } from '@/components/chat/MessageList';
 import { AgentPicker } from './AgentPicker';
 import { ModelPicker } from './ModelPicker';
 import { McpPicker } from './McpPicker';
+import { Codicon } from './Codicon';
 import type { McpOAuthPromptRequest } from './McpOAuthPrompt';
 import type { ChatMessage } from '@/types';
+import type { SessionMode } from '@/lib/websocket-client';
 
 interface ChatPanelProps {
   messages: ChatMessage[];
@@ -15,6 +17,9 @@ interface ChatPanelProps {
   onSwitchAgent?: (agentName: string | null) => Promise<void>;
   onInitiateMcpOAuth?: (serverName: string, loginHint?: string) => Promise<string | undefined>;
   onOpenMcpOAuthPrompt?: (request: McpOAuthPromptRequest) => void;
+  sessionMode: SessionMode;
+  onSwitchSessionMode: (mode: SessionMode) => Promise<void>;
+  onOpenPlan: () => void;
   onEnqueue?: (text: string) => void;
   queuedPrompts?: string[];
   onDequeue?: (index: number) => void;
@@ -29,6 +34,9 @@ export const ChatPanel: React.FC<ChatPanelProps> = ({
   onSwitchAgent,
   onInitiateMcpOAuth,
   onOpenMcpOAuthPrompt,
+  sessionMode,
+  onSwitchSessionMode,
+  onOpenPlan,
   onEnqueue,
   queuedPrompts,
   onDequeue,
@@ -53,6 +61,36 @@ export const ChatPanel: React.FC<ChatPanelProps> = ({
           <>
             <AgentPicker onSwitchAgent={onSwitchAgent} />
             <ModelPicker hasActiveSession={messages.length > 0} onSwitchModel={onSwitchModel} />
+            <button
+              type="button"
+              onClick={() =>
+                void onSwitchSessionMode(sessionMode === 'plan' ? 'interactive' : 'plan')
+              }
+              className="aui-plan-mode-button inline-flex h-[22px] items-center gap-1 rounded-[var(--vscode-cornerRadius-small)] px-1.5 text-[11px] transition-colors hover:bg-[var(--vscode-toolbar-hoverBackground)]"
+              style={{
+                color:
+                  sessionMode === 'plan'
+                    ? 'var(--vscode-badge-foreground)'
+                    : 'var(--vscode-icon-foreground)',
+                backgroundColor:
+                  sessionMode === 'plan' ? 'var(--vscode-badge-background)' : 'transparent',
+              }}
+              title={sessionMode === 'plan' ? 'Exit Plan mode' : 'Enter Plan mode'}
+              aria-label={sessionMode === 'plan' ? 'Exit Plan mode' : 'Enter Plan mode'}
+            >
+              <Codicon name="checklist" className="text-xs" />
+              Plan
+            </button>
+            <button
+              type="button"
+              onClick={onOpenPlan}
+              className="inline-flex h-[22px] items-center justify-center rounded-[var(--vscode-cornerRadius-small)] px-1 transition-colors hover:bg-[var(--vscode-toolbar-hoverBackground)]"
+              style={{ color: 'var(--vscode-icon-foreground)' }}
+              title="Open plan"
+              aria-label="Open plan"
+            >
+              <Codicon name="note" className="text-xs" />
+            </button>
           </>
         }
         rightToolbar={

--- a/src/components/PermissionManagerDialog.tsx
+++ b/src/components/PermissionManagerDialog.tsx
@@ -1,190 +1,67 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import React from 'react';
 import { Codicon } from '@/components/Codicon';
-import { usePermissionStore } from '@/stores';
-import { getLocalApiBase } from '@/lib/api';
 
-interface BrowseResponse {
-  path: string;
-  parent: string | null;
-  dirs: string[];
-  error?: string;
+interface PermissionManagerPanelProps {
+  approveAll: boolean;
+  onSetApproveAll: (enabled: boolean) => void | Promise<void>;
+  onResetSessionApprovals: () => void | Promise<void>;
 }
 
-export const PermissionManagerPanel: React.FC = () => {
-  const [browseOpen, setBrowseOpen] = useState(false);
-  const [browsePath, setBrowsePath] = useState<string>('');
-  const [browseParent, setBrowseParent] = useState<string | null>(null);
-  const [browseDirs, setBrowseDirs] = useState<string[]>([]);
-  const [browseLoading, setBrowseLoading] = useState(false);
-
-  const allowAll = usePermissionStore(s => s.allowAll);
-  const workingDirectory = usePermissionStore(s => s.workingDirectory);
-  const rules = usePermissionStore(s => s.rules);
-  const setAllowAll = usePermissionStore(s => s.setAllowAll);
-  const setWorkingDirectory = usePermissionStore(s => s.setWorkingDirectory);
-  const removeRule = usePermissionStore(s => s.removeRule);
-  const clearRules = usePermissionStore(s => s.clearRules);
-
-  const sortedRules = useMemo(
-    () => [...rules].sort((a, b) => a.pathPrefix.localeCompare(b.pathPrefix)),
-    [rules]
-  );
-
-  const loadDir = async (pathValue?: string) => {
-    setBrowseLoading(true);
-    try {
-      const query = pathValue ? `?path=${encodeURIComponent(pathValue)}` : '';
-      const response = await fetch(`${getLocalApiBase()}/api/browse${query}`);
-      const data = (await response.json()) as BrowseResponse;
-      if (data.error) return;
-      setBrowsePath(data.path);
-      setBrowseParent(data.parent);
-      setBrowseDirs(data.dirs ?? []);
-    } catch {
-      // Network error — clear stale directories so the UI doesn't show old data
-      setBrowseDirs([]);
-    } finally {
-      setBrowseLoading(false);
-    }
-  };
-
-  useEffect(() => {
-    void loadDir(workingDirectory ?? undefined);
-  }, [workingDirectory]);
-
+export const PermissionManagerPanel: React.FC<PermissionManagerPanelProps> = ({
+  approveAll,
+  onSetApproveAll,
+  onResetSessionApprovals,
+}) => {
   return (
     <div className="space-y-4 p-3 text-sm">
-      <div className="flex items-center justify-between rounded-md border border-border p-3">
+      <div
+        className="flex items-center justify-between rounded-[var(--vscode-cornerRadius-medium)] border p-3"
+        style={{ borderColor: 'var(--vscode-widget-border)' }}
+      >
         <div>
           <div className="font-medium">Allow all</div>
-          <div className="text-xs text-muted-foreground">Auto-approve all permission requests.</div>
+          <div className="text-xs" style={{ color: 'var(--vscode-descriptionForeground)' }}>
+            Use the Copilot CLI session setting to auto-approve permission requests.
+          </div>
         </div>
         <button
           type="button"
-          onClick={() => setAllowAll(!allowAll)}
-          className={`inline-flex rounded-md px-2 py-1 text-xs font-medium ${
-            allowAll ? 'bg-primary text-primary-foreground' : 'bg-muted text-muted-foreground'
-          }`}
+          onClick={() => void onSetApproveAll(!approveAll)}
+          className="inline-flex rounded-[var(--vscode-cornerRadius-medium)] px-2 py-1 text-xs font-medium"
+          style={{
+            color: approveAll
+              ? 'var(--vscode-button-foreground)'
+              : 'var(--vscode-button-secondaryForeground)',
+            backgroundColor: approveAll
+              ? 'var(--vscode-button-background)'
+              : 'var(--vscode-button-secondaryBackground)',
+          }}
         >
-          {allowAll ? 'On' : 'Off'}
+          {approveAll ? 'On' : 'Off'}
         </button>
       </div>
 
-      <div className="rounded-md border border-border p-3">
-        <div className="mb-1 font-medium">Working directory</div>
-        <div
-          className="text-xs text-muted-foreground truncate"
-          title={workingDirectory ?? undefined}
+      <div
+        className="rounded-[var(--vscode-cornerRadius-medium)] border p-3"
+        style={{ borderColor: 'var(--vscode-widget-border)' }}
+      >
+        <div className="mb-1 font-medium">Session approvals</div>
+        <div className="mb-3 text-xs" style={{ color: 'var(--vscode-descriptionForeground)' }}>
+          Approvals remembered for this Copilot session are owned by the SDK.
+        </div>
+        <button
+          type="button"
+          onClick={() => void onResetSessionApprovals()}
+          className="inline-flex items-center gap-1 rounded-[var(--vscode-cornerRadius-medium)] border px-2 py-1 text-xs"
+          style={{
+            borderColor: 'var(--vscode-widget-border)',
+            color: 'var(--vscode-foreground)',
+            backgroundColor: 'transparent',
+          }}
         >
-          {workingDirectory ?? 'Not set'}
-        </div>
-        <div className="mt-2 flex items-center gap-2">
-          <button
-            type="button"
-            onClick={() => setBrowseOpen(v => !v)}
-            className="inline-flex items-center gap-1 rounded-md border border-border px-2 py-1 text-xs hover:bg-accent"
-          >
-            <Codicon name="folder" className="text-xs" /> Browse
-          </button>
-          {workingDirectory && (
-            <button
-              type="button"
-              onClick={() => setWorkingDirectory(null)}
-              className="inline-flex rounded-md border border-border px-2 py-1 text-xs hover:bg-accent"
-            >
-              Clear
-            </button>
-          )}
-        </div>
-
-        {browseOpen && (
-          <div className="mt-2 rounded-md border border-border p-2">
-            <div className="mb-2 flex items-center justify-between text-xs">
-              <span className="truncate pr-2">{browsePath || '(loading...)'}</span>
-              {browseParent && (
-                <button
-                  type="button"
-                  onClick={() => void loadDir(browseParent)}
-                  className="rounded border border-border px-2 py-0.5 hover:bg-accent"
-                >
-                  Up
-                </button>
-              )}
-            </div>
-            <div className="max-h-36 overflow-auto rounded border border-border">
-              {browseLoading ? (
-                <div className="px-2 py-1.5 text-xs text-muted-foreground">Loading…</div>
-              ) : browseDirs.length === 0 ? (
-                <div className="px-2 py-1.5 text-xs text-muted-foreground">No subdirectories</div>
-              ) : (
-                browseDirs.map(dir => (
-                  <button
-                    type="button"
-                    key={dir}
-                    onClick={() => void loadDir(`${browsePath}/${dir}`)}
-                    className="flex w-full items-center gap-1 px-2 py-1 text-left text-xs hover:bg-accent"
-                  >
-                    <Codicon name="folder" className="text-xs" /> {dir}
-                  </button>
-                ))
-              )}
-            </div>
-            <div className="mt-2 flex justify-end">
-              <button
-                type="button"
-                onClick={() => {
-                  setWorkingDirectory(browsePath || null);
-                  setBrowseOpen(false);
-                }}
-                className="rounded-md bg-primary px-2 py-1 text-xs text-primary-foreground hover:opacity-90"
-              >
-                Select
-              </button>
-            </div>
-          </div>
-        )}
-      </div>
-
-      <div className="rounded-md border border-border p-3">
-        <div className="mb-2 flex items-center justify-between">
-          <div className="font-medium">Saved rules</div>
-          {sortedRules.length > 0 && (
-            <button
-              type="button"
-              onClick={clearRules}
-              className="rounded-md border border-border px-2 py-1 text-xs hover:bg-accent"
-            >
-              Clear all
-            </button>
-          )}
-        </div>
-
-        {sortedRules.length === 0 ? (
-          <div className="text-xs text-muted-foreground">No saved rules.</div>
-        ) : (
-          <div className="max-h-40 space-y-1 overflow-auto">
-            {sortedRules.map(rule => (
-              <div
-                key={rule.id}
-                className="flex items-center justify-between gap-2 rounded border border-border px-2 py-1"
-              >
-                <div className="min-w-0 text-xs">
-                  <div className="font-medium">{rule.kind}</div>
-                  <div className="truncate text-muted-foreground">{rule.pathPrefix}</div>
-                </div>
-                <button
-                  type="button"
-                  onClick={() => removeRule(rule.id)}
-                  className="rounded p-1 text-muted-foreground hover:bg-accent hover:text-foreground"
-                  aria-label="Remove rule"
-                  title="Remove rule"
-                >
-                  <Codicon name="trash" className="text-xs" />
-                </button>
-              </div>
-            ))}
-          </div>
-        )}
+          <Codicon name="discard" className="text-xs" />
+          Reset session approvals
+        </button>
       </div>
     </div>
   );

--- a/src/copilotProxy.mjs
+++ b/src/copilotProxy.mjs
@@ -259,7 +259,7 @@ async function handleConnection(ws) {
   /** @type {Map<number, { resolve: Function, reject: Function }>} */
   const pendingRequests = new Map();
 
-  /** @type {Map<string, { sessionId: string, resolve: (decision: 'approved'|'denied') => void, timer: NodeJS.Timeout }>} */
+  /** @type {Map<string, { sessionId: string, resolve: (decision: import('@github/copilot-sdk').PermissionRequestResult) => void, timer: NodeJS.Timeout }>} */
   const pendingPermissionResponses = new Map();
 
   function sendRequest(method, params) {
@@ -282,13 +282,14 @@ async function handleConnection(ws) {
       sessionId,
       requestId,
       request,
+      locationKey: process.cwd(),
     });
 
     return new Promise(resolve => {
       const timer = setTimeout(() => {
         pendingPermissionResponses.delete(requestId);
-        console.warn(`[proxy] permission.request timed out (${requestId}) — default deny`);
-        resolve('denied');
+        console.warn(`[proxy] permission.request timed out (${requestId}) — user not available`);
+        resolve({ kind: 'user-not-available' });
       }, 60_000);
 
       pendingPermissionResponses.set(requestId, {
@@ -378,11 +379,12 @@ async function handleConnection(ws) {
           `[proxy] session.create requested (host=${host}, model=${model}, sessionId=${sessionId}, tools=${(toolDefs || []).length}, mcpServers=${Object.keys(mcpServers || {}).length})`
         );
         // Build SDK Tool[] with handlers that forward tool calls to the browser
-        const tools = (toolDefs || []).map(t => ({
-          name: t.name,
-          description: t.description,
-          parameters: t.parameters,
-          handler: async (args, invocation) => {
+          const tools = (toolDefs || []).map(t => ({
+            name: t.name,
+            description: t.description,
+            parameters: t.parameters,
+            skipPermission: t.skipPermission !== false,
+            handler: async (args, invocation) => {
             const response = await sendRequest('tool.call', {
               sessionId: invocation.sessionId,
               toolCallId: invocation.toolCallId,
@@ -418,17 +420,9 @@ async function handleConnection(ws) {
             agent: typeof agent === 'string' && agent.length > 0 ? agent : undefined,
             onPermissionRequest: async request => {
               console.log(`[proxy] permission.request received: ${request.kind}`);
-              // Auto-approve custom-tool permissions — these are tools explicitly
-              // registered by the session creator, not built-in filesystem tools.
-              // The SDK denies permissions by default; our own tools
-              // should always be allowed to execute.
-              if (request.kind === 'custom-tool') {
-                console.log(`[proxy] permission.request auto-approved: ${request.kind}`);
-                return { kind: 'approve-once' };
-              }
               const decision = await requestPermissionDecision(session.sessionId, request);
-              console.log(`[proxy] permission.request resolved: ${request.kind} => ${decision}`);
-              return decision === 'approved' ? { kind: 'approve-once' } : { kind: 'reject' };
+              console.log(`[proxy] permission.request resolved: ${request.kind} => ${decision.kind}`);
+              return decision;
             },
           });
         } catch (err) {
@@ -469,7 +463,7 @@ async function handleConnection(ws) {
         });
         eventUnsubs.set(session.sessionId, unsub);
 
-        sendResponse(id, { sessionId: session.sessionId });
+        sendResponse(id, { sessionId: session.sessionId, workspacePath: session.workspacePath });
         break;
       }
 
@@ -581,7 +575,7 @@ async function handleConnection(ws) {
           return;
         }
         try {
-          await session.compact();
+          await session.rpc.history.compact();
           console.log(`[proxy] session.compact: session ${sessionId} compacted`);
           sendResponse(id, {});
         } catch (err) {
@@ -591,6 +585,24 @@ async function handleConnection(ws) {
         break;
       }
 
+      case 'session.abort': {
+        const { sessionId } = params || {};
+        const session = sessions.get(sessionId);
+        if (!session) {
+          sendError(id, -32602, `Session '${sessionId}' not found`);
+          return;
+        }
+        try {
+          await session.abort();
+          sendResponse(id, {});
+        } catch (err) {
+          console.error(`[proxy] session.abort failed:`, err);
+          sendError(id, -32603, err.message || 'Failed to abort session');
+        }
+        break;
+      }
+
+      case 'session.disconnect':
       case 'session.destroy': {
         const { sessionId } = params || {};
         const session = sessions.get(sessionId);
@@ -598,7 +610,7 @@ async function handleConnection(ws) {
           const unsub = eventUnsubs.get(sessionId);
           unsub?.();
           eventUnsubs.delete(sessionId);
-          await session.destroy();
+          await session.disconnect();
           sessions.delete(sessionId);
           if (currentSessionId === sessionId) {
             currentSessionId = null;
@@ -619,6 +631,90 @@ async function handleConnection(ws) {
           }
         }
         sendResponse(id, {});
+        break;
+      }
+
+      case 'session.mode.get': {
+        const { sessionId } = params || {};
+        const session = sessions.get(sessionId);
+        if (!session) {
+          sendError(id, -32602, `Session '${sessionId}' not found`);
+          return;
+        }
+        try {
+          const mode = await session.rpc.mode.get();
+          sendResponse(id, { mode });
+        } catch (err) {
+          console.error(`[proxy] session.mode.get failed:`, err);
+          sendError(id, -32603, err.message || 'Failed to get session mode');
+        }
+        break;
+      }
+
+      case 'session.mode.set': {
+        const { sessionId, mode } = params || {};
+        const session = sessions.get(sessionId);
+        if (!session) {
+          sendError(id, -32602, `Session '${sessionId}' not found`);
+          return;
+        }
+        try {
+          await session.rpc.mode.set({ mode });
+          sendResponse(id, {});
+        } catch (err) {
+          console.error(`[proxy] session.mode.set failed:`, err);
+          sendError(id, -32603, err.message || 'Failed to set session mode');
+        }
+        break;
+      }
+
+      case 'session.plan.read': {
+        const { sessionId } = params || {};
+        const session = sessions.get(sessionId);
+        if (!session) {
+          sendError(id, -32602, `Session '${sessionId}' not found`);
+          return;
+        }
+        try {
+          sendResponse(id, await session.rpc.plan.read());
+        } catch (err) {
+          console.error(`[proxy] session.plan.read failed:`, err);
+          sendError(id, -32603, err.message || 'Failed to read plan');
+        }
+        break;
+      }
+
+      case 'session.plan.update': {
+        const { sessionId, content } = params || {};
+        const session = sessions.get(sessionId);
+        if (!session) {
+          sendError(id, -32602, `Session '${sessionId}' not found`);
+          return;
+        }
+        try {
+          await session.rpc.plan.update({ content: String(content ?? '') });
+          sendResponse(id, {});
+        } catch (err) {
+          console.error(`[proxy] session.plan.update failed:`, err);
+          sendError(id, -32603, err.message || 'Failed to update plan');
+        }
+        break;
+      }
+
+      case 'session.plan.delete': {
+        const { sessionId } = params || {};
+        const session = sessions.get(sessionId);
+        if (!session) {
+          sendError(id, -32602, `Session '${sessionId}' not found`);
+          return;
+        }
+        try {
+          await session.rpc.plan.delete();
+          sendResponse(id, {});
+        } catch (err) {
+          console.error(`[proxy] session.plan.delete failed:`, err);
+          sendError(id, -32603, err.message || 'Failed to delete plan');
+        }
         break;
       }
 
@@ -655,11 +751,46 @@ async function handleConnection(ws) {
           );
           return;
         }
-        const normalizedDecision = decision === 'approved' ? 'approved' : 'denied';
         clearTimeout(pending.timer);
         pendingPermissionResponses.delete(requestId);
-        pending.resolve(normalizedDecision);
+        pending.resolve(
+          decision && typeof decision === 'object' && typeof decision.kind === 'string'
+            ? decision
+            : { kind: 'reject' }
+        );
         sendResponse(id, {});
+        break;
+      }
+
+      case 'permissions.setApproveAll': {
+        const { sessionId, enabled } = params || {};
+        const session = sessions.get(sessionId);
+        if (!session) {
+          sendError(id, -32602, `Session '${sessionId}' not found`);
+          return;
+        }
+        try {
+          sendResponse(id, await session.rpc.permissions.setApproveAll({ enabled: enabled === true }));
+        } catch (err) {
+          console.error(`[proxy] permissions.setApproveAll failed:`, err);
+          sendError(id, -32603, err.message || 'Failed to update approve-all setting');
+        }
+        break;
+      }
+
+      case 'permissions.resetSessionApprovals': {
+        const { sessionId } = params || {};
+        const session = sessions.get(sessionId);
+        if (!session) {
+          sendError(id, -32602, `Session '${sessionId}' not found`);
+          return;
+        }
+        try {
+          sendResponse(id, await session.rpc.permissions.resetSessionApprovals());
+        } catch (err) {
+          console.error(`[proxy] permissions.resetSessionApprovals failed:`, err);
+          sendError(id, -32603, err.message || 'Failed to reset session approvals');
+        }
         break;
       }
 
@@ -689,15 +820,15 @@ async function handleConnection(ws) {
 
     for (const pending of pendingPermissionResponses.values()) {
       clearTimeout(pending.timer);
-      pending.resolve('denied');
+      pending.resolve({ kind: 'user-not-available' });
     }
     pendingPermissionResponses.clear();
 
-    // Destroy server-side sessions so the shared CopilotClient doesn't
+    // Disconnect server-side sessions so the shared CopilotClient doesn't
     // accumulate open sessions across reconnects.
     for (const session of sessions.values()) {
       try {
-        await session.destroy();
+        await session.disconnect();
       } catch {
         // Session may already be gone — ignore.
       }

--- a/src/hooks/useOfficeChat.ts
+++ b/src/hooks/useOfficeChat.ts
@@ -2,6 +2,9 @@ import { useState, useRef, useCallback, useEffect } from 'react';
 import { flushSync } from 'react-dom';
 import type {
   AgentInfo,
+  ExitPlanModeRequestPayload,
+  PlanState,
+  SessionMode,
   WebSocketCopilotClient,
   BrowserCopilotSession,
 } from '@/lib/websocket-client';
@@ -11,7 +14,6 @@ import { getToolsForHost } from '@/tools';
 import { fetchConfiguredMcpServers, toSdkMcpServers } from '@/services/mcp';
 import { useSettingsStore } from '@/stores';
 import { useSessionHistoryStore } from '@/stores';
-import { usePermissionStore } from '@/stores';
 import { useMcpStatusStore } from '@/stores';
 import { buildSessionSystemPrompt } from '@/services/ai/systemPrompt';
 import { inferProvider } from '@/types';
@@ -19,9 +21,15 @@ import type { ChatMessage, ToolCallPart } from '@/types';
 import type { OfficeHostApp } from '@/services/office/host';
 import { generateId } from '@/utils/id';
 import type { McpOAuthPromptRequest } from '@/components/McpOAuthPrompt';
+import type { PermissionRequestResult, SessionEvent } from '@github/copilot-sdk';
 
 const MODEL_FETCH_TIMEOUT_MS = 10_000;
 const DEFAULT_THINKING_TEXT = 'Thinking…';
+const EMPTY_PLAN: PlanState = { exists: false, content: null, path: null };
+type PermissionApproval = Extract<
+  PermissionRequestResult,
+  { kind: 'approve-for-session' }
+>['approval'];
 
 /** Race a promise against a timeout. */
 function withTimeout<T>(promise: Promise<T>, ms: number, label: string): Promise<T> {
@@ -87,6 +95,21 @@ async function loadAvailableAgents(session: BrowserCopilotSession): Promise<void
   }
 }
 
+function getDefaultAgentForHost(host: OfficeHostApp): string | undefined {
+  switch (host) {
+    case 'excel':
+      return 'office-excel:excel';
+    case 'powerpoint':
+      return 'office-powerpoint:powerpoint';
+    case 'word':
+      return 'office-word:word';
+    case 'outlook':
+      return 'office-outlook:outlook';
+    default:
+      return undefined;
+  }
+}
+
 function getWsUrl(): string {
   if (typeof window === 'undefined') return 'wss://localhost:3000/api/copilot';
   const { hostname, protocol, host } = window.location;
@@ -99,6 +122,90 @@ function getWsUrl(): string {
   return `${proto}//${host}/api/copilot`;
 }
 
+function stringArray(value: unknown): string[] {
+  return Array.isArray(value)
+    ? value.filter((item): item is string => typeof item === 'string')
+    : [];
+}
+
+function stringValue(value: unknown): string {
+  return typeof value === 'string' ? value : '';
+}
+
+function approvalForPermission(payload: PermissionRequestPayload): PermissionApproval | null {
+  const request = payload.request as Record<string, unknown>;
+  const prompt = payload.promptRequest ?? {};
+  const kind = stringValue(prompt.kind) || stringValue(request.kind);
+
+  if (kind === 'commands' || kind === 'shell') {
+    let commandIdentifiers = stringArray(prompt.commandIdentifiers);
+    if (commandIdentifiers.length === 0) {
+      commandIdentifiers = stringArray(request.commandIdentifiers);
+    }
+    if (commandIdentifiers.length === 0 && Array.isArray(request.commands)) {
+      commandIdentifiers = request.commands
+        .map(command =>
+          typeof command === 'object' && command !== null && 'identifier' in command
+            ? stringValue((command as { identifier?: unknown }).identifier)
+            : ''
+        )
+        .filter(Boolean);
+    }
+    return commandIdentifiers.length > 0 ? { kind: 'commands', commandIdentifiers } : null;
+  }
+
+  if (kind === 'read' || (kind === 'path' && prompt.accessKind === 'read')) {
+    return { kind: 'read' };
+  }
+
+  if (kind === 'write' || (kind === 'path' && prompt.accessKind === 'write')) {
+    return { kind: 'write' };
+  }
+
+  if (kind === 'mcp') {
+    const serverName = stringValue(prompt.serverName) || stringValue(request.serverName);
+    if (!serverName) return null;
+    const toolNameRaw = prompt.toolName ?? request.toolName;
+    return {
+      kind: 'mcp',
+      serverName,
+      toolName: typeof toolNameRaw === 'string' ? toolNameRaw : null,
+    };
+  }
+
+  if (kind === 'memory') {
+    return { kind: 'memory' };
+  }
+
+  if (kind === 'custom-tool') {
+    const toolName = stringValue(prompt.toolName) || stringValue(request.toolName);
+    return toolName ? { kind: 'custom-tool', toolName } : null;
+  }
+
+  return null;
+}
+
+function permissionDetail(payload: PermissionRequestPayload): string {
+  const request = payload.request as Record<string, unknown>;
+  const prompt = payload.promptRequest ?? {};
+  const candidates = [
+    prompt.fullCommandText,
+    prompt.fileName,
+    prompt.path,
+    prompt.url,
+    prompt.intention,
+    request.fullCommandText,
+    request.fileName,
+    request.path,
+    request.url,
+    request.intention,
+  ];
+  return (
+    candidates.find((value): value is string => typeof value === 'string' && value.length > 0) ??
+    'User approval required'
+  );
+}
+
 export function useOfficeChat(host: OfficeHostApp) {
   const activeModel = useSettingsStore(s => s.activeModel);
   const activeAgentName = useSettingsStore(s => s.activeAgentName);
@@ -109,9 +216,6 @@ export function useOfficeChat(host: OfficeHostApp) {
   const setActiveSession = useSessionHistoryStore(s => s.setActiveSession);
   const upsertActiveSession = useSessionHistoryStore(s => s.upsertActiveSession);
   const deleteSessionHistoryItem = useSessionHistoryStore(s => s.deleteSession);
-  const evaluatePermission = usePermissionStore(s => s.evaluate);
-  const addPermissionRule = usePermissionStore(s => s.addRule);
-  const allowAllPermissions = usePermissionStore(s => s.allowAll);
 
   const clientRef = useRef<WebSocketCopilotClient | null>(null);
   const sessionRef = useRef<BrowserCopilotSession | null>(null);
@@ -129,12 +233,10 @@ export function useOfficeChat(host: OfficeHostApp) {
   const activeModelRef = useRef(activeModel);
   const activeAgentNameRef = useRef(activeAgentName);
   const disabledMcpServerNamesRef = useRef(disabledMcpServerNames);
-  const evaluatePermissionRef = useRef(evaluatePermission);
   // Keep refs in sync on every render (runs synchronously, before any effects)
   activeModelRef.current = activeModel;
   activeAgentNameRef.current = activeAgentName;
   disabledMcpServerNamesRef.current = disabledMcpServerNames;
-  evaluatePermissionRef.current = evaluatePermission;
 
   // Switch model mid-session when the user picks a different model
   useEffect(() => {
@@ -151,6 +253,13 @@ export function useOfficeChat(host: OfficeHostApp) {
   const [sessionError, setSessionError] = useState<Error | null>(null);
   const [isConnecting, setIsConnecting] = useState(true);
   const [pendingPermission, setPendingPermission] = useState<PermissionRequestPayload | null>(null);
+  const [permissionApproveAll, setPermissionApproveAll] = useState(false);
+  const [sessionMode, setSessionMode] = useState<SessionMode>('interactive');
+  const [planState, setPlanState] = useState<PlanState>(EMPTY_PLAN);
+  const [workspacePath, setWorkspacePath] = useState<string | null>(null);
+  const [pendingExitPlanMode, setPendingExitPlanMode] = useState<ExitPlanModeRequestPayload | null>(
+    null
+  );
   const [pendingMcpOAuthPrompt, setPendingMcpOAuthPrompt] = useState<McpOAuthPromptRequest | null>(
     null
   );
@@ -222,6 +331,10 @@ export function useOfficeChat(host: OfficeHostApp) {
     console.log('[chat] initSession: connecting to', wsUrl);
     setIsConnecting(true);
     setSessionError(null);
+    setSessionMode('interactive');
+    setPlanState(EMPTY_PLAN);
+    setWorkspacePath(null);
+    setPendingExitPlanMode(null);
 
     try {
       const client = await withTimeout(createWebSocketClient(wsUrl), 15_000, 'WebSocket connect');
@@ -293,11 +406,11 @@ export function useOfficeChat(host: OfficeHostApp) {
       const session = await withTimeout(
         client.createSession({
           model: activeModelRef.current,
-          systemMessage: { mode: 'replace', content: systemContent },
+          systemMessage: { mode: 'customize', content: systemContent },
           tools: getToolsForHost(host),
           mcpServers,
           host,
-          agent: activeAgentNameRef.current ?? undefined,
+          agent: activeAgentNameRef.current ?? getDefaultAgentForHost(host),
         }),
         60_000,
         'session.create'
@@ -314,15 +427,67 @@ export function useOfficeChat(host: OfficeHostApp) {
       sessionRef.current = session;
       setSessionError(null);
       setPendingPermission(null);
+      setPendingExitPlanMode(null);
+      setWorkspacePath(session.workspacePath ?? null);
       activePermissionRequestRef.current = null;
       console.log('[chat] Session created:', session.sessionId);
 
-      session.onPermissionRequest(payload => {
-        const autoDecision = evaluatePermissionRef.current(payload.request);
-        if (autoDecision === 'approved') {
-          void session.respondPermission(payload.requestId, 'approved');
-          return;
+      const refreshPlan = () => {
+        if (typeof session.readPlan !== 'function') return;
+        void session
+          .readPlan()
+          .then(nextPlan => setPlanState(nextPlan))
+          .catch(err => console.warn('[chat] session.plan.read failed:', err));
+      };
+
+      const handleSessionStateEvent = (event: SessionEvent) => {
+        if (event.type === 'session.mode_changed') {
+          const nextMode = event.data.newMode;
+          if (nextMode === 'interactive' || nextMode === 'plan' || nextMode === 'autopilot') {
+            setSessionMode(nextMode);
+          }
+        } else if (event.type === 'session.plan_changed') {
+          refreshPlan();
+        } else if (event.type === 'exit_plan_mode.requested') {
+          setPendingExitPlanMode({
+            sessionId: session.sessionId,
+            requestId: event.data.requestId,
+            actions: event.data.actions,
+            planContent: event.data.planContent,
+            recommendedAction: event.data.recommendedAction,
+            summary: event.data.summary,
+          });
+          setPlanState({
+            exists: true,
+            content: event.data.planContent,
+            path: session.workspacePath ? `${session.workspacePath}\\plan.md` : null,
+          });
+        } else if (event.type === 'exit_plan_mode.completed') {
+          setPendingExitPlanMode(current =>
+            current?.requestId === event.data.requestId ? null : current
+          );
+          const selectedMode = event.data.selectedAction;
+          if (
+            selectedMode === 'interactive' ||
+            selectedMode === 'plan' ||
+            selectedMode === 'autopilot'
+          ) {
+            setSessionMode(selectedMode);
+          }
         }
+      };
+
+      session.on(handleSessionStateEvent);
+
+      if (typeof session.getMode === 'function') {
+        void session
+          .getMode()
+          .then(mode => setSessionMode(mode))
+          .catch(err => console.warn('[chat] session.mode.get failed:', err));
+      }
+      refreshPlan();
+
+      session.onPermissionRequest(payload => {
         activePermissionRequestRef.current = payload.requestId;
         setPendingPermission(payload);
       });
@@ -880,22 +1045,19 @@ export function useOfficeChat(host: OfficeHostApp) {
       });
     });
 
-    // Also destroy and recreate the session to actually stop the SDK query.
-    // Without this, the proxy/SDK keeps processing events until the response
-    // finishes naturally.
+    // Abort the active SDK turn without tearing down the session.
     const session = sessionRef.current;
     if (session) {
-      void session.destroy().catch(() => {
+      void session.abort().catch(() => {
         /* ignore */
       });
-      sessionRef.current = null;
-      void initSessionRef.current();
     }
   }, []);
 
   const clearMessages = useCallback(() => {
     setMessages([]);
     setPendingPermission(null);
+    setPendingExitPlanMode(null);
     activePermissionRequestRef.current = null;
     // Clear queued prompts on new conversation
     queueRef.current = [];
@@ -911,6 +1073,7 @@ export function useOfficeChat(host: OfficeHostApp) {
       setActiveSession(sessionId);
       setMessages(deserializeMessages(session.messages));
       setPendingPermission(null);
+      setPendingExitPlanMode(null);
       activePermissionRequestRef.current = null;
       void initSession();
     },
@@ -930,6 +1093,7 @@ export function useOfficeChat(host: OfficeHostApp) {
       if (!deletedWasActive) return;
 
       setPendingPermission(null);
+      setPendingExitPlanMode(null);
       activePermissionRequestRef.current = null;
 
       if (nextHostSession) {
@@ -954,7 +1118,7 @@ export function useOfficeChat(host: OfficeHostApp) {
     ]
   );
 
-  const respondPermission = useCallback(async (decision: 'approved' | 'denied') => {
+  const respondPermission = useCallback(async (decision: PermissionRequestResult) => {
     const session = sessionRef.current;
     const requestId = activePermissionRequestRef.current;
     if (!session || !requestId) return;
@@ -969,30 +1133,48 @@ export function useOfficeChat(host: OfficeHostApp) {
   }, []);
 
   const approvePermission = useCallback(() => {
-    void respondPermission('approved');
+    void respondPermission({ kind: 'approve-once' });
   }, [respondPermission]);
 
   const denyPermission = useCallback(() => {
-    void respondPermission('denied');
+    void respondPermission({ kind: 'reject' });
   }, [respondPermission]);
 
-  const allowPermissionAlways = useCallback(() => {
-    const request = pendingPermission?.request;
-    if (!request) return;
-    const pathPrefix =
-      (typeof request.path === 'string' && request.path) ||
-      (typeof request.fileName === 'string' && request.fileName) ||
-      (typeof request.fullCommandText === 'string' && request.fullCommandText) ||
-      null;
+  const approvePermissionForSession = useCallback(() => {
+    if (!pendingPermission) return;
+    const approval = approvalForPermission(pendingPermission);
+    void respondPermission(
+      approval ? { kind: 'approve-for-session', approval } : { kind: 'approve-once' }
+    );
+  }, [pendingPermission, respondPermission]);
 
-    if (pathPrefix) {
-      addPermissionRule({
-        kind: request.kind,
-        pathPrefix,
-      });
+  const approvePermissionForLocation = useCallback(() => {
+    if (!pendingPermission) return;
+    const approval = approvalForPermission(pendingPermission);
+    const locationKey = pendingPermission.locationKey;
+    void respondPermission(
+      approval && locationKey
+        ? { kind: 'approve-for-location', approval, locationKey }
+        : { kind: 'approve-once' }
+    );
+  }, [pendingPermission, respondPermission]);
+
+  const setApproveAllPermissions = useCallback(async (enabled: boolean) => {
+    const session = sessionRef.current;
+    if (!session) {
+      throw new Error('Cannot update permissions: no active session');
     }
-    void respondPermission('approved');
-  }, [addPermissionRule, pendingPermission, respondPermission]);
+    await session.setApproveAll(enabled);
+    setPermissionApproveAll(enabled);
+  }, []);
+
+  const resetSessionApprovals = useCallback(async () => {
+    const session = sessionRef.current;
+    if (!session) {
+      throw new Error('Cannot reset permissions: no active session');
+    }
+    await session.resetSessionApprovals();
+  }, []);
 
   const initiateMcpOAuth = useCallback(async (serverName: string, loginHint?: string) => {
     const session = sessionRef.current;
@@ -1076,30 +1258,97 @@ export function useOfficeChat(host: OfficeHostApp) {
 
   /**
    * Switch to a different Copilot CLI-owned agent mid-session.
-   * Passing null returns to the default agent.
+   * Passing null returns to the bundled plugin agent for the active Office host.
    */
-  const switchAgent = useCallback(async (agentName: string | null) => {
+  const switchAgent = useCallback(
+    async (agentName: string | null) => {
+      const session = sessionRef.current;
+      if (!session) {
+        throw new Error('Cannot switch agent: no active session');
+      }
+
+      try {
+        let selected: AgentInfo | null = null;
+        if (agentName === null) {
+          const defaultAgentName = getDefaultAgentForHost(host);
+          if (defaultAgentName) {
+            console.log(`[chat] Switching agent to host default ${defaultAgentName}`);
+            selected = await session.selectAgent(defaultAgentName);
+          } else {
+            console.log('[chat] Switching agent to default');
+            await session.deselectAgent();
+          }
+        } else {
+          console.log(`[chat] Switching agent to ${agentName}`);
+          selected = await session.selectAgent(agentName);
+        }
+        useSettingsStore
+          .getState()
+          .setActiveAgent(agentName === null ? null : (selected?.name ?? null));
+        console.log(
+          `[chat] Agent switched successfully to ${agentName === null ? 'host default' : (selected?.name ?? 'default')}`
+        );
+      } catch (err) {
+        console.error('[chat] Failed to switch agent:', err);
+        throw err instanceof Error ? err : new Error(String(err));
+      }
+    },
+    [host]
+  );
+
+  const switchSessionMode = useCallback(async (mode: SessionMode) => {
     const session = sessionRef.current;
     if (!session) {
-      throw new Error('Cannot switch agent: no active session');
+      throw new Error('Cannot switch mode: no active session');
     }
-
-    try {
-      let selected: AgentInfo | null = null;
-      if (agentName === null) {
-        console.log('[chat] Switching agent to default');
-        await session.deselectAgent();
-      } else {
-        console.log(`[chat] Switching agent to ${agentName}`);
-        selected = await session.selectAgent(agentName);
-      }
-      useSettingsStore.getState().setActiveAgent(selected?.name ?? null);
-      console.log(`[chat] Agent switched successfully to ${selected?.name ?? 'default'}`);
-    } catch (err) {
-      console.error('[chat] Failed to switch agent:', err);
-      throw err instanceof Error ? err : new Error(String(err));
+    await session.setMode(mode);
+    setSessionMode(mode);
+    if (mode !== 'plan') {
+      setPendingExitPlanMode(null);
     }
   }, []);
+
+  const refreshPlan = useCallback(async () => {
+    const session = sessionRef.current;
+    if (!session) return;
+    setPlanState(await session.readPlan());
+  }, []);
+
+  const updatePlan = useCallback(async (content: string) => {
+    const session = sessionRef.current;
+    if (!session) {
+      throw new Error('Cannot update plan: no active session');
+    }
+    await session.updatePlan(content);
+    setPlanState(await session.readPlan());
+  }, []);
+
+  const deletePlan = useCallback(async () => {
+    const session = sessionRef.current;
+    if (!session) {
+      throw new Error('Cannot delete plan: no active session');
+    }
+    await session.deletePlan();
+    setPlanState(EMPTY_PLAN);
+  }, []);
+
+  const resolveExitPlanMode = useCallback(
+    async (selectedAction: string, feedback?: string) => {
+      const nextMode =
+        selectedAction === 'autopilot'
+          ? 'autopilot'
+          : selectedAction === 'interactive' || selectedAction === 'exit_only'
+            ? 'interactive'
+            : 'plan';
+
+      if (feedback?.trim()) {
+        await send(`Plan feedback: ${feedback.trim()}`);
+      }
+      await switchSessionMode(nextMode);
+      setPendingExitPlanMode(null);
+    },
+    [send, switchSessionMode]
+  );
 
   return {
     messages,
@@ -1114,10 +1363,23 @@ export function useOfficeChat(host: OfficeHostApp) {
     sessions,
     activeSessionId,
     pendingPermission,
-    allowAllPermissions,
+    permissionApproveAll,
+    setApproveAllPermissions,
+    resetSessionApprovals,
     approvePermission,
     denyPermission,
-    allowPermissionAlways,
+    approvePermissionForSession,
+    approvePermissionForLocation,
+    permissionDetail: pendingPermission ? permissionDetail(pendingPermission) : '',
+    sessionMode,
+    switchSessionMode,
+    planState,
+    workspacePath,
+    pendingExitPlanMode,
+    refreshPlan,
+    updatePlan,
+    deletePlan,
+    resolveExitPlanMode,
     initiateMcpOAuth,
     pendingMcpOAuthPrompt,
     openMcpOAuthPrompt,

--- a/src/lib/websocket-client.ts
+++ b/src/lib/websocket-client.ts
@@ -15,6 +15,7 @@ import type {
   ToolHandler,
   ToolInvocation,
   ToolResultObject,
+  PermissionRequestResult,
 } from '@github/copilot-sdk';
 
 interface ToolCallRequestPayload {
@@ -44,6 +45,25 @@ export interface PermissionRequestPayload {
     args?: unknown;
     [key: string]: unknown;
   };
+  promptRequest?: Record<string, unknown>;
+  locationKey?: string;
+}
+
+export type SessionMode = 'interactive' | 'plan' | 'autopilot';
+
+export interface PlanState {
+  exists: boolean;
+  content: string | null;
+  path: string | null;
+}
+
+export interface ExitPlanModeRequestPayload {
+  sessionId: string;
+  requestId: string;
+  actions: string[];
+  planContent: string;
+  recommendedAction: string;
+  summary: string;
 }
 
 /** Extended session config for browser → proxy communication. */
@@ -69,7 +89,8 @@ export class BrowserCopilotSession {
 
   constructor(
     public readonly sessionId: string,
-    private connection: MessageConnection
+    private connection: MessageConnection,
+    public readonly workspacePath?: string
   ) {}
 
   async send(options: MessageOptions): Promise<string> {
@@ -168,7 +189,7 @@ export class BrowserCopilotSession {
     }
   }
 
-  async respondPermission(requestId: string, decision: 'approved' | 'denied'): Promise<void> {
+  async respondPermission(requestId: string, decision: PermissionRequestResult): Promise<void> {
     await this.connection.sendRequest('permission.respond', {
       sessionId: this.sessionId,
       requestId,
@@ -210,6 +231,67 @@ export class BrowserCopilotSession {
     });
   }
 
+  async abort(): Promise<void> {
+    await this.connection.sendRequest('session.abort', {
+      sessionId: this.sessionId,
+    });
+  }
+
+  async disconnect(): Promise<void> {
+    await this.connection.sendRequest('session.disconnect', {
+      sessionId: this.sessionId,
+    });
+    this.eventHandlers.clear();
+    this.toolHandlers.clear();
+    this.permissionHandlers.clear();
+  }
+
+  async getMode(): Promise<SessionMode> {
+    const result = await this.connection.sendRequest<{ mode: SessionMode }>('session.mode.get', {
+      sessionId: this.sessionId,
+    });
+    return result.mode;
+  }
+
+  async setMode(mode: SessionMode): Promise<void> {
+    await this.connection.sendRequest('session.mode.set', {
+      sessionId: this.sessionId,
+      mode,
+    });
+  }
+
+  async readPlan(): Promise<PlanState> {
+    return this.connection.sendRequest<PlanState>('session.plan.read', {
+      sessionId: this.sessionId,
+    });
+  }
+
+  async updatePlan(content: string): Promise<void> {
+    await this.connection.sendRequest('session.plan.update', {
+      sessionId: this.sessionId,
+      content,
+    });
+  }
+
+  async deletePlan(): Promise<void> {
+    await this.connection.sendRequest('session.plan.delete', {
+      sessionId: this.sessionId,
+    });
+  }
+
+  async setApproveAll(enabled: boolean): Promise<void> {
+    await this.connection.sendRequest('permissions.setApproveAll', {
+      sessionId: this.sessionId,
+      enabled,
+    });
+  }
+
+  async resetSessionApprovals(): Promise<void> {
+    await this.connection.sendRequest('permissions.resetSessionApprovals', {
+      sessionId: this.sessionId,
+    });
+  }
+
   async initiateMcpOAuth(serverName: string): Promise<McpOAuthResult> {
     return this.connection.sendRequest<McpOAuthResult>('mcp.initiateOAuth', {
       sessionId: this.sessionId,
@@ -226,12 +308,7 @@ export class BrowserCopilotSession {
   }
 
   async destroy(): Promise<void> {
-    await this.connection.sendRequest('session.destroy', {
-      sessionId: this.sessionId,
-    });
-    this.eventHandlers.clear();
-    this.toolHandlers.clear();
-    this.permissionHandlers.clear();
+    await this.disconnect();
   }
 }
 
@@ -325,7 +402,10 @@ export class WebSocketCopilotClient {
       throw new Error('Client not connected. Call start() first.');
     }
 
-    const response = await this.connection.sendRequest<{ sessionId: string }>('session.create', {
+    const response = await this.connection.sendRequest<{
+      sessionId: string;
+      workspacePath?: string;
+    }>('session.create', {
       model: config.model,
       sessionId: config.sessionId,
       systemMessage: config.systemMessage,
@@ -333,6 +413,7 @@ export class WebSocketCopilotClient {
         name: tool.name,
         description: tool.description,
         parameters: tool.parameters,
+        skipPermission: tool.skipPermission,
       })),
       mcpServers: config.mcpServers,
       availableTools: config.availableTools,
@@ -341,7 +422,7 @@ export class WebSocketCopilotClient {
     });
 
     const sessionId = response.sessionId;
-    const session = new BrowserCopilotSession(sessionId, this.connection);
+    const session = new BrowserCopilotSession(sessionId, this.connection, response.workspacePath);
     session.registerTools(config.tools);
     this.sessions.set(sessionId, session);
     return session;
@@ -396,7 +477,7 @@ export class WebSocketCopilotClient {
   async stop(): Promise<void> {
     for (const session of this.sessions.values()) {
       try {
-        await session.destroy();
+        await session.disconnect();
       } catch {
         // ignore
       }

--- a/src/services/ai/systemPrompt.ts
+++ b/src/services/ai/systemPrompt.ts
@@ -1,8 +1,4 @@
 import BASE_PROMPT from './BASE_PROMPT.md';
-import EXCEL_APP_PROMPT from './prompts/EXCEL_APP_PROMPT.md';
-import POWERPOINT_APP_PROMPT from './prompts/POWERPOINT_APP_PROMPT.md';
-import WORD_APP_PROMPT from './prompts/WORD_APP_PROMPT.md';
-import OUTLOOK_APP_PROMPT from './prompts/OUTLOOK_APP_PROMPT.md';
 import type { OfficeHostApp } from '@/services/office/host';
 
 export { BASE_PROMPT };
@@ -12,22 +8,13 @@ interface SessionSystemPromptOptions {
 }
 
 export function getAppPromptForHost(host: OfficeHostApp): string {
-  switch (host) {
-    case 'excel':
-      return EXCEL_APP_PROMPT;
-    case 'powerpoint':
-      return POWERPOINT_APP_PROMPT;
-    case 'word':
-      return WORD_APP_PROMPT;
-    case 'outlook':
-      return OUTLOOK_APP_PROMPT;
-    default:
-      return 'You are an AI assistant running inside a Microsoft Office add-in.';
-  }
+  void host;
+  return '';
 }
 
 export function buildSystemPrompt(host: OfficeHostApp): string {
-  return `${BASE_PROMPT}\n\n${getAppPromptForHost(host)}`;
+  const hostPrompt = getAppPromptForHost(host).trim();
+  return hostPrompt ? `${BASE_PROMPT}\n\n${hostPrompt}` : BASE_PROMPT;
 }
 
 export function buildSessionSystemPrompt(

--- a/src/taskpane/App.tsx
+++ b/src/taskpane/App.tsx
@@ -12,6 +12,7 @@ import { ChatActionsContext } from '@/contexts/ChatActionsContext';
 import { detectOfficeHost } from '@/services/office/host';
 import type { OfficeHostApp } from '@/services/office/host';
 import { McpOAuthPrompt } from '@/components/McpOAuthPrompt';
+import type { ExitPlanModeRequestPayload, PlanState } from '@/lib/websocket-client';
 
 const bannerBaseStyle: React.CSSProperties = {
   borderBottomColor: 'var(--vscode-widget-border)',
@@ -69,9 +70,10 @@ const PermissionBanner: React.FC<{
   kind: string;
   detail: string;
   onApprove: () => void;
+  onApproveForSession: () => void;
+  onApproveForLocation: () => void;
   onDeny: () => void;
-  onAlwaysAllow: () => void;
-}> = ({ kind, detail, onApprove, onDeny, onAlwaysAllow }) => (
+}> = ({ kind, detail, onApprove, onApproveForSession, onApproveForLocation, onDeny }) => (
   <div
     className="flex items-center gap-2 border-b px-3 py-2 text-sm"
     style={{
@@ -129,7 +131,7 @@ const PermissionBanner: React.FC<{
         Allow
       </button>
       <button
-        onClick={onAlwaysAllow}
+        onClick={onApproveForSession}
         className={buttonBaseClassName}
         style={{
           borderColor: 'var(--vscode-widget-border)',
@@ -143,15 +145,112 @@ const PermissionBanner: React.FC<{
           event.currentTarget.style.backgroundColor = 'transparent';
         }}
       >
-        Always allow
+        Allow session
+      </button>
+      <button
+        onClick={onApproveForLocation}
+        className={buttonBaseClassName}
+        style={{
+          borderColor: 'var(--vscode-widget-border)',
+          backgroundColor: 'transparent',
+          color: 'var(--vscode-foreground)',
+        }}
+        onMouseEnter={event => {
+          event.currentTarget.style.backgroundColor = 'var(--vscode-toolbar-hoverBackground)';
+        }}
+        onMouseLeave={event => {
+          event.currentTarget.style.backgroundColor = 'transparent';
+        }}
+      >
+        Allow workspace
       </button>
     </div>
   </div>
 );
 
+const PlanPanel: React.FC<{
+  plan: PlanState;
+  workspacePath: string | null;
+  pendingExitPlanMode: ExitPlanModeRequestPayload | null;
+  onRefresh: () => void | Promise<void>;
+  onResolveExitPlanMode: (selectedAction: string, feedback?: string) => void | Promise<void>;
+}> = ({ plan, workspacePath, pendingExitPlanMode, onRefresh, onResolveExitPlanMode }) => (
+  <div className="flex h-full flex-col gap-3 p-3 text-sm">
+    {workspacePath && (
+      <div className="truncate text-xs" style={{ color: 'var(--vscode-descriptionForeground)' }}>
+        Workspace: {workspacePath}
+      </div>
+    )}
+    {pendingExitPlanMode && (
+      <div
+        className="rounded-[var(--vscode-cornerRadius-medium)] border p-3"
+        style={{ borderColor: 'var(--vscode-widget-border)' }}
+      >
+        <div className="mb-1 font-medium">Plan ready</div>
+        <div className="mb-3 text-xs" style={{ color: 'var(--vscode-descriptionForeground)' }}>
+          {pendingExitPlanMode.summary}
+        </div>
+        <div className="flex flex-wrap gap-1">
+          {pendingExitPlanMode.actions.map(action => (
+            <button
+              key={action}
+              type="button"
+              onClick={() => void onResolveExitPlanMode(action)}
+              className={buttonBaseClassName}
+              style={{
+                borderColor:
+                  action === pendingExitPlanMode.recommendedAction
+                    ? 'var(--vscode-button-background)'
+                    : 'var(--vscode-widget-border)',
+                backgroundColor:
+                  action === pendingExitPlanMode.recommendedAction
+                    ? 'var(--vscode-button-background)'
+                    : 'transparent',
+                color:
+                  action === pendingExitPlanMode.recommendedAction
+                    ? 'var(--vscode-button-foreground)'
+                    : 'var(--vscode-foreground)',
+              }}
+            >
+              {action.replace(/_/g, ' ')}
+            </button>
+          ))}
+        </div>
+      </div>
+    )}
+    <div className="flex items-center justify-between">
+      <div className="font-medium">plan.md</div>
+      <button
+        type="button"
+        onClick={() => void onRefresh()}
+        className="inline-flex items-center gap-1 rounded-[var(--vscode-cornerRadius-medium)] border px-2 py-1 text-xs"
+        style={{
+          borderColor: 'var(--vscode-widget-border)',
+          backgroundColor: 'transparent',
+          color: 'var(--vscode-foreground)',
+        }}
+      >
+        <Codicon name="refresh" className="text-xs" />
+        Refresh
+      </button>
+    </div>
+    <pre
+      className="min-h-0 flex-1 overflow-auto rounded-[var(--vscode-cornerRadius-medium)] border p-2 text-xs whitespace-pre-wrap"
+      style={{
+        borderColor: 'var(--vscode-widget-border)',
+        backgroundColor: 'var(--vscode-editor-background)',
+        color: 'var(--vscode-editor-foreground)',
+      }}
+    >
+      {plan.content ?? 'No plan has been created yet.'}
+    </pre>
+  </div>
+);
+
 const PANEL_TITLES: Record<string, { title: string; description?: string }> = {
   history: { title: 'Session History' },
-  permissions: { title: 'Permissions', description: 'Manage auto-approval and saved rules' },
+  permissions: { title: 'Permissions', description: 'Manage Copilot CLI approvals' },
+  plan: { title: 'Plan', description: 'Review the current SDK plan workspace' },
 };
 
 const ReadyAssistant: React.FC<{ host: OfficeHostApp }> = ({ host }) => {
@@ -171,13 +270,25 @@ const ReadyAssistant: React.FC<{ host: OfficeHostApp }> = ({ host }) => {
     sessions,
     activeSessionId,
     pendingPermission,
+    permissionDetail,
+    permissionApproveAll,
     pendingMcpOAuthPrompt,
     approvePermission,
+    approvePermissionForSession,
+    approvePermissionForLocation,
     denyPermission,
-    allowPermissionAlways,
+    setApproveAllPermissions,
+    resetSessionApprovals,
     initiateMcpOAuth,
     openMcpOAuthPrompt,
     dismissMcpOAuthPrompt,
+    sessionMode,
+    switchSessionMode,
+    planState,
+    workspacePath,
+    pendingExitPlanMode,
+    refreshPlan,
+    resolveExitPlanMode,
     enqueue,
     queuedPrompts,
     dequeue,
@@ -185,14 +296,6 @@ const ReadyAssistant: React.FC<{ host: OfficeHostApp }> = ({ host }) => {
 
   const [activePanel, setActivePanel] = useState<string | null>(null);
   const closePanel = useCallback(() => setActivePanel(null), []);
-
-  const permissionDetail = pendingPermission
-    ? (pendingPermission.request.path ??
-      pendingPermission.request.fileName ??
-      pendingPermission.request.fullCommandText ??
-      pendingPermission.request.intention ??
-      'User approval required')
-    : '';
 
   return (
     <ChatActionsContext.Provider value={{ send, enqueue }}>
@@ -222,8 +325,9 @@ const ReadyAssistant: React.FC<{ host: OfficeHostApp }> = ({ host }) => {
               kind={pendingPermission.request.kind}
               detail={permissionDetail}
               onApprove={approvePermission}
+              onApproveForSession={approvePermissionForSession}
+              onApproveForLocation={approvePermissionForLocation}
               onDeny={denyPermission}
-              onAlwaysAllow={allowPermissionAlways}
             />
           )}
           <ChatErrorBoundary>
@@ -236,6 +340,9 @@ const ReadyAssistant: React.FC<{ host: OfficeHostApp }> = ({ host }) => {
               onSwitchAgent={switchAgent}
               onInitiateMcpOAuth={initiateMcpOAuth}
               onOpenMcpOAuthPrompt={openMcpOAuthPrompt}
+              sessionMode={sessionMode}
+              onSwitchSessionMode={switchSessionMode}
+              onOpenPlan={() => setActivePanel('plan')}
               onEnqueue={enqueue}
               queuedPrompts={queuedPrompts}
               onDequeue={dequeue}
@@ -266,7 +373,22 @@ const ReadyAssistant: React.FC<{ host: OfficeHostApp }> = ({ host }) => {
                 onDeleteSession={deleteSession}
               />
             )}
-            {key === 'permissions' && <PermissionManagerPanel />}
+            {key === 'permissions' && (
+              <PermissionManagerPanel
+                approveAll={permissionApproveAll}
+                onSetApproveAll={setApproveAllPermissions}
+                onResetSessionApprovals={resetSessionApprovals}
+              />
+            )}
+            {key === 'plan' && (
+              <PlanPanel
+                plan={planState}
+                workspacePath={workspacePath}
+                pendingExitPlanMode={pendingExitPlanMode}
+                onRefresh={refreshPlan}
+                onResolveExitPlanMode={resolveExitPlanMode}
+              />
+            )}
           </SlidePanel>
         ))}
       </div>

--- a/tests-ui/chat/chat-permissions-history.spec.ts
+++ b/tests-ui/chat/chat-permissions-history.spec.ts
@@ -3,22 +3,23 @@ import { test, expect } from '../fixtures';
 test.describe('Permissions and session history UI', () => {
   test.describe.configure({ timeout: 120_000 });
 
-  test('opens permissions panel and can set working directory via browser', async ({
+  test('opens permissions panel and can manage SDK approvals', async ({
     configuredTaskpane: page,
   }) => {
     await page.getByRole('button', { name: 'Permissions' }).click();
 
     await expect(page.getByRole('heading', { name: 'Permissions' })).toBeVisible();
     await expect(
-      page.getByText('Manage auto-approval and saved rules')
+      page.getByText('Manage Copilot CLI approvals')
     ).toBeVisible();
 
-    await page.getByRole('button', { name: /Browse/i }).click();
-    await expect(page.getByRole('button', { name: 'Select', exact: true })).toBeVisible({ timeout: 10_000 });
+    await expect(page.getByText('Allow all')).toBeVisible();
+    await expect(page.getByText('Session approvals', { exact: true })).toBeVisible();
 
-    await page.getByRole('button', { name: 'Select', exact: true }).click();
+    await page.getByRole('button', { name: 'Off' }).click();
+    await expect(page.getByRole('button', { name: 'On' })).toBeVisible();
 
-    await expect(page.getByText('Not set')).not.toBeVisible();
+    await page.getByRole('button', { name: 'Reset session approvals' }).click();
   });
 
   test('opens history manage panel and deletes a saved session', async ({

--- a/tests-ui/chat/chat-thinking-indicator.spec.ts
+++ b/tests-ui/chat/chat-thinking-indicator.spec.ts
@@ -48,9 +48,7 @@ test.describe('Thinking indicator (live Copilot)', () => {
     });
 
     // Prompt that triggers manage_memory tool (no Excel needed)
-    await composer.fill(
-      'Use the manage_memory tool with action "list" and tell me how many skills you have.'
-    );
+    await composer.fill('In one short paragraph, explain how Excel recalculates formulas.');
     await composer.press('Enter');
 
     // Wait for the response to complete

--- a/tests/integration/chat-panel.test.tsx
+++ b/tests/integration/chat-panel.test.tsx
@@ -37,6 +37,9 @@ const DEFAULT_PROPS = {
   isRunning: false,
   onSend: vi.fn(),
   onCancel: vi.fn(),
+  sessionMode: 'interactive' as const,
+  onSwitchSessionMode: vi.fn(),
+  onOpenPlan: vi.fn(),
 };
 
 // ─── Tests ───
@@ -62,6 +65,7 @@ describe('ChatPanel — integration', () => {
     expect(screen.getByLabelText('Select agent')).toBeInTheDocument();
     // ModelPicker renders with its aria-label in the left toolbar
     expect(screen.getByLabelText('Select model')).toBeInTheDocument();
+    expect(screen.getByLabelText('Enter Plan mode')).toBeInTheDocument();
     // McpPicker renders with server icon in the right toolbar (NOT the Plugins button)
     expect(screen.getByLabelText('MCP servers')).toBeInTheDocument();
     // No duplicate Plugins button in the toolbar (it lives in the header only)

--- a/tests/integration/copilot-custom-agent.integration.test.ts
+++ b/tests/integration/copilot-custom-agent.integration.test.ts
@@ -374,7 +374,7 @@ function handleRequest(req) {
         // MCP tool calls require permission approval. Auto-approve all requests
         // so the model can call get_secret_word without waiting for a human decision.
         session.onPermissionRequest(async payload => {
-          await session.respondPermission(payload.requestId, 'approved');
+          await session.respondPermission(payload.requestId, { kind: 'approve-once' });
         });
 
         let fullText = '';

--- a/tests/integration/permission-manager-dialog.test.tsx
+++ b/tests/integration/permission-manager-dialog.test.tsx
@@ -1,177 +1,68 @@
 /**
  * Integration tests for PermissionManagerPanel.
  *
- * Renders the real component with the real Zustand store.
- * Tests allowAll toggle, rule display/removal, workingDirectory display,
- * and browse panel interaction.
+ * Renders the real component and verifies the SDK/CLI-style controls exposed by the panel.
  */
-import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { screen, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { renderWithProviders } from '../test-utils';
 import { PermissionManagerPanel } from '@/components/PermissionManagerDialog';
-import { usePermissionStore } from '@/stores/permissionStore';
-
-// Mock fetch for /api/browse
-const mockFetchResponses: Record<string, unknown> = {};
-
-beforeEach(() => {
-  usePermissionStore.setState({
-    allowAll: true,
-    workingDirectory: null,
-    rules: [],
-  });
-
-  // Default fetch mocks
-  mockFetchResponses['/api/browse'] = {
-    path: '/Users/test/project',
-    parent: '/Users/test',
-    dirs: ['src', 'tests', 'node_modules'],
-  };
-
-  vi.stubGlobal(
-    'fetch',
-    vi.fn((url: string) => {
-      const urlStr = typeof url === 'string' ? url : String(url);
-      // Match by path prefix
-      const key = Object.keys(mockFetchResponses).find(k => urlStr.includes(k));
-      const body = key ? mockFetchResponses[key] : {};
-      return Promise.resolve({
-        ok: true,
-        json: () => Promise.resolve(body),
-      });
-    })
-  );
-});
 
 describe('Integration: PermissionManagerPanel', () => {
-  it('renders the Allow all toggle', () => {
-    renderWithProviders(<PermissionManagerPanel />);
+  it('renders the SDK approve-all control', () => {
+    renderWithProviders(
+      <PermissionManagerPanel
+        approveAll={false}
+        onSetApproveAll={vi.fn()}
+        onResetSessionApprovals={vi.fn()}
+      />
+    );
+
     expect(screen.getByText('Allow all')).toBeInTheDocument();
+    expect(screen.getByText('Off')).toBeInTheDocument();
+    expect(screen.getByText(/Copilot CLI session setting/i)).toBeInTheDocument();
   });
 
-  it('shows the current allowAll state as On', () => {
-    renderWithProviders(<PermissionManagerPanel />);
+  it('calls onSetApproveAll with the next value', async () => {
+    const onSetApproveAll = vi.fn();
+
+    renderWithProviders(
+      <PermissionManagerPanel
+        approveAll={false}
+        onSetApproveAll={onSetApproveAll}
+        onResetSessionApprovals={vi.fn()}
+      />
+    );
+
+    await userEvent.click(screen.getByText('Off'));
+    expect(onSetApproveAll).toHaveBeenCalledWith(true);
+  });
+
+  it('renders approve-all as enabled', () => {
+    renderWithProviders(
+      <PermissionManagerPanel
+        approveAll
+        onSetApproveAll={vi.fn()}
+        onResetSessionApprovals={vi.fn()}
+      />
+    );
+
     expect(screen.getByText('On')).toBeInTheDocument();
   });
 
-  it('toggles allowAll when button is clicked', async () => {
-    renderWithProviders(<PermissionManagerPanel />);
-    const toggleBtn = screen.getByText('On');
-    await userEvent.click(toggleBtn);
-    expect(usePermissionStore.getState().allowAll).toBe(false);
-    expect(screen.getByText('Off')).toBeInTheDocument();
-  });
+  it('calls onResetSessionApprovals', async () => {
+    const onResetSessionApprovals = vi.fn();
 
-  it('shows "Not set" when workingDirectory is null', () => {
-    renderWithProviders(<PermissionManagerPanel />);
-    expect(screen.getByText('Not set')).toBeInTheDocument();
-  });
+    renderWithProviders(
+      <PermissionManagerPanel
+        approveAll={false}
+        onSetApproveAll={vi.fn()}
+        onResetSessionApprovals={onResetSessionApprovals}
+      />
+    );
 
-  it('shows workingDirectory value when set', () => {
-    usePermissionStore.setState({ workingDirectory: '/Users/test/project' });
-    renderWithProviders(<PermissionManagerPanel />);
-    expect(screen.getByText('/Users/test/project')).toBeInTheDocument();
-  });
-
-  it('shows Clear button only when workingDirectory is set', () => {
-    const { unmount } = renderWithProviders(<PermissionManagerPanel />);
-    expect(screen.queryByText('Clear')).not.toBeInTheDocument();
-    unmount();
-
-    usePermissionStore.setState({ workingDirectory: '/some/path' });
-    renderWithProviders(<PermissionManagerPanel />);
-    expect(screen.getByText('Clear')).toBeInTheDocument();
-  });
-
-  it('shows "No saved rules." when no rules exist', () => {
-    renderWithProviders(<PermissionManagerPanel />);
-    expect(screen.getByText('No saved rules.')).toBeInTheDocument();
-  });
-
-  it('renders rules when they exist', () => {
-    usePermissionStore.setState({
-      rules: [
-        { id: 'write:/src', kind: 'write', pathPrefix: '/src' },
-        { id: 'read:/tests', kind: 'read', pathPrefix: '/tests' },
-      ],
-    });
-    renderWithProviders(<PermissionManagerPanel />);
-
-    expect(screen.getByText('write')).toBeInTheDocument();
-    expect(screen.getByText('/src')).toBeInTheDocument();
-    expect(screen.getByText('read')).toBeInTheDocument();
-    expect(screen.getByText('/tests')).toBeInTheDocument();
-  });
-
-  it('removes a rule when the Remove button is clicked', async () => {
-    usePermissionStore.setState({
-      rules: [{ id: 'write:/src', kind: 'write', pathPrefix: '/src' }],
-    });
-    renderWithProviders(<PermissionManagerPanel />);
-
-    const removeBtn = screen.getByLabelText('Remove rule');
-    await userEvent.click(removeBtn);
-
-    expect(usePermissionStore.getState().rules).toHaveLength(0);
-  });
-
-  it('shows Clear all button when rules exist', () => {
-    usePermissionStore.setState({
-      rules: [{ id: 'write:/src', kind: 'write', pathPrefix: '/src' }],
-    });
-    renderWithProviders(<PermissionManagerPanel />);
-    expect(screen.getByText('Clear all')).toBeInTheDocument();
-  });
-
-  it('clears all rules when Clear all is clicked', async () => {
-    usePermissionStore.setState({
-      rules: [
-        { id: 'write:/src', kind: 'write', pathPrefix: '/src' },
-        { id: 'read:/tests', kind: 'read', pathPrefix: '/tests' },
-      ],
-    });
-    renderWithProviders(<PermissionManagerPanel />);
-
-    await userEvent.click(screen.getByText('Clear all'));
-    expect(usePermissionStore.getState().rules).toHaveLength(0);
-  });
-
-  it('opens the browse panel when Browse is clicked', async () => {
-    renderWithProviders(<PermissionManagerPanel />);
-
-    const browseBtn = screen.getByText('Browse');
-    await userEvent.click(browseBtn);
-
-    // Wait for the directory listing to appear
-    await waitFor(() => {
-      expect(screen.getByText('Select')).toBeInTheDocument();
-    });
-  });
-
-  it('shows directory listing from /api/browse', async () => {
-    renderWithProviders(<PermissionManagerPanel />);
-
-    await userEvent.click(screen.getByText('Browse'));
-
-    await waitFor(() => {
-      expect(screen.getByText('src')).toBeInTheDocument();
-      expect(screen.getByText('tests')).toBeInTheDocument();
-      expect(screen.getByText('node_modules')).toBeInTheDocument();
-    });
-  });
-
-  it('sets workingDirectory when Select is clicked in browse', async () => {
-    renderWithProviders(<PermissionManagerPanel />);
-
-    await userEvent.click(screen.getByText('Browse'));
-
-    await waitFor(() => {
-      expect(screen.getByText('Select')).toBeInTheDocument();
-    });
-
-    await userEvent.click(screen.getByText('Select'));
-
-    expect(usePermissionStore.getState().workingDirectory).toBe('/Users/test/project');
+    await userEvent.click(screen.getByText('Reset session approvals'));
+    expect(onResetSessionApprovals).toHaveBeenCalled();
   });
 });

--- a/tests/integration/system-prompt.test.ts
+++ b/tests/integration/system-prompt.test.ts
@@ -14,44 +14,11 @@ import {
 
 describe('Integration: systemPrompt', () => {
   describe('getAppPromptForHost', () => {
-    it('returns non-empty prompt for excel', () => {
-      const prompt = getAppPromptForHost('excel');
-      expect(prompt).toBeTruthy();
-      expect(prompt.length).toBeGreaterThan(10);
-    });
-
-    it('returns non-empty prompt for powerpoint', () => {
-      const prompt = getAppPromptForHost('powerpoint');
-      expect(prompt).toBeTruthy();
-      expect(prompt.length).toBeGreaterThan(10);
-    });
-
-    it('returns non-empty prompt for word', () => {
-      const prompt = getAppPromptForHost('word');
-      expect(prompt).toBeTruthy();
-      expect(prompt.length).toBeGreaterThan(10);
-    });
-
-    it('returns non-empty prompt for outlook', () => {
-      const prompt = getAppPromptForHost('outlook');
-      expect(prompt).toBeTruthy();
-      expect(prompt.length).toBeGreaterThan(10);
-    });
-
-    it('returns a default fallback for unknown host', () => {
-      const prompt = getAppPromptForHost('unknown' as any);
-      expect(prompt).toContain('Office');
-    });
-
-    it('returns different prompts for different hosts', () => {
-      const excelPrompt = getAppPromptForHost('excel');
-      const pptPrompt = getAppPromptForHost('powerpoint');
-      const wordPrompt = getAppPromptForHost('word');
-      const outlookPrompt = getAppPromptForHost('outlook');
-
-      // All four host-specific prompts should be distinct
-      const prompts = new Set([excelPrompt, pptPrompt, wordPrompt, outlookPrompt]);
-      expect(prompts.size).toBe(4);
+    it('does not add app-owned host behavior for bundled plugin agents', () => {
+      const hosts = ['excel', 'powerpoint', 'word', 'outlook', 'unknown'] as const;
+      for (const host of hosts) {
+        expect(getAppPromptForHost(host as any)).toBe('');
+      }
     });
   });
 
@@ -68,29 +35,17 @@ describe('Integration: systemPrompt', () => {
       expect(prompt).toContain(BASE_PROMPT);
     });
 
-    it('includes host-specific prompt', () => {
-      const hostPrompt = getAppPromptForHost('excel');
-      const full = buildSystemPrompt('excel');
-      expect(full).toContain(hostPrompt);
-    });
-
-    it('joins BASE_PROMPT and host prompt with double newline', () => {
-      const full = buildSystemPrompt('powerpoint');
-      const hostPrompt = getAppPromptForHost('powerpoint');
-      expect(full).toBe(`${BASE_PROMPT}\n\n${hostPrompt}`);
-    });
-
-    it('works for every known host', () => {
+    it('uses the same app UI protocol prompt for every known host', () => {
       const hosts = ['excel', 'powerpoint', 'word', 'outlook'] as const;
       for (const host of hosts) {
         const prompt = buildSystemPrompt(host);
-        expect(prompt.length).toBeGreaterThan(BASE_PROMPT.length);
+        expect(prompt).toBe(BASE_PROMPT);
       }
     });
   });
 
   describe('buildSessionSystemPrompt', () => {
-    it('appends memory context after base and host instructions', () => {
+    it('appends memory context after app UI protocol instructions', () => {
       const prompt = buildSessionSystemPrompt('excel', {
         memoryContext: 'Remember: prefer concise summaries.',
       });

--- a/tests/integration/use-office-chat.test.tsx
+++ b/tests/integration/use-office-chat.test.tsx
@@ -847,7 +847,7 @@ describe('useOfficeChat', () => {
   });
 
   it('passes selected CLI-owned agent name into session creation', async () => {
-    useSettingsStore.getState().setActiveAgent('office-excel');
+    useSettingsStore.getState().setActiveAgent('office-word:word');
     const session = makeFakeSession([IDLE_EVENT]);
     const client = makeFakeClient(session);
     mockCreate.mockResolvedValue(client as never);
@@ -859,11 +859,27 @@ describe('useOfficeChat', () => {
     });
 
     const config = client.createSession.mock.calls[0][0] as Record<string, unknown>;
-    expect(config.agent).toBe('office-excel');
+    expect(config.agent).toBe('office-word:word');
     expect(config.customAgents).toBeUndefined();
   });
 
-  it('systemMessage includes host prompt but not app-owned agent instructions', async () => {
+  it('defaults to the bundled CLI agent for the active Office host', async () => {
+    const session = makeFakeSession([IDLE_EVENT]);
+    const client = makeFakeClient(session);
+    mockCreate.mockResolvedValue(client as never);
+
+    renderHook(() => useOfficeChat('powerpoint'), { wrapper });
+
+    await act(async () => {
+      await new Promise(r => setTimeout(r, 100));
+    });
+
+    const config = client.createSession.mock.calls[0][0] as Record<string, unknown>;
+    expect(config.agent).toBe('office-powerpoint:powerpoint');
+    expect(useSettingsStore.getState().activeAgentName).toBeNull();
+  });
+
+  it('systemMessage includes app UI protocol but not host-owned plugin instructions', async () => {
     const session = makeFakeSession([IDLE_EVENT]);
     const client = makeFakeClient(session);
     mockCreate.mockResolvedValue(client as never);
@@ -875,7 +891,10 @@ describe('useOfficeChat', () => {
     });
 
     const config = client.createSession.mock.calls[0][0] as Record<string, unknown>;
-    const sysMsg = config.systemMessage as { content: string };
+    const sysMsg = config.systemMessage as { mode: string; content: string };
+    expect(sysMsg.mode).toBe('customize');
+    expect(sysMsg.content).not.toContain('Microsoft Excel add-in');
+    expect(sysMsg.content).not.toContain('## Excel behavior');
     expect(sysMsg.content).not.toContain('## Host Agent Instructions');
     expect(sysMsg.content).not.toContain('## Adaptive Agent Instructions');
     expect(sysMsg.content).toContain('Progress narration');


### PR DESCRIPTION
## Summary
- Add SDK-native Plan mode support through session mode and plan RPCs
- Mirror Copilot CLI permission handling with SDK approval decisions and session/location approvals
- Default Office sessions to bundled plugin agents and keep app system prompt focused on UI protocol
- Update permission, Plan mode, prompt, and UI test coverage

## Validation
- npm run typecheck
- npm run lint (passes with existing pivotTable.config.ts warning)
- npm run test:integration
- npm run test:ui -- --workers=1
- npm run test:e2e (230 passing, 4 pending)

Please merge with **Squash and merge** on GitHub.